### PR TITLE
Give all TypeSpecs a ThriftName()

### DIFF
--- a/compile/container.go
+++ b/compile/container.go
@@ -21,6 +21,8 @@
 package compile
 
 import (
+	"fmt"
+
 	"github.com/uber/thriftrw-go/ast"
 	"github.com/uber/thriftrw-go/wire"
 )
@@ -60,6 +62,13 @@ func (m *MapSpec) Link(scope Scope) (TypeSpec, error) {
 	return m, nil
 }
 
+// ThriftName for MapSpec
+func (m *MapSpec) ThriftName() string {
+	return fmt.Sprintf(
+		"map<%s, %s>", m.KeySpec.ThriftName(), m.ValueSpec.ThriftName(),
+	)
+}
+
 // TypeCode for MapSpec
 func (m *MapSpec) TypeCode() wire.Type {
 	return wire.TMap
@@ -95,6 +104,11 @@ func (l *ListSpec) TypeCode() wire.Type {
 	return wire.TList
 }
 
+// ThriftName for ListSpec
+func (l *ListSpec) ThriftName() string {
+	return fmt.Sprintf("list<%s>", l.ValueSpec.ThriftName())
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 // SetSpec represents sets of values of the same type.
@@ -123,4 +137,9 @@ func (s *SetSpec) Link(scope Scope) (TypeSpec, error) {
 // TypeCode for SetSpec
 func (s *SetSpec) TypeCode() wire.Type {
 	return wire.TSet
+}
+
+// ThriftName for SetSpec.
+func (s *SetSpec) ThriftName() string {
+	return fmt.Sprintf("set<%s>", s.ValueSpec.ThriftName())
 }

--- a/compile/primitive.go
+++ b/compile/primitive.go
@@ -20,26 +20,68 @@
 
 package compile
 
-import "github.com/uber/thriftrw-go/wire"
+import (
+	"fmt"
+
+	"github.com/uber/thriftrw-go/ast"
+	"github.com/uber/thriftrw-go/wire"
+)
 
 // TypeSpecs for primitive Thrift types.
 var (
-	BoolSpec   = primitiveTypeSpec(wire.TBool)
-	I8Spec     = primitiveTypeSpec(wire.TI8)
-	I16Spec    = primitiveTypeSpec(wire.TI16)
-	I32Spec    = primitiveTypeSpec(wire.TI32)
-	I64Spec    = primitiveTypeSpec(wire.TI64)
-	DoubleSpec = primitiveTypeSpec(wire.TDouble)
-	StringSpec = primitiveTypeSpec(wire.TBinary)
-	BinarySpec = primitiveTypeSpec(wire.TBinary)
+	BoolSpec   = primitiveTypeSpec{"bool", wire.TBool}
+	I8Spec     = primitiveTypeSpec{"byte", wire.TI8}
+	I16Spec    = primitiveTypeSpec{"i16", wire.TI16}
+	I32Spec    = primitiveTypeSpec{"i32", wire.TI32}
+	I64Spec    = primitiveTypeSpec{"i64", wire.TI64}
+	DoubleSpec = primitiveTypeSpec{"double", wire.TDouble}
+	StringSpec = primitiveTypeSpec{"string", wire.TBinary}
+	BinarySpec = primitiveTypeSpec{"binary", wire.TBinary}
 )
 
-type primitiveTypeSpec wire.Type
-
-func (t primitiveTypeSpec) TypeCode() wire.Type {
-	return wire.Type(t)
+type primitiveTypeSpec struct {
+	Name string
+	Code wire.Type
+	// TODO(abg): We'll want to expose type annotations here
 }
 
+// TypeCode of the primitive type.
+func (t primitiveTypeSpec) TypeCode() wire.Type {
+	return t.Code
+}
+
+// ThriftName of the primitive type.
+func (t primitiveTypeSpec) ThriftName() string {
+	return t.Name
+}
+
+// Link for primitive types is a no-op because primitive types don't make any
+// references.
 func (t primitiveTypeSpec) Link(Scope) (TypeSpec, error) {
 	return t, nil
+}
+
+// compileBaseType compiles a base type reference in the AST to a primitive
+// TypeSpec.
+func compileBaseType(t ast.BaseType) primitiveTypeSpec {
+	switch t.ID {
+	case ast.BoolTypeID:
+		return BoolSpec
+	case ast.I8TypeID:
+		return I8Spec
+	case ast.I16TypeID:
+		return I16Spec
+	case ast.I32TypeID:
+		return I32Spec
+	case ast.I64TypeID:
+		return I64Spec
+	case ast.DoubleTypeID:
+		return DoubleSpec
+	case ast.StringTypeID:
+		return StringSpec
+	case ast.BinaryTypeID:
+		return BinarySpec
+	default:
+		panic(fmt.Sprintf("unknown base type %v", t))
+	}
 }

--- a/compile/service.go
+++ b/compile/service.go
@@ -228,8 +228,8 @@ func (rs *ResultSpec) Link(scope Scope) (err error) {
 		spec, ok := exception.Type.(*StructSpec)
 		if !ok || spec.Type != ast.ExceptionType {
 			return notAnExceptionError{
-				TypeName:  exception.ThriftName(),
 				FieldName: name,
+				TypeName:  spec.ThriftName(),
 			}
 		}
 	}

--- a/compile/type.go
+++ b/compile/type.go
@@ -35,15 +35,8 @@ type TypeSpec interface {
 
 	// TypeCode is the wire-level Thrift Type associated with this Type.
 	TypeCode() wire.Type
-}
 
-// DefinedTypeSpec contains information about types that map directly to types
-// defined in the Thrift file.
-type DefinedTypeSpec interface {
-	TypeSpec
-
-	// ThriftName is the name of the given object as it appears in the Thrift
-	// file.
+	// ThriftName is the name of the type as it appears in the Thrift file.
 	ThriftName() string
 }
 
@@ -87,7 +80,7 @@ func compileType(typ ast.Type) TypeSpec {
 	}
 	switch t := typ.(type) {
 	case ast.BaseType:
-		return resolveBaseType(t)
+		return compileBaseType(t)
 	case ast.MapType:
 		return compileMapType(t)
 	case ast.ListType:
@@ -98,28 +91,5 @@ func compileType(typ ast.Type) TypeSpec {
 		return &typeSpecReference{Name: t.Name, Line: t.Line}
 	default:
 		panic(fmt.Sprintf("unknown type %v", typ))
-	}
-}
-
-func resolveBaseType(t ast.BaseType) TypeSpec {
-	switch t.ID {
-	case ast.BoolTypeID:
-		return BoolSpec
-	case ast.I8TypeID:
-		return I8Spec
-	case ast.I16TypeID:
-		return I16Spec
-	case ast.I32TypeID:
-		return I32Spec
-	case ast.I64TypeID:
-		return I64Spec
-	case ast.DoubleTypeID:
-		return DoubleSpec
-	case ast.StringTypeID:
-		return StringSpec
-	case ast.BinaryTypeID:
-		return BinarySpec
-	default:
-		panic(fmt.Sprintf("unknown base type %v", t))
 	}
 }


### PR DESCRIPTION
This consolidates the TypeSpec and DefinedTypeSpec interfaces into one.
