### PR TITLE
More tests for link time errors.

### DIFF
--- a/compile/constant.go
+++ b/compile/constant.go
@@ -47,11 +47,15 @@ func (c *Constant) Link(scope Scope) (err error) {
 	}
 
 	if c.Type, err = c.Type.Link(scope); err != nil {
-		return err
+		return compileError{Target: c.Name, Reason: err}
 	}
-	err = verifyConstantValue(c.Value, scope)
+
+	if err := verifyConstantValue(c.Value, scope); err != nil {
+		return compileError{Target: c.Name, Reason: err}
+	}
+
 	// TODO(abg): validate that the constant matches the TypeSpec
-	return err
+	return nil
 }
 
 // LinkConstantValue ensures that all references made by the given constant

--- a/compile/constant_test.go
+++ b/compile/constant_test.go
@@ -120,8 +120,32 @@ func TestCompileConstantFailure(t *testing.T) {
 			`const list<string> foo = [x]`,
 			scope("y", ast.ConstantString("bar")),
 			[]string{
+				`cannot compile "foo"`,
 				`could not resolve reference "x"`,
-				`unknown constant: x`,
+			},
+		},
+		{
+			`const Foo foo = {"bar": "baz"}`,
+			nil,
+			[]string{
+				`cannot compile "foo"`,
+				`could not resolve reference "Foo"`,
+			},
+		},
+		{
+			`const map<string, string> something = {foo: "bar"}`,
+			nil,
+			[]string{
+				`cannot compile "something"`,
+				`could not resolve reference "foo"`,
+			},
+		},
+		{
+			`const map<string, string> something = {"foo": bar}`,
+			nil,
+			[]string{
+				`cannot compile "something"`,
+				`could not resolve reference "bar"`,
 			},
 		},
 	}

--- a/compile/container_test.go
+++ b/compile/container_test.go
@@ -61,10 +61,31 @@ func TestCompileList(t *testing.T) {
 		output := mustLink(t, tt.output, scope())
 
 		scope := scopeOrDefault(tt.scope)
-		spec, err := compileListType(tt.input).Link(scope)
+		spec, err := compileType(tt.input).Link(scope)
 		if assert.NoError(t, err, tt.desc) {
 			assert.Equal(t, wire.TList, spec.TypeCode(), tt.desc)
 			assert.Equal(t, output, spec, tt.desc)
+		}
+	}
+}
+
+func TestLinkListFailure(t *testing.T) {
+	tests := []struct {
+		input    ast.ListType
+		messages []string
+	}{
+		{
+			ast.ListType{ValueType: ast.TypeReference{Name: "Foo"}},
+			[]string{`could not resolve reference "Foo"`},
+		},
+	}
+
+	for _, tt := range tests {
+		_, err := compileType(tt.input).Link(scope())
+		if assert.Error(t, err) {
+			for _, msg := range tt.messages {
+				assert.Contains(t, err.Error(), msg)
+			}
 		}
 	}
 }
@@ -97,10 +118,41 @@ func TestCompileMap(t *testing.T) {
 		output := mustLink(t, tt.output, scope())
 
 		scope := scopeOrDefault(tt.scope)
-		spec, err := compileMapType(tt.input).Link(scope)
+		spec, err := compileType(tt.input).Link(scope)
 		if assert.NoError(t, err, tt.desc) {
 			assert.Equal(t, wire.TMap, spec.TypeCode(), tt.desc)
 			assert.Equal(t, output, spec, tt.desc)
+		}
+	}
+}
+
+func TestLinkMapFailure(t *testing.T) {
+	tests := []struct {
+		input    ast.MapType
+		messages []string
+	}{
+		{
+			ast.MapType{
+				KeyType:   ast.BaseType{ID: ast.I8TypeID},
+				ValueType: ast.TypeReference{Name: "Foo"},
+			},
+			[]string{`could not resolve reference "Foo"`},
+		},
+		{
+			ast.MapType{
+				KeyType:   ast.TypeReference{Name: "Foo"},
+				ValueType: ast.BaseType{ID: ast.I8TypeID},
+			},
+			[]string{`could not resolve reference "Foo"`},
+		},
+	}
+
+	for _, tt := range tests {
+		_, err := compileType(tt.input).Link(scope())
+		if assert.Error(t, err) {
+			for _, msg := range tt.messages {
+				assert.Contains(t, err.Error(), msg)
+			}
 		}
 	}
 }
