### PR TITLE
Remove common prefix from methods on Definition and Header.

### DIFF
--- a/ast/definition.go
+++ b/ast/definition.go
@@ -23,8 +23,8 @@ package ast
 // Definition unifies the different types representing items defined in the
 // Thrift file.
 type Definition interface {
-	DefinitionName() string
-	DefinitionLine() int
+	Name() string
+	Line() int
 	definition()
 }
 
@@ -32,31 +32,31 @@ type Definition interface {
 //
 // 	const i32 foo = 42
 type Constant struct {
-	Name  string
+	CName string
 	Type  Type
 	Value ConstantValue
-	Line  int
+	CLine int
 }
 
-func (c *Constant) definition()            {}
-func (c *Constant) DefinitionName() string { return c.Name }
-func (c *Constant) DefinitionLine() int    { return c.Line }
+func (c *Constant) definition()  {}
+func (c *Constant) Name() string { return c.CName }
+func (c *Constant) Line() int    { return c.CLine }
 
 // Typedef is used to define an alias for another type.
 //
 // 	typedef string UUID
 // 	typedef i64 Timestamp (unit = "milliseconds")
 type Typedef struct {
-	Name        string
+	TName       string
 	Type        Type
 	Annotations []*Annotation
-	Line        int
+	TLine       int
 }
 
 // Definition implementation for Typedef.
-func (t *Typedef) definition()            {}
-func (t *Typedef) DefinitionName() string { return t.Name }
-func (t *Typedef) DefinitionLine() int    { return t.Line }
+func (t *Typedef) definition()  {}
+func (t *Typedef) Name() string { return t.TName }
+func (t *Typedef) Line() int    { return t.TLine }
 
 // Enum is a set of named integer values.
 //
@@ -68,16 +68,16 @@ func (t *Typedef) DefinitionLine() int    { return t.Line }
 // 		Admin = 3
 // 	} (go.name = "UserRole")
 type Enum struct {
-	Name        string
+	EName       string
 	Items       []*EnumItem
 	Annotations []*Annotation
-	Line        int
+	ELine       int
 }
 
 // DefinitionName for Enum.
-func (e *Enum) definition()            {}
-func (e *Enum) DefinitionName() string { return e.Name }
-func (e *Enum) DefinitionLine() int    { return e.Line }
+func (e *Enum) definition()  {}
+func (e *Enum) Name() string { return e.EName }
+func (e *Enum) Line() int    { return e.ELine }
 
 // EnumItem is a single item in an Enum definition.
 type EnumItem struct {
@@ -120,17 +120,17 @@ const (
 //
 // 	exception ServiceError { 1: required string message }
 type Struct struct {
-	Name        string
+	SName       string
 	Type        StructureType
 	Fields      []*Field
 	Annotations []*Annotation
-	Line        int
+	SLine       int
 }
 
 // DefinitionName implementation for Struct.
-func (s *Struct) definition()            {}
-func (s *Struct) DefinitionName() string { return s.Name }
-func (s *Struct) DefinitionLine() int    { return s.Line }
+func (s *Struct) definition()  {}
+func (s *Struct) Name() string { return s.SName }
+func (s *Struct) Line() int    { return s.SLine }
 
 // Service is a collection of functions.
 //
@@ -139,19 +139,19 @@ func (s *Struct) DefinitionLine() int    { return s.Line }
 // 		binary getValue(1: string key)
 // 	} (router.serviceName = "key_value")
 type Service struct {
-	Name      string
+	SName     string
 	Functions []*Function
 	// Reference to the parent service if this service inherits another
 	// service, nil otherwise.
 	Parent      *ServiceReference
 	Annotations []*Annotation
-	Line        int
+	SLine       int
 }
 
 // DefinitionName implementation for Service.
-func (s *Service) definition()            {}
-func (s *Service) DefinitionName() string { return s.Name }
-func (s *Service) DefinitionLine() int    { return s.Line }
+func (s *Service) definition()  {}
+func (s *Service) Name() string { return s.SName }
+func (s *Service) Line() int    { return s.SLine }
 
 // Function is a single function inside a service.
 //

--- a/ast/header.go
+++ b/ast/header.go
@@ -22,7 +22,7 @@ package ast
 
 // Header unifies types representing header in the AST.
 type Header interface {
-	HeaderLine() int
+	Line() int
 	header()
 }
 
@@ -35,13 +35,13 @@ type Header interface {
 //
 // 	include t "shared.thrift"
 type Include struct {
-	Path string
-	Name string
-	Line int
+	Path  string
+	Name  string
+	ILine int
 }
 
-func (i *Include) header()         {}
-func (i *Include) HeaderLine() int { return i.Line }
+func (i *Include) header()   {}
+func (i *Include) Line() int { return i.ILine }
 
 // Namespace statements allow users to choose the package name used by the
 // generated code in certain languages.
@@ -50,8 +50,8 @@ func (i *Include) HeaderLine() int { return i.Line }
 type Namespace struct {
 	Scope string
 	Name  string
-	Line  int
+	NLine int
 }
 
-func (n *Namespace) header()         {}
-func (n *Namespace) HeaderLine() int { return n.Line }
+func (n *Namespace) header()   {}
+func (n *Namespace) Line() int { return n.NLine }

--- a/idl/internal/thrift.y
+++ b/idl/internal/thrift.y
@@ -110,7 +110,7 @@ header
         {
             $$ = &ast.Include{
                 Path: $3,
-                Line: $1,
+                ILine: $1,
             }
         }
     | lineno INCLUDE IDENTIFIER LITERAL
@@ -118,7 +118,7 @@ header
             $$ = &ast.Include{
                 Name: $3,
                 Path: $4,
-                Line: $1,
+                ILine: $1,
             }
         }
     | lineno NAMESPACE '*' IDENTIFIER
@@ -126,7 +126,7 @@ header
             $$ = &ast.Namespace{
                 Scope: "*",
                 Name: $4,
-                Line: $1,
+                NLine: $1,
             }
         }
     | lineno NAMESPACE IDENTIFIER IDENTIFIER
@@ -134,7 +134,7 @@ header
             $$ = &ast.Namespace{
                 Scope: $3,
                 Name: $4,
-                Line: $1,
+                NLine: $1,
             }
         }
     ;
@@ -154,49 +154,49 @@ definition
     : lineno CONST type IDENTIFIER '=' const_value
         {
             $$ = &ast.Constant{
-                Name: $4,
+                CName: $4,
                 Type: $3,
                 Value: $6,
-                Line: $1,
+                CLine: $1,
             }
         }
     /* types */
     | lineno TYPEDEF type IDENTIFIER type_annotations
         {
             $$ = &ast.Typedef{
-                Name: $4,
+                TName: $4,
                 Type: $3,
                 Annotations: $5,
-                Line: $1,
+                TLine: $1,
             }
         }
     | lineno ENUM IDENTIFIER '{' enum_items '}' type_annotations
         {
             $$ = &ast.Enum{
-                Name: $3,
+                EName: $3,
                 Items: $5,
                 Annotations: $7,
-                Line: $1,
+                ELine: $1,
             }
         }
     | lineno struct_type IDENTIFIER '{' fields '}' type_annotations
         {
             $$ = &ast.Struct{
-                Name: $3,
+                SName: $3,
                 Type: $2,
                 Fields: $5,
                 Annotations: $7,
-                Line: $1,
+                SLine: $1,
             }
         }
     /* services */
     | lineno SERVICE IDENTIFIER '{' functions '}' type_annotations
         {
             $$ = &ast.Service{
-                Name: $3,
+                SName: $3,
                 Functions: $5,
                 Annotations: $7,
-                Line: $1,
+                SLine: $1,
             }
         }
     | lineno SERVICE IDENTIFIER EXTENDS lineno IDENTIFIER '{' functions '}'
@@ -208,11 +208,11 @@ definition
             }
 
             $$ = &ast.Service{
-                Name: $3,
+                SName: $3,
                 Functions: $8,
                 Parent: parent,
                 Annotations: $10,
-                Line: $1,
+                SLine: $1,
             }
         }
     ;