@@ -124,10 +176,31 @@ func TestCompileSet(t *testing.T) {
 		output := mustLink(t, tt.output, scope())
 
 		scope := scopeOrDefault(tt.scope)
-		spec, err := compileSetType(tt.input).Link(scope)
+		spec, err := compileType(tt.input).Link(scope)
 		if assert.NoError(t, err, tt.desc) {
 			assert.Equal(t, wire.TSet, spec.TypeCode(), tt.desc)
 			assert.Equal(t, output, spec, tt.desc)
+		}
+	}
+}
+
+func TestLinkSetFailure(t *testing.T) {
+	tests := []struct {
+		input    ast.SetType
+		messages []string
+	}{
+		{
+			ast.SetType{ValueType: ast.TypeReference{Name: "Foo"}},
+			[]string{`could not resolve reference "Foo"`},
+		},
+	}
+
+	for _, tt := range tests {
+		_, err := compileType(tt.input).Link(scope())
+		if assert.Error(t, err) {
+			for _, msg := range tt.messages {
+				assert.Contains(t, err.Error(), msg)
+			}
 		}
 	}
 }

--- a/compile/error.go
+++ b/compile/error.go
@@ -224,6 +224,6 @@ type notAnExceptionError struct {
 
 func (e notAnExceptionError) Error() string {
 	return fmt.Sprintf(
-		"field %q of type %q is not an exception", e.FieldName, e.TypeName,
+		"field %q with type %q is not an exception", e.FieldName, e.TypeName,
 	)
 }

--- a/compile/service.go
+++ b/compile/service.go
@@ -74,10 +74,13 @@ func (s *ServiceSpec) Link(scope Scope) error {
 	if s.parentSrc != nil {
 		parent, err := scope.LookupService(s.parentSrc.Name)
 		if err != nil {
-			return referenceError{
-				Target: s.parentSrc.Name,
-				Line:   s.parentSrc.Line,
-				Reason: err,
+			return compileError{
+				Target: s.Name,
+				Reason: referenceError{
+					Target: s.parentSrc.Name,
+					Line:   s.parentSrc.Line,
+					Reason: err,
+				},
 			}
 		}
 

--- a/compile/type_test.go
+++ b/compile/type_test.go
@@ -38,6 +38,11 @@ func mustLink(t *testing.T, spec TypeSpec, scope Scope) TypeSpec {
 	return result
 }
 
+func TestCompileTypeWithNil(t *testing.T) {
+	// make sure compileType(nil) doesn't explode.
+	assert.Nil(t, compileType(nil))
+}
+
 func TestResolveBaseType(t *testing.T) {
 	tests := []struct {
 		input    ast.BaseType

--- a/compile/typedef_test.go
+++ b/compile/typedef_test.go
@@ -81,3 +81,33 @@ func TestCompileTypedef(t *testing.T) {
 		}
 	}
 }
+
+func TestCompileTypedefFailure(t *testing.T) {
+	tests := []struct {
+		desc     string
+		src      string
+		scope    Scope
+		messages []string
+	}{
+		{
+			"unknown type",
+			"typedef foo bar",
+			nil,
+			[]string{
+				`could not resolve reference "foo"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		src := parseTypedef(tt.src)
+		scope := scopeOrDefault(tt.scope)
+
+		_, err := compileTypedef(src).Link(scope)
+		if assert.Error(t, err, tt.desc) {
+			for _, msg := range tt.messages {
+				assert.Contains(t, err.Error(), msg, tt.desc)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Including #32, this essentially covers everything except compiler.go.