--- a/idl/internal/y.go
+++ b/idl/internal/y.go
@@ -20,8 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
-
 //line thrift.y:2
 package internal
 
@@ -684,8 +682,8 @@ yydefault:
 		//line thrift.y:110
 		{
 			yyVAL.header = &ast.Include{
-				Path: yyDollar[3].str,
-				Line: yyDollar[1].line,
+				Path:  yyDollar[3].str,
+				ILine: yyDollar[1].line,
 			}
 		}
 	case 5:
@@ -693,9 +691,9 @@ yydefault:
 		//line thrift.y:117
 		{
 			yyVAL.header = &ast.Include{
-				Name: yyDollar[3].str,
-				Path: yyDollar[4].str,
-				Line: yyDollar[1].line,
+				Name:  yyDollar[3].str,
+				Path:  yyDollar[4].str,
+				ILine: yyDollar[1].line,
 			}
 		}
 	case 6:
@@ -705,7 +703,7 @@ yydefault:
 			yyVAL.header = &ast.Namespace{
 				Scope: "*",
 				Name:  yyDollar[4].str,
-				Line:  yyDollar[1].line,
+				NLine: yyDollar[1].line,
 			}
 		}
 	case 7:
@@ -715,7 +713,7 @@ yydefault:
 			yyVAL.header = &ast.Namespace{
 				Scope: yyDollar[3].str,
 				Name:  yyDollar[4].str,
-				Line:  yyDollar[1].line,
+				NLine: yyDollar[1].line,
 			}
 		}
 	case 8:
@@ -735,10 +733,10 @@ yydefault:
 		//line thrift.y:155
 		{
 			yyVAL.definition = &ast.Constant{
-				Name:  yyDollar[4].str,
+				CName: yyDollar[4].str,
 				Type:  yyDollar[3].fieldType,
 				Value: yyDollar[6].constantValue,
-				Line:  yyDollar[1].line,
+				CLine: yyDollar[1].line,
 			}
 		}
 	case 11:
@@ -746,10 +744,10 @@ yydefault:
 		//line thrift.y:165
 		{
 			yyVAL.definition = &ast.Typedef{
-				Name:        yyDollar[4].str,
+				TName:       yyDollar[4].str,
 				Type:        yyDollar[3].fieldType,
 				Annotations: yyDollar[5].typeAnnotations,
-				Line:        yyDollar[1].line,
+				TLine:       yyDollar[1].line,
 			}
 		}
 	case 12:
@@ -757,10 +755,10 @@ yydefault:
 		//line thrift.y:174
 		{
 			yyVAL.definition = &ast.Enum{
-				Name:        yyDollar[3].str,
+				EName:       yyDollar[3].str,
 				Items:       yyDollar[5].enumItems,
 				Annotations: yyDollar[7].typeAnnotations,
-				Line:        yyDollar[1].line,
+				ELine:       yyDollar[1].line,
 			}
 		}
 	case 13:
@@ -768,11 +766,11 @@ yydefault:
 		//line thrift.y:183
 		{
 			yyVAL.definition = &ast.Struct{
-				Name:        yyDollar[3].str,
+				SName:       yyDollar[3].str,
 				Type:        yyDollar[2].structType,
 				Fields:      yyDollar[5].fields,
 				Annotations: yyDollar[7].typeAnnotations,
-				Line:        yyDollar[1].line,
+				SLine:       yyDollar[1].line,
 			}
 		}
 	case 14:
@@ -780,10 +778,10 @@ yydefault:
 		//line thrift.y:194
 		{
 			yyVAL.definition = &ast.Service{
-				Name:        yyDollar[3].str,
+				SName:       yyDollar[3].str,
 				Functions:   yyDollar[5].functions,
 				Annotations: yyDollar[7].typeAnnotations,
-				Line:        yyDollar[1].line,
+				SLine:       yyDollar[1].line,
 			}
 		}
 	case 15:
@@ -796,11 +794,11 @@ yydefault:
 			}
 
 			yyVAL.definition = &ast.Service{
-				Name:        yyDollar[3].str,
+				SName:       yyDollar[3].str,
 				Functions:   yyDollar[8].functions,
 				Parent:      parent,
 				Annotations: yyDollar[10].typeAnnotations,
-				Line:        yyDollar[1].line,
+				SLine:       yyDollar[1].line,
 			}
 		}
 	case 16:

--- a/idl/parser_test.go
+++ b/idl/parser_test.go
@@ -91,8 +91,8 @@ func TestParseHeaders(t *testing.T) {
 				include t "bar.thrift"
 			`,
 			&Program{Headers: []Header{
-				&Include{Path: "foo.thrift", Line: 2},
-				&Include{Path: "bar.thrift", Name: "t", Line: 3},
+				&Include{Path: "foo.thrift", ILine: 2},
+				&Include{Path: "bar.thrift", Name: "t", ILine: 3},
 			}},
 		},
 		{
@@ -121,9 +121,9 @@ func TestParseHeaders(t *testing.T) {
 			`,
 			&Program{
 				Headers: []Header{
-					&Include{Path: "shared.thrift", Line: 3},
+					&Include{Path: "shared.thrift", ILine: 3},
 					&Namespace{"go", "foo_service", 4},
-					&Include{Path: "errors.thrift", Line: 9},
+					&Include{Path: "errors.thrift", ILine: 9},
 					&Namespace{"py", "services.foo", 12},
 				},
 			},
@@ -145,31 +145,31 @@ func TestParseConstants(t *testing.T) {
 			`,
 			&Program{Definitions: []Definition{
 				&Constant{
-					Name:  "foo",
+					CName: "foo",
 					Type:  BaseType{ID: I32TypeID},
 					Value: ConstantInteger(42),
-					Line:  2,
+					CLine: 2,
 				},
 				&Constant{
-					Name: "bar",
-					Type: BaseType{ID: I64TypeID},
+					CName: "bar",
+					Type:  BaseType{ID: I64TypeID},
 					Value: ConstantReference{
 						Name: "shared.baz",
 						Line: 3,
 					},
-					Line: 3,
+					CLine: 3,
 				},
 				&Constant{
-					Name:  "baz",
+					CName: "baz",
 					Type:  BaseType{ID: StringTypeID},
 					Value: ConstantString("hello world"),
-					Line:  5,
+					CLine: 5,
 				},
 				&Constant{
-					Name:  "qux",
+					CName: "qux",
 					Type:  BaseType{ID: DoubleTypeID},
 					Value: ConstantDouble(3.141592),
-					Line:  7,
+					CLine: 7,
 				},
 			}},
 		},
@@ -178,7 +178,7 @@ func TestParseConstants(t *testing.T) {
 			 const bool include_something = false`,
 			&Program{Definitions: []Definition{
 				&Constant{
-					Name: "baz",
+					CName: "baz",
 					Type: BaseType{
 						ID: BoolTypeID,
 						Annotations: []*Annotation{
@@ -186,13 +186,13 @@ func TestParseConstants(t *testing.T) {
 						},
 					},
 					Value: ConstantBoolean(true),
-					Line:  1,
+					CLine: 1,
 				},
 				&Constant{
-					Name:  "include_something",
+					CName: "include_something",
 					Type:  BaseType{ID: BoolTypeID},
 					Value: ConstantBoolean(false),
-					Line:  2,
+					CLine: 2,
 				},
 			}},
 		},
@@ -213,7 +213,7 @@ func TestParseConstants(t *testing.T) {
 			`,
 			&Program{Definitions: []Definition{
 				&Constant{
-					Name: "stuff",
+					CName: "stuff",
 					Type: MapType{
 						KeyType: BaseType{
 							ID: StringTypeID,
@@ -238,10 +238,10 @@ func TestParseConstants(t *testing.T) {
 							},
 						},
 					},
-					Line: 2,
+					CLine: 2,
 				},
 				&Constant{
-					Name: "list_of_lists",
+					CName: "list_of_lists",
 					Type: ListType{ValueType: ListType{
 						ValueType: BaseType{ID: I32TypeID},
 					}},
@@ -263,11 +263,11 @@ func TestParseConstants(t *testing.T) {
 							},
 						},
 					},
-					Line: 6,
+					CLine: 6,
 				},
 				&Constant{
-					Name: "const_struct",
-					Type: TypeReference{Name: "Item", Line: 10},
+					CName: "const_struct",
+					Type:  TypeReference{Name: "Item", Line: 10},
 					Value: ConstantMap{Items: []ConstantMapItem{
 						ConstantMapItem{
 							Key:   ConstantString("key"),
@@ -278,7 +278,7 @@ func TestParseConstants(t *testing.T) {
 							Value: ConstantInteger(42),
 						},
 					}},
-					Line: 10,
+					CLine: 10,
 				},
 			}},
 		},
@@ -289,16 +289,16 @@ func TestParseConstants(t *testing.T) {
 			`,
 			&Program{Definitions: []Definition{
 				&Constant{
-					Name:  "foo",
+					CName: "foo",
 					Type:  BaseType{ID: StringTypeID},
 					Value: ConstantString(`a "b" c`),
-					Line:  2,
+					CLine: 2,
 				},
 				&Constant{
-					Name:  "bar",
+					CName: "bar",
 					Type:  BaseType{ID: StringTypeID},
 					Value: ConstantString(`a 'b' c`),
-					Line:  3,
+					CLine: 3,
 				},
 			}},
 		},
@@ -316,8 +316,8 @@ func TestParseTypedef(t *testing.T) {
 			`,
 			&Program{Definitions: []Definition{
 				&Typedef{
-					Name: "UUID",
-					Type: BaseType{ID: StringTypeID},
+					TName: "UUID",
+					Type:  BaseType{ID: StringTypeID},
 					Annotations: []*Annotation{
 						&Annotation{
 							Name:  "length",
@@ -325,10 +325,10 @@ func TestParseTypedef(t *testing.T) {
 							Line:  2,
 						},
 					},
-					Line: 2,
+					TLine: 2,
 				},
 				&Typedef{
-					Name: "Date",
+					TName: "Date",
 					Type: BaseType{
 						ID: I64TypeID,
 						Annotations: []*Annotation{
@@ -339,7 +339,7 @@ func TestParseTypedef(t *testing.T) {
 							},
 						},
 					},
-					Line: 4,
+					TLine: 4,
 				},
 			}},
 		},
@@ -358,7 +358,7 @@ func TestParseEnum(t *testing.T) {
 				{
 				}
 			`,
-			&Program{Definitions: []Definition{&Enum{Name: "EmptyEnum", Line: 2}}},
+			&Program{Definitions: []Definition{&Enum{EName: "EmptyEnum", ELine: 2}}},
 		},
 		{
 			`
@@ -371,7 +371,7 @@ func TestParseEnum(t *testing.T) {
 			`,
 			&Program{Definitions: []Definition{
 				&Enum{
-					Name: "SillyEnum",
+					EName: "SillyEnum",
 					Items: []*EnumItem{
 						&EnumItem{
 							Name: "foo",
@@ -393,7 +393,7 @@ func TestParseEnum(t *testing.T) {
 						&Annotation{Name: "_", Value: "__", Line: 7},
 						&Annotation{Name: "foo", Value: "bar", Line: 7},
 					},
-					Line: 2,
+					ELine: 2,
 				},
 			}},
 		},
@@ -411,9 +411,9 @@ func TestParseStruct(t *testing.T) {
 				exception EmptyExc {}
 			`,
 			&Program{Definitions: []Definition{
-				&Struct{Name: "EmptyStruct", Type: StructType, Line: 2},
-				&Struct{Name: "EmptyUnion", Type: UnionType, Line: 3},
-				&Struct{Name: "EmptyExc", Type: ExceptionType, Line: 4},
+				&Struct{SName: "EmptyStruct", Type: StructType, SLine: 2},
+				&Struct{SName: "EmptyUnion", Type: UnionType, SLine: 3},
+				&Struct{SName: "EmptyExc", Type: ExceptionType, SLine: 4},
 			}},
 		},
 		{
@@ -434,8 +434,8 @@ func TestParseStruct(t *testing.T) {
 			`,
 			&Program{Definitions: []Definition{
 				&Struct{
-					Name: "i128",
-					Type: StructType,
+					SName: "i128",
+					Type:  StructType,
 					Fields: []*Field{
 						&Field{
 							ID:           1,
@@ -459,11 +459,11 @@ func TestParseStruct(t *testing.T) {
 							Line:  5,
 						},
 					},
-					Line: 2,
+					SLine: 2,
 				},
 				&Struct{
-					Name: "Contents",
-					Type: UnionType,
+					SName: "Contents",
+					Type:  UnionType,
 					Fields: []*Field{
 						&Field{
 							ID:           1,
@@ -497,11 +497,11 @@ func TestParseStruct(t *testing.T) {
 							Line: 9,
 						},
 					},
-					Line: 7,
+					SLine: 7,
 				},
 				&Struct{
-					Name: "GreatSadness",
-					Type: ExceptionType,
+					SName: "GreatSadness",
+					Type:  ExceptionType,
 					Fields: []*Field{
 						&Field{
 							ID:           1,
@@ -511,7 +511,7 @@ func TestParseStruct(t *testing.T) {
 							Line:         13,
 						},
 					},
-					Line: 12,
+					SLine: 12,
 				},
 			}},
 		},
@@ -528,14 +528,14 @@ func TestParseServices(t *testing.T) {
 				service AnotherEmptyService extends EmptyService {}
 			`,
 			&Program{Definitions: []Definition{
-				&Service{Name: "EmptyService", Line: 2},
+				&Service{SName: "EmptyService", SLine: 2},
 				&Service{
-					Name: "AnotherEmptyService",
+					SName: "AnotherEmptyService",
 					Parent: &ServiceReference{
 						Name: "EmptyService",
 						Line: 3,
 					},
-					Line: 3,
+					SLine: 3,
 				},
 			}},
 		},
@@ -557,7 +557,7 @@ func TestParseServices(t *testing.T) {
 			`,
 			&Program{Definitions: []Definition{
 				&Service{
-					Name: "KeyValue",
+					SName: "KeyValue",
 					Functions: []*Function{
 						&Function{
 							Name:   "empty",
@@ -614,7 +614,7 @@ func TestParseServices(t *testing.T) {
 							Line:  14,
 						},
 					},
-					Line: 2,
+					SLine: 2,
 				},
 			}},
 		},


### PR DESCRIPTION
To avoid conflicts with field names while leaving fields public, the conflicting fields had to be prefixed.
