### PR TITLE
Fixed bug in parser that would fail on empty line comments

### DIFF
--- a/idl/internal/lex.go
+++ b/idl/internal/lex.go
@@ -35,11 +35,11 @@ import (
 )
 
 //line lex.go:19
-const thrift_start int = 14
-const thrift_first_final int = 14
+const thrift_start int = 13
+const thrift_first_final int = 13
 const thrift_error int = 0
 
-const thrift_en_main int = 14
+const thrift_en_main int = 13
 
 //line lex.rl:22
 type lexer struct {
@@ -86,50 +86,50 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof
 		}
 		switch lex.cs {
-		case 14:
-			goto st_case_14
+		case 13:
+			goto st_case_13
 		case 0:
 			goto st_case_0
 		case 1:
 			goto st_case_1
 		case 2:
 			goto st_case_2
+		case 14:
+			goto st_case_14
 		case 3:
 			goto st_case_3
-		case 15:
-			goto st_case_15
 		case 4:
 			goto st_case_4
 		case 5:
 			goto st_case_5
-		case 6:
-			goto st_case_6
+		case 15:
+			goto st_case_15
 		case 16:
 			goto st_case_16
-		case 17:
-			goto st_case_17
+		case 6:
+			goto st_case_6
 		case 7:
 			goto st_case_7
+		case 17:
+			goto st_case_17
 		case 8:
 			goto st_case_8
-		case 18:
-			goto st_case_18
 		case 9:
 			goto st_case_9
 		case 10:
 			goto st_case_10
+		case 18:
+			goto st_case_18
 		case 11:
 			goto st_case_11
 		case 19:
 			goto st_case_19
-		case 12:
-			goto st_case_12
 		case 20:
 			goto st_case_20
+		case 12:
+			goto st_case_12
 		case 21:
 			goto st_case_21
-		case 13:
-			goto st_case_13
 		case 22:
 			goto st_case_22
 		case 23:
@@ -458,8 +458,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st_case_184
 		case 185:
 			goto st_case_185
-		case 186:
-			goto st_case_186
 		}
 		goto st_out
 	tr2:
@@ -485,12 +483,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr8:
+		goto st13
+	tr7:
 //line lex.rl:159
 		(lex.p) = (lex.te) - 1
 		{
@@ -503,17 +501,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr15:
+		goto st13
+	tr14:
 //line lex.rl:140
 		lex.te = (lex.p) + 1
 
-		goto st14
-	tr16:
+		goto st13
+	tr15:
 //line lex.rl:142
 		(lex.p) = (lex.te) - 1
 		{
@@ -532,12 +530,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr18:
+		goto st13
+	tr17:
 //line NONE:1
 		switch lex.act {
 		case 1:
@@ -546,7 +544,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = INCLUDE
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -556,7 +554,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = NAMESPACE
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -566,7 +564,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = VOID
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -576,7 +574,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = BOOL
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -586,7 +584,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = BYTE
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -596,7 +594,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = I8
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -606,7 +604,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = I16
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -616,7 +614,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = I32
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -626,7 +624,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = I64
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -636,7 +634,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = DOUBLE
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -646,7 +644,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = STRING
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -656,7 +654,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = BINARY
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -666,7 +664,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = MAP
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -676,7 +674,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = LIST
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -686,7 +684,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = SET
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -696,7 +694,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = ONEWAY
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -706,7 +704,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = TYPEDEF
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -716,7 +714,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = STRUCT
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -726,7 +724,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = UNION
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -736,7 +734,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = EXCEPTION
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -746,7 +744,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = EXTENDS
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -756,7 +754,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = THROWS
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -766,7 +764,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = SERVICE
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -776,7 +774,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = ENUM
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -786,7 +784,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = CONST
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -796,7 +794,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = REQUIRED
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -806,7 +804,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = OPTIONAL
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -816,7 +814,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = TRUE
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -826,7 +824,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = FALSE
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
@@ -838,44 +836,44 @@ func (lex *lexer) Lex(out *yySymType) int {
 				tok = IDENTIFIER
 				{
 					(lex.p)++
-					lex.cs = 14
+					lex.cs = 13
 					goto _out
 				}
 			}
 		}
 
-		goto st14
-	tr20:
+		goto st13
+	tr19:
 //line lex.rl:137
 		lex.te = (lex.p) + 1
 
-		goto st14
-	tr21:
+		goto st13
+	tr20:
 //line lex.rl:59
 		lex.line++
 //line lex.rl:138
 		lex.te = (lex.p) + 1
 
-		goto st14
-	tr22:
+		goto st13
+	tr21:
 //line lex.rl:131
 		lex.te = (lex.p) + 1
 		{
 			tok = int(lex.data[lex.ts])
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr41:
+		goto st13
+	tr40:
 //line lex.rl:139
 		lex.te = (lex.p)
 		(lex.p)--
 
-		goto st14
-	tr42:
+		goto st13
+	tr41:
 //line lex.rl:142
 		lex.te = (lex.p)
 		(lex.p)--
@@ -895,12 +893,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr44:
+		goto st13
+	tr43:
 //line lex.rl:159
 		lex.te = (lex.p)
 		(lex.p)--
@@ -914,12 +912,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr47:
+		goto st13
+	tr46:
 //line lex.rl:191
 		lex.te = (lex.p)
 		(lex.p)--
@@ -928,12 +926,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = IDENTIFIER
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr56:
+		goto st13
+	tr55:
 //line lex.rl:112
 		lex.te = (lex.p)
 		(lex.p)--
@@ -941,12 +939,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = BINARY
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr61:
+		goto st13
+	tr60:
 //line lex.rl:104
 		lex.te = (lex.p)
 		(lex.p)--
@@ -954,12 +952,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = BOOL
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr66:
+		goto st13
+	tr65:
 //line lex.rl:105
 		lex.te = (lex.p)
 		(lex.p)--
@@ -967,12 +965,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = BYTE
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr73:
+		goto st13
+	tr72:
 //line lex.rl:125
 		lex.te = (lex.p)
 		(lex.p)--
@@ -980,12 +978,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = CONST
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr81:
+		goto st13
+	tr80:
 //line lex.rl:110
 		lex.te = (lex.p)
 		(lex.p)--
@@ -993,12 +991,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = DOUBLE
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr88:
+		goto st13
+	tr87:
 //line lex.rl:124
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1006,12 +1004,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = ENUM
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr99:
+		goto st13
+	tr98:
 //line lex.rl:120
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1019,12 +1017,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = EXCEPTION
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr106:
+		goto st13
+	tr105:
 //line lex.rl:121
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1032,12 +1030,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = EXTENDS
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr113:
+		goto st13
+	tr112:
 //line lex.rl:129
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1045,12 +1043,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = FALSE
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr122:
+		goto st13
+	tr121:
 //line lex.rl:107
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1058,12 +1056,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = I16
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr126:
+		goto st13
+	tr125:
 //line lex.rl:108
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1071,12 +1069,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = I32
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr130:
+		goto st13
+	tr129:
 //line lex.rl:109
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1084,12 +1082,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = I64
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr133:
+		goto st13
+	tr132:
 //line lex.rl:106
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1097,12 +1095,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = I8
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr141:
+		goto st13
+	tr140:
 //line lex.rl:101
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1110,12 +1108,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = INCLUDE
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr147:
+		goto st13
+	tr146:
 //line lex.rl:114
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1123,12 +1121,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = LIST
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr152:
+		goto st13
+	tr151:
 //line lex.rl:113
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1136,12 +1134,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = MAP
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr163:
+		goto st13
+	tr162:
 //line lex.rl:102
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1149,12 +1147,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = NAMESPACE
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr172:
+		goto st13
+	tr171:
 //line lex.rl:116
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1162,12 +1160,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = ONEWAY
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr181:
+		goto st13
+	tr180:
 //line lex.rl:127
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1175,12 +1173,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = OPTIONAL
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr191:
+		goto st13
+	tr190:
 //line lex.rl:126
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1188,12 +1186,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = REQUIRED
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr202:
+		goto st13
+	tr201:
 //line lex.rl:123
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1201,12 +1199,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = SERVICE
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr205:
+		goto st13
+	tr204:
 //line lex.rl:115
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1214,12 +1212,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = SET
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr213:
+		goto st13
+	tr212:
 //line lex.rl:111
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1227,12 +1225,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = STRING
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr218:
+		goto st13
+	tr217:
 //line lex.rl:118
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1240,12 +1238,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = STRUCT
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr228:
+		goto st13
+	tr227:
 //line lex.rl:122
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1253,12 +1251,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = THROWS
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr233:
+		goto st13
+	tr232:
 //line lex.rl:128
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1266,12 +1264,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = TRUE
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr241:
+		goto st13
+	tr240:
 //line lex.rl:117
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1279,12 +1277,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = TYPEDEF
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr248:
+		goto st13
+	tr247:
 //line lex.rl:119
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1292,12 +1290,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = UNION
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	tr254:
+		goto st13
+	tr253:
 //line lex.rl:103
 		lex.te = (lex.p)
 		(lex.p)--
@@ -1305,108 +1303,108 @@ func (lex *lexer) Lex(out *yySymType) int {
 			tok = VOID
 			{
 				(lex.p)++
-				lex.cs = 14
+				lex.cs = 13
 				goto _out
 			}
 		}
-		goto st14
-	st14:
+		goto st13
+	st13:
 //line NONE:1
 		lex.ts = 0
 
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof14
+			goto _test_eof13
 		}
-	st_case_14:
+	st_case_13:
 //line NONE:1
 		lex.ts = (lex.p)
 
-//line lex.go:872
+//line lex.go:870
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto tr20
+			goto tr19
 		case 10:
-			goto tr21
+			goto tr20
 		case 13:
-			goto tr20
+			goto tr19
 		case 32:
-			goto tr20
+			goto tr19
 		case 34:
 			goto st1
 		case 35:
-			goto st3
+			goto st14
 		case 39:
-			goto st4
+			goto st3
 		case 43:
-			goto st6
+			goto st5
 		case 45:
-			goto st6
+			goto st5
 		case 47:
-			goto st9
+			goto st8
 		case 48:
-			goto tr25
+			goto tr24
 		case 91:
-			goto tr22
+			goto tr21
 		case 93:
-			goto tr22
+			goto tr21
 		case 95:
-			goto tr19
+			goto tr18
 		case 98:
-			goto tr26
+			goto tr25
 		case 99:
-			goto tr27
+			goto tr26
 		case 100:
-			goto tr28
+			goto tr27
 		case 101:
-			goto tr29
+			goto tr28
 		case 102:
-			goto tr30
+			goto tr29
 		case 105:
-			goto tr31
+			goto tr30
 		case 108:
-			goto tr32
+			goto tr31
 		case 109:
-			goto tr33
+			goto tr32
 		case 110:
-			goto tr34
+			goto tr33
 		case 111:
-			goto tr35
+			goto tr34
 		case 114:
-			goto tr36
+			goto tr35
 		case 115:
-			goto tr37
+			goto tr36
 		case 116:
-			goto tr38
+			goto tr37
 		case 117:
-			goto tr39
+			goto tr38
 		case 118:
-			goto tr40
+			goto tr39
 		case 123:
-			goto tr22
+			goto tr21
 		case 125:
-			goto tr22
+			goto tr21
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
 			switch {
 			case lex.data[(lex.p)] > 44:
 				if 49 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-					goto st16
+					goto st15
 				}
 			case lex.data[(lex.p)] >= 40:
-				goto tr22
+				goto tr21
 			}
 		case lex.data[(lex.p)] > 62:
 			switch {
 			case lex.data[(lex.p)] > 90:
 				if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-					goto tr19
+					goto tr18
 				}
 			case lex.data[(lex.p)] >= 65:
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr22
+			goto tr21
 		}
 		goto st0
 	st_case_0:
@@ -1433,220 +1431,264 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_2:
 		goto st1
+	st14:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof14
+		}
+	st_case_14:
+		if lex.data[(lex.p)] == 10 {
+			goto tr40
+		}
+		goto st14
 	st3:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof3
 		}
 	st_case_3:
-		if lex.data[(lex.p)] == 10 {
-			goto st0
-		}
-		goto st15
-	st15:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof15
-		}
-	st_case_15:
-		if lex.data[(lex.p)] == 10 {
-			goto tr41
-		}
-		goto st15
-	st4:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof4
-		}
-	st_case_4:
 		switch lex.data[(lex.p)] {
 		case 10:
 			goto st0
 		case 39:
 			goto tr2
 		case 92:
-			goto st5
+			goto st4
 		}
-		goto st4
+		goto st3
+	st4:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof4
+		}
+	st_case_4:
+		goto st3
 	st5:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof5
 		}
 	st_case_5:
-		goto st4
-	st6:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof6
-		}
-	st_case_6:
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto st16
+			goto st15
 		}
 		goto st0
+	st15:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof15
+		}
+	st_case_15:
+		if lex.data[(lex.p)] == 46 {
+			goto tr42
+		}
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+			goto st15
+		}
+		goto tr41
+	tr42:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st16
 	st16:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof16
 		}
 	st_case_16:
-		if lex.data[(lex.p)] == 46 {
-			goto tr43
-		}
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto st16
-		}
-		goto tr42
-	tr43:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st17
-	st17:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof17
-		}
-	st_case_17:
-//line lex.go:1053
+//line lex.go:1042
 		switch lex.data[(lex.p)] {
 		case 69:
-			goto st7
+			goto st6
 		case 101:
+			goto st6
+		}
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+			goto tr42
+		}
+		goto tr43
+	st6:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof6
+		}
+	st_case_6:
+		switch lex.data[(lex.p)] {
+		case 43:
+			goto st7
+		case 45:
 			goto st7
 		}
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto tr43
+			goto st17
 		}
-		goto tr44
+		goto tr7
 	st7:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof7
 		}
 	st_case_7:
-		switch lex.data[(lex.p)] {
-		case 43:
-			goto st8
-		case 45:
-			goto st8
-		}
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto st18
+			goto st17
 		}
-		goto tr8
+		goto tr7
+	st17:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof17
+		}
+	st_case_17:
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+			goto st17
+		}
+		goto tr43
 	st8:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof8
 		}
 	st_case_8:
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto st18
+		switch lex.data[(lex.p)] {
+		case 42:
+			goto st9
+		case 47:
+			goto st14
 		}
-		goto tr8
-	st18:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof18
-		}
-	st_case_18:
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto st18
-		}
-		goto tr44
+		goto st0
+	tr12:
+//line lex.rl:59
+		lex.line++
+		goto st9
 	st9:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof9
 		}
 	st_case_9:
+//line lex.go:1107
 		switch lex.data[(lex.p)] {
+		case 10:
+			goto tr12
 		case 42:
 			goto st10
-		case 47:
-			goto st3
 		}
-		goto st0
-	tr13:
-//line lex.rl:59
-		lex.line++
-		goto st10
+		goto st9
 	st10:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof10
 		}
 	st_case_10:
-//line lex.go:1118
 		switch lex.data[(lex.p)] {
 		case 10:
-			goto tr13
+			goto tr12
 		case 42:
+			goto st10
+		case 47:
+			goto tr14
+		}
+		goto st9
+	tr24:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+		goto st18
+	st18:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof18
+		}
+	st_case_18:
+//line lex.go:1139
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto tr42
+		case 120:
 			goto st11
 		}
-		goto st10
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+			goto st15
+		}
+		goto tr41
 	st11:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof11
 		}
 	st_case_11:
-		switch lex.data[(lex.p)] {
-		case 10:
-			goto tr13
-		case 42:
-			goto st11
-		case 47:
-			goto tr15
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto st19
+			}
+		case lex.data[(lex.p)] > 70:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
+				goto st19
+			}
+		default:
+			goto st19
 		}
-		goto st10
-	tr25:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-		goto st19
+		goto tr15
 	st19:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof19
 		}
 	st_case_19:
-//line lex.go:1150
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto tr43
-		case 120:
-			goto st12
-		}
-		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto st16
-		}
-		goto tr42
-	st12:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof12
-		}
-	st_case_12:
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto st20
+				goto st19
 			}
 		case lex.data[(lex.p)] > 70:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
-				goto st20
+				goto st19
 			}
 		default:
-			goto st20
+			goto st19
 		}
-		goto tr16
+		goto tr41
+	tr18:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
+		goto st20
 	st20:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof20
 		}
 	st_case_20:
+//line lex.go:1198
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto st20
+				goto tr18
 			}
-		case lex.data[(lex.p)] > 70:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
-				goto st20
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto st20
+			goto tr18
 		}
-		goto tr42
-	tr19:
+		goto tr46
+	st12:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof12
+		}
+	st_case_12:
+		if lex.data[(lex.p)] == 95 {
+			goto tr18
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr17
+	tr25:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -1658,48 +1700,33 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof21
 		}
 	st_case_21:
-//line lex.go:1209
+//line lex.go:1251
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
+			goto tr18
+		case 105:
+			goto tr48
+		case 111:
+			goto tr49
+		case 121:
+			goto tr50
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	st13:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof13
-		}
-	st_case_13:
-		if lex.data[(lex.p)] == 95 {
-			goto tr19
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr18
-	tr26:
+		goto tr46
+	tr48:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -1711,33 +1738,29 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof22
 		}
 	st_case_22:
-//line lex.go:1262
+//line lex.go:1289
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 105:
-			goto tr49
-		case 111:
-			goto tr50
-		case 121:
+			goto tr18
+		case 110:
 			goto tr51
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr49:
+		goto tr46
+	tr51:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -1749,28 +1772,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof23
 		}
 	st_case_23:
-//line lex.go:1300
+//line lex.go:1323
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
+			goto tr18
+		case 97:
 			goto tr52
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr52:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -1783,28 +1806,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof24
 		}
 	st_case_24:
-//line lex.go:1334
+//line lex.go:1357
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 97:
+			goto tr18
+		case 114:
 			goto tr53
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr53:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -1817,124 +1840,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof25
 		}
 	st_case_25:
-//line lex.go:1368
+//line lex.go:1391
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 114:
+			goto tr18
+		case 121:
 			goto tr54
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr54:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:112
+		lex.act = 12
 		goto st26
 	st26:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof26
 		}
 	st_case_26:
-//line lex.go:1402
+//line lex.go:1425
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st27
+		case 10:
+			goto tr57
+		case 13:
+			goto st27
+		case 32:
+			goto st27
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 121:
-			goto tr55
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr55:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:112
-		lex.act = 12
+		goto tr55
+	tr57:
+//line lex.rl:59
+		lex.line++
 		goto st27
 	st27:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof27
 		}
 	st_case_27:
-//line lex.go:1436
+//line lex.go:1462
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st28
+			goto st27
 		case 10:
-			goto tr58
+			goto tr57
 		case 13:
-			goto st28
+			goto st27
 		case 32:
-			goto st28
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st27
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr56
-	tr58:
-//line lex.rl:59
-		lex.line++
+		goto tr55
+	tr49:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st28
 	st28:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof28
 		}
 	st_case_28:
-//line lex.go:1473
+//line lex.go:1486
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st28
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 111:
 			goto tr58
-		case 13:
-			goto st28
-		case 32:
-			goto st28
 		}
-		goto tr56
-	tr50:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr58:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -1946,124 +1969,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof29
 		}
 	st_case_29:
-//line lex.go:1497
+//line lex.go:1520
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 111:
+			goto tr18
+		case 108:
 			goto tr59
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr59:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:104
+		lex.act = 4
 		goto st30
 	st30:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof30
 		}
 	st_case_30:
-//line lex.go:1531
+//line lex.go:1554
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st31
+		case 10:
+			goto tr62
+		case 13:
+			goto st31
+		case 32:
+			goto st31
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 108:
-			goto tr60
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr60:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:104
-		lex.act = 4
+		goto tr60
+	tr62:
+//line lex.rl:59
+		lex.line++
 		goto st31
 	st31:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof31
 		}
 	st_case_31:
-//line lex.go:1565
+//line lex.go:1591
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st32
+			goto st31
 		case 10:
-			goto tr63
+			goto tr62
 		case 13:
-			goto st32
+			goto st31
 		case 32:
-			goto st32
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st31
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr61
-	tr63:
-//line lex.rl:59
-		lex.line++
+		goto tr60
+	tr50:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st32
 	st32:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof32
 		}
 	st_case_32:
-//line lex.go:1602
+//line lex.go:1615
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st32
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 116:
 			goto tr63
-		case 13:
-			goto st32
-		case 32:
-			goto st32
 		}
-		goto tr61
-	tr51:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr63:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -2075,124 +2098,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof33
 		}
 	st_case_33:
-//line lex.go:1626
+//line lex.go:1649
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 116:
+			goto tr18
+		case 101:
 			goto tr64
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr64:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:105
+		lex.act = 5
 		goto st34
 	st34:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof34
 		}
 	st_case_34:
-//line lex.go:1660
+//line lex.go:1683
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st35
+		case 10:
+			goto tr67
+		case 13:
+			goto st35
+		case 32:
+			goto st35
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
-			goto tr65
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr65:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:105
-		lex.act = 5
+		goto tr65
+	tr67:
+//line lex.rl:59
+		lex.line++
 		goto st35
 	st35:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof35
 		}
 	st_case_35:
-//line lex.go:1694
+//line lex.go:1720
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st36
+			goto st35
 		case 10:
-			goto tr68
+			goto tr67
 		case 13:
-			goto st36
+			goto st35
 		case 32:
-			goto st36
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st35
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr66
-	tr68:
-//line lex.rl:59
-		lex.line++
+		goto tr65
+	tr26:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st36
 	st36:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof36
 		}
 	st_case_36:
-//line lex.go:1731
+//line lex.go:1744
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st36
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 111:
 			goto tr68
-		case 13:
-			goto st36
-		case 32:
-			goto st36
 		}
-		goto tr66
-	tr27:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr68:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -2204,28 +2227,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof37
 		}
 	st_case_37:
-//line lex.go:1755
+//line lex.go:1778
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 111:
+			goto tr18
+		case 110:
 			goto tr69
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr69:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -2238,28 +2261,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof38
 		}
 	st_case_38:
-//line lex.go:1789
+//line lex.go:1812
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
+			goto tr18
+		case 115:
 			goto tr70
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr70:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -2272,124 +2295,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof39
 		}
 	st_case_39:
-//line lex.go:1823
+//line lex.go:1846
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 115:
+			goto tr18
+		case 116:
 			goto tr71
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr71:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:125
+		lex.act = 25
 		goto st40
 	st40:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof40
 		}
 	st_case_40:
-//line lex.go:1857
+//line lex.go:1880
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st41
+		case 10:
+			goto tr74
+		case 13:
+			goto st41
+		case 32:
+			goto st41
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 116:
-			goto tr72
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr72:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:125
-		lex.act = 25
+		goto tr72
+	tr74:
+//line lex.rl:59
+		lex.line++
 		goto st41
 	st41:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof41
 		}
 	st_case_41:
-//line lex.go:1891
+//line lex.go:1917
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st42
+			goto st41
 		case 10:
-			goto tr75
+			goto tr74
 		case 13:
-			goto st42
+			goto st41
 		case 32:
-			goto st42
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st41
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr73
-	tr75:
-//line lex.rl:59
-		lex.line++
+		goto tr72
+	tr27:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st42
 	st42:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof42
 		}
 	st_case_42:
-//line lex.go:1928
+//line lex.go:1941
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st42
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 111:
 			goto tr75
-		case 13:
-			goto st42
-		case 32:
-			goto st42
 		}
-		goto tr73
-	tr28:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr75:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -2401,28 +2424,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof43
 		}
 	st_case_43:
-//line lex.go:1952
+//line lex.go:1975
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 111:
+			goto tr18
+		case 117:
 			goto tr76
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr76:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -2435,28 +2458,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof44
 		}
 	st_case_44:
-//line lex.go:1986
+//line lex.go:2009
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 117:
+			goto tr18
+		case 98:
 			goto tr77
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr77:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -2469,28 +2492,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof45
 		}
 	st_case_45:
-//line lex.go:2020
+//line lex.go:2043
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 98:
+			goto tr18
+		case 108:
 			goto tr78
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr78:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -2503,124 +2526,126 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof46
 		}
 	st_case_46:
-//line lex.go:2054
+//line lex.go:2077
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 108:
+			goto tr18
+		case 101:
 			goto tr79
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr79:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:110
+		lex.act = 10
 		goto st47
 	st47:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof47
 		}
 	st_case_47:
-//line lex.go:2088
+//line lex.go:2111
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st48
+		case 10:
+			goto tr82
+		case 13:
+			goto st48
+		case 32:
+			goto st48
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
-			goto tr80
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr80:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:110
-		lex.act = 10
+		goto tr80
+	tr82:
+//line lex.rl:59
+		lex.line++
 		goto st48
 	st48:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof48
 		}
 	st_case_48:
-//line lex.go:2122
+//line lex.go:2148
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st49
+			goto st48
 		case 10:
-			goto tr83
+			goto tr82
 		case 13:
-			goto st49
+			goto st48
 		case 32:
-			goto st49
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st48
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr81
-	tr83:
-//line lex.rl:59
-		lex.line++
+		goto tr80
+	tr28:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st49
 	st49:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof49
 		}
 	st_case_49:
-//line lex.go:2159
+//line lex.go:2172
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st49
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 110:
 			goto tr83
-		case 13:
-			goto st49
-		case 32:
-			goto st49
+		case 120:
+			goto tr84
 		}
-		goto tr81
-	tr29:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr83:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -2632,31 +2657,29 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof50
 		}
 	st_case_50:
-//line lex.go:2183
+//line lex.go:2208
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
-			goto tr84
-		case 120:
+			goto tr18
+		case 117:
 			goto tr85
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr84:
+		goto tr46
+	tr85:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -2668,124 +2691,126 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof51
 		}
 	st_case_51:
-//line lex.go:2219
+//line lex.go:2242
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 117:
+			goto tr18
+		case 109:
 			goto tr86
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr86:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:124
+		lex.act = 24
 		goto st52
 	st52:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof52
 		}
 	st_case_52:
-//line lex.go:2253
+//line lex.go:2276
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st53
+		case 10:
+			goto tr89
+		case 13:
+			goto st53
+		case 32:
+			goto st53
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 109:
-			goto tr87
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr87:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:124
-		lex.act = 24
+		goto tr87
+	tr89:
+//line lex.rl:59
+		lex.line++
 		goto st53
 	st53:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof53
 		}
 	st_case_53:
-//line lex.go:2287
+//line lex.go:2313
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st54
+			goto st53
 		case 10:
-			goto tr90
+			goto tr89
 		case 13:
-			goto st54
+			goto st53
 		case 32:
-			goto st54
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st53
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr88
-	tr90:
-//line lex.rl:59
-		lex.line++
+		goto tr87
+	tr84:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st54
 	st54:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof54
 		}
 	st_case_54:
-//line lex.go:2324
+//line lex.go:2337
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st54
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 99:
 			goto tr90
-		case 13:
-			goto st54
-		case 32:
-			goto st54
+		case 116:
+			goto tr91
 		}
-		goto tr88
-	tr85:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr90:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -2797,31 +2822,29 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof55
 		}
 	st_case_55:
-//line lex.go:2348
+//line lex.go:2373
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 99:
-			goto tr91
-		case 116:
+			goto tr18
+		case 101:
 			goto tr92
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr91:
+		goto tr46
+	tr92:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -2833,28 +2856,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof56
 		}
 	st_case_56:
-//line lex.go:2384
+//line lex.go:2407
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
+			goto tr18
+		case 112:
 			goto tr93
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr93:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -2867,28 +2890,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof57
 		}
 	st_case_57:
-//line lex.go:2418
+//line lex.go:2441
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 112:
+			goto tr18
+		case 116:
 			goto tr94
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr94:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -2901,28 +2924,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof58
 		}
 	st_case_58:
-//line lex.go:2452
+//line lex.go:2475
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 116:
+			goto tr18
+		case 105:
 			goto tr95
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr95:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -2935,28 +2958,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof59
 		}
 	st_case_59:
-//line lex.go:2486
+//line lex.go:2509
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 105:
+			goto tr18
+		case 111:
 			goto tr96
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr96:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -2969,124 +2992,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof60
 		}
 	st_case_60:
-//line lex.go:2520
+//line lex.go:2543
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 111:
+			goto tr18
+		case 110:
 			goto tr97
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr97:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:120
+		lex.act = 20
 		goto st61
 	st61:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof61
 		}
 	st_case_61:
-//line lex.go:2554
+//line lex.go:2577
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st62
+		case 10:
+			goto tr100
+		case 13:
+			goto st62
+		case 32:
+			goto st62
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
-			goto tr98
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr98:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:120
-		lex.act = 20
+		goto tr98
+	tr100:
+//line lex.rl:59
+		lex.line++
 		goto st62
 	st62:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof62
 		}
 	st_case_62:
-//line lex.go:2588
+//line lex.go:2614
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st63
+			goto st62
 		case 10:
-			goto tr101
+			goto tr100
 		case 13:
-			goto st63
+			goto st62
 		case 32:
-			goto st63
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st62
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr99
-	tr101:
-//line lex.rl:59
-		lex.line++
+		goto tr98
+	tr91:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st63
 	st63:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof63
 		}
 	st_case_63:
-//line lex.go:2625
+//line lex.go:2638
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st63
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 101:
 			goto tr101
-		case 13:
-			goto st63
-		case 32:
-			goto st63
 		}
-		goto tr99
-	tr92:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr101:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -3098,28 +3121,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof64
 		}
 	st_case_64:
-//line lex.go:2649
+//line lex.go:2672
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
+			goto tr18
+		case 110:
 			goto tr102
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr102:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -3132,28 +3155,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof65
 		}
 	st_case_65:
-//line lex.go:2683
+//line lex.go:2706
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
+			goto tr18
+		case 100:
 			goto tr103
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr103:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -3166,124 +3189,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof66
 		}
 	st_case_66:
-//line lex.go:2717
+//line lex.go:2740
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 100:
+			goto tr18
+		case 115:
 			goto tr104
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr104:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:121
+		lex.act = 21
 		goto st67
 	st67:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof67
 		}
 	st_case_67:
-//line lex.go:2751
+//line lex.go:2774
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st68
+		case 10:
+			goto tr107
+		case 13:
+			goto st68
+		case 32:
+			goto st68
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 115:
-			goto tr105
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr105:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:121
-		lex.act = 21
+		goto tr105
+	tr107:
+//line lex.rl:59
+		lex.line++
 		goto st68
 	st68:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof68
 		}
 	st_case_68:
-//line lex.go:2785
+//line lex.go:2811
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st69
+			goto st68
 		case 10:
-			goto tr108
+			goto tr107
 		case 13:
-			goto st69
+			goto st68
 		case 32:
-			goto st69
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st68
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr106
-	tr108:
-//line lex.rl:59
-		lex.line++
+		goto tr105
+	tr29:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st69
 	st69:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof69
 		}
 	st_case_69:
-//line lex.go:2822
+//line lex.go:2835
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st69
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 97:
 			goto tr108
-		case 13:
-			goto st69
-		case 32:
-			goto st69
 		}
-		goto tr106
-	tr30:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr108:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -3295,28 +3318,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof70
 		}
 	st_case_70:
-//line lex.go:2846
+//line lex.go:2869
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 97:
+			goto tr18
+		case 108:
 			goto tr109
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr109:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -3329,28 +3352,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof71
 		}
 	st_case_71:
-//line lex.go:2880
+//line lex.go:2903
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 108:
+			goto tr18
+		case 115:
 			goto tr110
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr110:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -3363,124 +3386,132 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof72
 		}
 	st_case_72:
-//line lex.go:2914
+//line lex.go:2937
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 115:
+			goto tr18
+		case 101:
 			goto tr111
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr111:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:129
+		lex.act = 29
 		goto st73
 	st73:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof73
 		}
 	st_case_73:
-//line lex.go:2948
+//line lex.go:2971
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st74
+		case 10:
+			goto tr114
+		case 13:
+			goto st74
+		case 32:
+			goto st74
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
-			goto tr112
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr112:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:129
-		lex.act = 29
+		goto tr112
+	tr114:
+//line lex.rl:59
+		lex.line++
 		goto st74
 	st74:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof74
 		}
 	st_case_74:
-//line lex.go:2982
+//line lex.go:3008
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st75
+			goto st74
 		case 10:
-			goto tr115
+			goto tr114
 		case 13:
-			goto st75
+			goto st74
 		case 32:
-			goto st75
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st74
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr113
-	tr115:
-//line lex.rl:59
-		lex.line++
+		goto tr112
+	tr30:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st75
 	st75:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof75
 		}
 	st_case_75:
-//line lex.go:3019
+//line lex.go:3032
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st75
-		case 10:
+		case 46:
+			goto st12
+		case 49:
 			goto tr115
-		case 13:
-			goto st75
-		case 32:
-			goto st75
+		case 51:
+			goto tr116
+		case 54:
+			goto tr117
+		case 56:
+			goto tr118
+		case 95:
+			goto tr18
+		case 110:
+			goto tr119
 		}
-		goto tr113
-	tr31:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr115:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -3492,383 +3523,375 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof76
 		}
 	st_case_76:
-//line lex.go:3043
+//line lex.go:3074
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
-		case 49:
-			goto tr116
-		case 51:
-			goto tr117
+			goto st12
 		case 54:
-			goto tr118
-		case 56:
-			goto tr119
-		case 95:
-			goto tr19
-		case 110:
 			goto tr120
+		case 95:
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr116:
+		goto tr46
+	tr120:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:107
+		lex.act = 7
 		goto st77
 	st77:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof77
 		}
 	st_case_77:
-//line lex.go:3085
+//line lex.go:3108
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st78
+		case 10:
+			goto tr123
+		case 13:
+			goto st78
+		case 32:
+			goto st78
 		case 46:
-			goto st13
-		case 54:
-			goto tr121
+			goto st12
 		case 95:
-			goto tr19
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr121:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:107
-		lex.act = 7
+		goto tr121
+	tr123:
+//line lex.rl:59
+		lex.line++
 		goto st78
 	st78:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof78
 		}
 	st_case_78:
-//line lex.go:3119
+//line lex.go:3145
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st79
+			goto st78
 		case 10:
-			goto tr124
+			goto tr123
 		case 13:
-			goto st79
+			goto st78
 		case 32:
-			goto st79
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st78
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr122
-	tr124:
-//line lex.rl:59
-		lex.line++
+		goto tr121
+	tr116:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st79
 	st79:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof79
 		}
 	st_case_79:
-//line lex.go:3156
+//line lex.go:3169
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st79
-		case 10:
+		case 46:
+			goto st12
+		case 50:
 			goto tr124
-		case 13:
-			goto st79
-		case 32:
-			goto st79
+		case 95:
+			goto tr18
 		}
-		goto tr122
-	tr117:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr124:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:108
+		lex.act = 8
 		goto st80
 	st80:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof80
 		}
 	st_case_80:
-//line lex.go:3180
+//line lex.go:3203
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st81
+		case 10:
+			goto tr127
+		case 13:
+			goto st81
+		case 32:
+			goto st81
 		case 46:
-			goto st13
-		case 50:
-			goto tr125
+			goto st12
 		case 95:
-			goto tr19
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr125:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:108
-		lex.act = 8
+		goto tr125
+	tr127:
+//line lex.rl:59
+		lex.line++
 		goto st81
 	st81:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof81
 		}
 	st_case_81:
-//line lex.go:3214
+//line lex.go:3240
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st82
+			goto st81
 		case 10:
-			goto tr128
+			goto tr127
 		case 13:
-			goto st82
+			goto st81
 		case 32:
-			goto st82
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st81
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr126
-	tr128:
-//line lex.rl:59
-		lex.line++
+		goto tr125
+	tr117:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st82
 	st82:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof82
 		}
 	st_case_82:
-//line lex.go:3251
+//line lex.go:3264
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st82
-		case 10:
+		case 46:
+			goto st12
+		case 52:
 			goto tr128
-		case 13:
-			goto st82
-		case 32:
-			goto st82
+		case 95:
+			goto tr18
 		}
-		goto tr126
-	tr118:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr128:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:109
+		lex.act = 9
 		goto st83
 	st83:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof83
 		}
 	st_case_83:
-//line lex.go:3275
+//line lex.go:3298
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st84
+		case 10:
+			goto tr131
+		case 13:
+			goto st84
+		case 32:
+			goto st84
 		case 46:
-			goto st13
-		case 52:
-			goto tr129
+			goto st12
 		case 95:
-			goto tr19
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr129:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:109
-		lex.act = 9
+		goto tr129
+	tr131:
+//line lex.rl:59
+		lex.line++
 		goto st84
 	st84:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof84
 		}
 	st_case_84:
-//line lex.go:3309
+//line lex.go:3335
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st85
+			goto st84
 		case 10:
-			goto tr132
+			goto tr131
 		case 13:
-			goto st85
+			goto st84
 		case 32:
-			goto st85
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st84
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr130
-	tr132:
-//line lex.rl:59
-		lex.line++
+		goto tr129
+	tr118:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:106
+		lex.act = 6
 		goto st85
 	st85:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof85
 		}
 	st_case_85:
-//line lex.go:3346
+//line lex.go:3359
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st85
+			goto st86
 		case 10:
-			goto tr132
+			goto tr134
 		case 13:
-			goto st85
+			goto st86
 		case 32:
-			goto st85
+			goto st86
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
 		}
-		goto tr130
-	tr119:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:106
-		lex.act = 6
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr132
+	tr134:
+//line lex.rl:59
+		lex.line++
 		goto st86
 	st86:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof86
 		}
 	st_case_86:
-//line lex.go:3370
+//line lex.go:3396
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st87
+			goto st86
 		case 10:
-			goto tr135
+			goto tr134
 		case 13:
-			goto st87
+			goto st86
 		case 32:
-			goto st87
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st86
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr133
-	tr135:
-//line lex.rl:59
-		lex.line++
+		goto tr132
+	tr119:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st87
 	st87:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof87
 		}
 	st_case_87:
-//line lex.go:3407
+//line lex.go:3420
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st87
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 99:
 			goto tr135
-		case 13:
-			goto st87
-		case 32:
-			goto st87
 		}
-		goto tr133
-	tr120:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr135:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -3880,28 +3903,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof88
 		}
 	st_case_88:
-//line lex.go:3431
+//line lex.go:3454
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 99:
+			goto tr18
+		case 108:
 			goto tr136
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr136:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -3914,28 +3937,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof89
 		}
 	st_case_89:
-//line lex.go:3465
+//line lex.go:3488
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 108:
+			goto tr18
+		case 117:
 			goto tr137
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr137:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -3948,28 +3971,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof90
 		}
 	st_case_90:
-//line lex.go:3499
+//line lex.go:3522
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 117:
+			goto tr18
+		case 100:
 			goto tr138
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr138:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -3982,124 +4005,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof91
 		}
 	st_case_91:
-//line lex.go:3533
+//line lex.go:3556
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 100:
+			goto tr18
+		case 101:
 			goto tr139
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr139:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:101
+		lex.act = 1
 		goto st92
 	st92:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof92
 		}
 	st_case_92:
-//line lex.go:3567
+//line lex.go:3590
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st93
+		case 10:
+			goto tr142
+		case 13:
+			goto st93
+		case 32:
+			goto st93
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
-			goto tr140
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr140:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:101
-		lex.act = 1
+		goto tr140
+	tr142:
+//line lex.rl:59
+		lex.line++
 		goto st93
 	st93:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof93
 		}
 	st_case_93:
-//line lex.go:3601
+//line lex.go:3627
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st94
+			goto st93
 		case 10:
-			goto tr143
+			goto tr142
 		case 13:
-			goto st94
+			goto st93
 		case 32:
-			goto st94
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st93
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr141
-	tr143:
-//line lex.rl:59
-		lex.line++
+		goto tr140
+	tr31:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st94
 	st94:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof94
 		}
 	st_case_94:
-//line lex.go:3638
+//line lex.go:3651
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st94
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 105:
 			goto tr143
-		case 13:
-			goto st94
-		case 32:
-			goto st94
 		}
-		goto tr141
-	tr32:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr143:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -4111,28 +4134,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof95
 		}
 	st_case_95:
-//line lex.go:3662
+//line lex.go:3685
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 105:
+			goto tr18
+		case 115:
 			goto tr144
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr144:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -4145,124 +4168,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof96
 		}
 	st_case_96:
-//line lex.go:3696
+//line lex.go:3719
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 115:
+			goto tr18
+		case 116:
 			goto tr145
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr145:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:114
+		lex.act = 14
 		goto st97
 	st97:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof97
 		}
 	st_case_97:
-//line lex.go:3730
+//line lex.go:3753
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st98
+		case 10:
+			goto tr148
+		case 13:
+			goto st98
+		case 32:
+			goto st98
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 116:
-			goto tr146
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr146:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:114
-		lex.act = 14
+		goto tr146
+	tr148:
+//line lex.rl:59
+		lex.line++
 		goto st98
 	st98:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof98
 		}
 	st_case_98:
-//line lex.go:3764
+//line lex.go:3790
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st99
+			goto st98
 		case 10:
-			goto tr149
+			goto tr148
 		case 13:
-			goto st99
+			goto st98
 		case 32:
-			goto st99
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st98
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr147
-	tr149:
-//line lex.rl:59
-		lex.line++
+		goto tr146
+	tr32:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st99
 	st99:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof99
 		}
 	st_case_99:
-//line lex.go:3801
+//line lex.go:3814
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st99
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 97:
 			goto tr149
-		case 13:
-			goto st99
-		case 32:
-			goto st99
 		}
-		goto tr147
-	tr33:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr149:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -4274,124 +4297,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof100
 		}
 	st_case_100:
-//line lex.go:3825
+//line lex.go:3848
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 97:
+			goto tr18
+		case 112:
 			goto tr150
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr150:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:113
+		lex.act = 13
 		goto st101
 	st101:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof101
 		}
 	st_case_101:
-//line lex.go:3859
+//line lex.go:3882
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st102
+		case 10:
+			goto tr153
+		case 13:
+			goto st102
+		case 32:
+			goto st102
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 112:
-			goto tr151
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr151:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:113
-		lex.act = 13
+		goto tr151
+	tr153:
+//line lex.rl:59
+		lex.line++
 		goto st102
 	st102:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof102
 		}
 	st_case_102:
-//line lex.go:3893
+//line lex.go:3919
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st103
+			goto st102
 		case 10:
-			goto tr154
+			goto tr153
 		case 13:
-			goto st103
+			goto st102
 		case 32:
-			goto st103
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st102
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr152
-	tr154:
-//line lex.rl:59
-		lex.line++
+		goto tr151
+	tr33:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st103
 	st103:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof103
 		}
 	st_case_103:
-//line lex.go:3930
+//line lex.go:3943
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st103
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 97:
 			goto tr154
-		case 13:
-			goto st103
-		case 32:
-			goto st103
 		}
-		goto tr152
-	tr34:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr154:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -4403,28 +4426,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof104
 		}
 	st_case_104:
-//line lex.go:3954
+//line lex.go:3977
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 97:
+			goto tr18
+		case 109:
 			goto tr155
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr155:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -4437,28 +4460,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof105
 		}
 	st_case_105:
-//line lex.go:3988
+//line lex.go:4011
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 109:
+			goto tr18
+		case 101:
 			goto tr156
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr156:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -4471,28 +4494,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof106
 		}
 	st_case_106:
-//line lex.go:4022
+//line lex.go:4045
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
+			goto tr18
+		case 115:
 			goto tr157
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr157:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -4505,28 +4528,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof107
 		}
 	st_case_107:
-//line lex.go:4056
+//line lex.go:4079
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 115:
+			goto tr18
+		case 112:
 			goto tr158
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr158:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -4539,28 +4562,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof108
 		}
 	st_case_108:
-//line lex.go:4090
+//line lex.go:4113
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 112:
+			goto tr18
+		case 97:
 			goto tr159
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr159:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -4573,28 +4596,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof109
 		}
 	st_case_109:
-//line lex.go:4124
+//line lex.go:4147
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 97:
+			goto tr18
+		case 99:
 			goto tr160
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr160:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -4607,124 +4630,126 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof110
 		}
 	st_case_110:
-//line lex.go:4158
+//line lex.go:4181
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 99:
+			goto tr18
+		case 101:
 			goto tr161
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr161:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:102
+		lex.act = 2
 		goto st111
 	st111:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof111
 		}
 	st_case_111:
-//line lex.go:4192
+//line lex.go:4215
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st112
+		case 10:
+			goto tr164
+		case 13:
+			goto st112
+		case 32:
+			goto st112
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
-			goto tr162
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr162:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:102
-		lex.act = 2
+		goto tr162
+	tr164:
+//line lex.rl:59
+		lex.line++
 		goto st112
 	st112:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof112
 		}
 	st_case_112:
-//line lex.go:4226
+//line lex.go:4252
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st113
+			goto st112
 		case 10:
-			goto tr165
+			goto tr164
 		case 13:
-			goto st113
+			goto st112
 		case 32:
-			goto st113
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st112
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr163
-	tr165:
-//line lex.rl:59
-		lex.line++
+		goto tr162
+	tr34:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st113
 	st113:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof113
 		}
 	st_case_113:
-//line lex.go:4263
+//line lex.go:4276
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st113
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 110:
 			goto tr165
-		case 13:
-			goto st113
-		case 32:
-			goto st113
+		case 112:
+			goto tr166
 		}
-		goto tr163
-	tr35:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr165:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -4736,31 +4761,29 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof114
 		}
 	st_case_114:
-//line lex.go:4287
+//line lex.go:4312
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
-			goto tr166
-		case 112:
+			goto tr18
+		case 101:
 			goto tr167
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr166:
+		goto tr46
+	tr167:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -4772,28 +4795,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof115
 		}
 	st_case_115:
-//line lex.go:4323
+//line lex.go:4346
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
+			goto tr18
+		case 119:
 			goto tr168
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr168:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -4806,28 +4829,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof116
 		}
 	st_case_116:
-//line lex.go:4357
+//line lex.go:4380
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 119:
+			goto tr18
+		case 97:
 			goto tr169
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr169:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -4840,124 +4863,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof117
 		}
 	st_case_117:
-//line lex.go:4391
+//line lex.go:4414
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 97:
+			goto tr18
+		case 121:
 			goto tr170
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr170:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:116
+		lex.act = 16
 		goto st118
 	st118:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof118
 		}
 	st_case_118:
-//line lex.go:4425
+//line lex.go:4448
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st119
+		case 10:
+			goto tr173
+		case 13:
+			goto st119
+		case 32:
+			goto st119
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 121:
-			goto tr171
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr171:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:116
-		lex.act = 16
+		goto tr171
+	tr173:
+//line lex.rl:59
+		lex.line++
 		goto st119
 	st119:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof119
 		}
 	st_case_119:
-//line lex.go:4459
+//line lex.go:4485
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st120
+			goto st119
 		case 10:
-			goto tr174
+			goto tr173
 		case 13:
-			goto st120
+			goto st119
 		case 32:
-			goto st120
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st119
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr172
-	tr174:
-//line lex.rl:59
-		lex.line++
+		goto tr171
+	tr166:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st120
 	st120:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof120
 		}
 	st_case_120:
-//line lex.go:4496
+//line lex.go:4509
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st120
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 116:
 			goto tr174
-		case 13:
-			goto st120
-		case 32:
-			goto st120
 		}
-		goto tr172
-	tr167:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr174:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -4969,28 +4992,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof121
 		}
 	st_case_121:
-//line lex.go:4520
+//line lex.go:4543
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 116:
+			goto tr18
+		case 105:
 			goto tr175
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr175:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5003,28 +5026,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof122
 		}
 	st_case_122:
-//line lex.go:4554
+//line lex.go:4577
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 105:
+			goto tr18
+		case 111:
 			goto tr176
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr176:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5037,28 +5060,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof123
 		}
 	st_case_123:
-//line lex.go:4588
+//line lex.go:4611
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 111:
+			goto tr18
+		case 110:
 			goto tr177
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr177:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5071,28 +5094,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof124
 		}
 	st_case_124:
-//line lex.go:4622
+//line lex.go:4645
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
+			goto tr18
+		case 97:
 			goto tr178
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr178:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5105,124 +5128,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof125
 		}
 	st_case_125:
-//line lex.go:4656
+//line lex.go:4679
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 97:
+			goto tr18
+		case 108:
 			goto tr179
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr179:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:127
+		lex.act = 27
 		goto st126
 	st126:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof126
 		}
 	st_case_126:
-//line lex.go:4690
+//line lex.go:4713
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st127
+		case 10:
+			goto tr182
+		case 13:
+			goto st127
+		case 32:
+			goto st127
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 108:
-			goto tr180
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr180:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:127
-		lex.act = 27
+		goto tr180
+	tr182:
+//line lex.rl:59
+		lex.line++
 		goto st127
 	st127:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof127
 		}
 	st_case_127:
-//line lex.go:4724
+//line lex.go:4750
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st128
+			goto st127
 		case 10:
-			goto tr183
+			goto tr182
 		case 13:
-			goto st128
+			goto st127
 		case 32:
-			goto st128
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st127
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr181
-	tr183:
-//line lex.rl:59
-		lex.line++
+		goto tr180
+	tr35:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st128
 	st128:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof128
 		}
 	st_case_128:
-//line lex.go:4761
+//line lex.go:4774
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st128
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 101:
 			goto tr183
-		case 13:
-			goto st128
-		case 32:
-			goto st128
 		}
-		goto tr181
-	tr36:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr183:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -5234,28 +5257,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof129
 		}
 	st_case_129:
-//line lex.go:4785
+//line lex.go:4808
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
+			goto tr18
+		case 113:
 			goto tr184
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr184:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5268,28 +5291,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof130
 		}
 	st_case_130:
-//line lex.go:4819
+//line lex.go:4842
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 113:
+			goto tr18
+		case 117:
 			goto tr185
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr185:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5302,28 +5325,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof131
 		}
 	st_case_131:
-//line lex.go:4853
+//line lex.go:4876
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 117:
+			goto tr18
+		case 105:
 			goto tr186
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr186:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5336,28 +5359,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof132
 		}
 	st_case_132:
-//line lex.go:4887
+//line lex.go:4910
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 105:
+			goto tr18
+		case 114:
 			goto tr187
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr187:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5370,28 +5393,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof133
 		}
 	st_case_133:
-//line lex.go:4921
+//line lex.go:4944
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 114:
+			goto tr18
+		case 101:
 			goto tr188
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr188:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5404,124 +5427,126 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof134
 		}
 	st_case_134:
-//line lex.go:4955
+//line lex.go:4978
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
+			goto tr18
+		case 100:
 			goto tr189
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr189:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:126
+		lex.act = 26
 		goto st135
 	st135:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof135
 		}
 	st_case_135:
-//line lex.go:4989
+//line lex.go:5012
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st136
+		case 10:
+			goto tr192
+		case 13:
+			goto st136
+		case 32:
+			goto st136
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 100:
-			goto tr190
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr190:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:126
-		lex.act = 26
+		goto tr190
+	tr192:
+//line lex.rl:59
+		lex.line++
 		goto st136
 	st136:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof136
 		}
 	st_case_136:
-//line lex.go:5023
+//line lex.go:5049
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st137
+			goto st136
 		case 10:
-			goto tr193
+			goto tr192
 		case 13:
-			goto st137
+			goto st136
 		case 32:
-			goto st137
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st136
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr191
-	tr193:
-//line lex.rl:59
-		lex.line++
+		goto tr190
+	tr36:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st137
 	st137:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof137
 		}
 	st_case_137:
-//line lex.go:5060
+//line lex.go:5073
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st137
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 101:
 			goto tr193
-		case 13:
-			goto st137
-		case 32:
-			goto st137
+		case 116:
+			goto tr194
 		}
-		goto tr191
-	tr37:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr193:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -5533,31 +5558,31 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof138
 		}
 	st_case_138:
-//line lex.go:5084
+//line lex.go:5109
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
-			goto tr194
-		case 116:
+			goto tr18
+		case 114:
 			goto tr195
+		case 116:
+			goto tr196
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr194:
+		goto tr46
+	tr195:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -5569,31 +5594,29 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof139
 		}
 	st_case_139:
-//line lex.go:5120
+//line lex.go:5145
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 114:
-			goto tr196
-		case 116:
+			goto tr18
+		case 118:
 			goto tr197
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr196:
+		goto tr46
+	tr197:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -5605,28 +5628,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof140
 		}
 	st_case_140:
-//line lex.go:5156
+//line lex.go:5179
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 118:
+			goto tr18
+		case 105:
 			goto tr198
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr198:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5639,28 +5662,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof141
 		}
 	st_case_141:
-//line lex.go:5190
+//line lex.go:5213
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 105:
+			goto tr18
+		case 99:
 			goto tr199
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr199:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5673,185 +5696,185 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof142
 		}
 	st_case_142:
-//line lex.go:5224
+//line lex.go:5247
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 99:
+			goto tr18
+		case 101:
 			goto tr200
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr200:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:123
+		lex.act = 23
 		goto st143
 	st143:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof143
 		}
 	st_case_143:
-//line lex.go:5258
+//line lex.go:5281
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st144
+		case 10:
+			goto tr203
+		case 13:
+			goto st144
+		case 32:
+			goto st144
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
-			goto tr201
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr201:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:123
-		lex.act = 23
+		goto tr201
+	tr203:
+//line lex.rl:59
+		lex.line++
 		goto st144
 	st144:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof144
 		}
 	st_case_144:
-//line lex.go:5292
+//line lex.go:5318
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st145
+			goto st144
 		case 10:
-			goto tr204
+			goto tr203
 		case 13:
-			goto st145
+			goto st144
 		case 32:
-			goto st145
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st144
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr202
-	tr204:
-//line lex.rl:59
-		lex.line++
+		goto tr201
+	tr196:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:115
+		lex.act = 15
 		goto st145
 	st145:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof145
 		}
 	st_case_145:
-//line lex.go:5329
+//line lex.go:5342
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st145
+			goto st146
 		case 10:
-			goto tr204
+			goto tr206
 		case 13:
-			goto st145
+			goto st146
 		case 32:
-			goto st145
+			goto st146
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
 		}
-		goto tr202
-	tr197:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:115
-		lex.act = 15
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr204
+	tr206:
+//line lex.rl:59
+		lex.line++
 		goto st146
 	st146:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof146
 		}
 	st_case_146:
-//line lex.go:5353
+//line lex.go:5379
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st147
+			goto st146
 		case 10:
-			goto tr207
+			goto tr206
 		case 13:
-			goto st147
+			goto st146
 		case 32:
-			goto st147
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st146
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr205
-	tr207:
-//line lex.rl:59
-		lex.line++
+		goto tr204
+	tr194:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st147
 	st147:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof147
 		}
 	st_case_147:
-//line lex.go:5390
+//line lex.go:5403
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st147
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 114:
 			goto tr207
-		case 13:
-			goto st147
-		case 32:
-			goto st147
 		}
-		goto tr205
-	tr195:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr207:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -5863,28 +5886,30 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof148
 		}
 	st_case_148:
-//line lex.go:5414
+//line lex.go:5437
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 114:
+			goto tr18
+		case 105:
 			goto tr208
+		case 117:
+			goto tr209
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr208:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -5897,31 +5922,29 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof149
 		}
 	st_case_149:
-//line lex.go:5448
+//line lex.go:5473
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 105:
-			goto tr209
-		case 117:
+			goto tr18
+		case 110:
 			goto tr210
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr209:
+		goto tr46
+	tr210:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -5933,124 +5956,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof150
 		}
 	st_case_150:
-//line lex.go:5484
+//line lex.go:5507
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
+			goto tr18
+		case 103:
 			goto tr211
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr211:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:111
+		lex.act = 11
 		goto st151
 	st151:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof151
 		}
 	st_case_151:
-//line lex.go:5518
+//line lex.go:5541
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st152
+		case 10:
+			goto tr214
+		case 13:
+			goto st152
+		case 32:
+			goto st152
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 103:
-			goto tr212
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr212:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:111
-		lex.act = 11
+		goto tr212
+	tr214:
+//line lex.rl:59
+		lex.line++
 		goto st152
 	st152:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof152
 		}
 	st_case_152:
-//line lex.go:5552
+//line lex.go:5578
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st153
+			goto st152
 		case 10:
-			goto tr215
+			goto tr214
 		case 13:
-			goto st153
+			goto st152
 		case 32:
-			goto st153
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st152
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr213
-	tr215:
-//line lex.rl:59
-		lex.line++
+		goto tr212
+	tr209:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st153
 	st153:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof153
 		}
 	st_case_153:
-//line lex.go:5589
+//line lex.go:5602
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st153
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 99:
 			goto tr215
-		case 13:
-			goto st153
-		case 32:
-			goto st153
 		}
-		goto tr213
-	tr210:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr215:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -6062,124 +6085,128 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof154
 		}
 	st_case_154:
-//line lex.go:5613
+//line lex.go:5636
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 99:
+			goto tr18
+		case 116:
 			goto tr216
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr216:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:118
+		lex.act = 18
 		goto st155
 	st155:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof155
 		}
 	st_case_155:
-//line lex.go:5647
+//line lex.go:5670
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st156
+		case 10:
+			goto tr219
+		case 13:
+			goto st156
+		case 32:
+			goto st156
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 116:
-			goto tr217
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr217:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:118
-		lex.act = 18
+		goto tr217
+	tr219:
+//line lex.rl:59
+		lex.line++
 		goto st156
 	st156:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof156
 		}
 	st_case_156:
-//line lex.go:5681
+//line lex.go:5707
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st157
+			goto st156
 		case 10:
-			goto tr220
+			goto tr219
 		case 13:
-			goto st157
+			goto st156
 		case 32:
-			goto st157
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st156
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr218
-	tr220:
-//line lex.rl:59
-		lex.line++
+		goto tr217
+	tr37:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st157
 	st157:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof157
 		}
 	st_case_157:
-//line lex.go:5718
+//line lex.go:5731
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st157
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 104:
 			goto tr220
-		case 13:
-			goto st157
-		case 32:
-			goto st157
+		case 114:
+			goto tr221
+		case 121:
+			goto tr222
 		}
-		goto tr218
-	tr38:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr220:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -6191,33 +6218,29 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof158
 		}
 	st_case_158:
-//line lex.go:5742
+//line lex.go:5769
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 104:
-			goto tr221
+			goto tr18
 		case 114:
-			goto tr222
-		case 121:
 			goto tr223
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr221:
+		goto tr46
+	tr223:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -6229,28 +6252,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof159
 		}
 	st_case_159:
-//line lex.go:5780
+//line lex.go:5803
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 114:
+			goto tr18
+		case 111:
 			goto tr224
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr224:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -6263,28 +6286,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof160
 		}
 	st_case_160:
-//line lex.go:5814
+//line lex.go:5837
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 111:
+			goto tr18
+		case 119:
 			goto tr225
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr225:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -6297,124 +6320,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof161
 		}
 	st_case_161:
-//line lex.go:5848
+//line lex.go:5871
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 119:
+			goto tr18
+		case 115:
 			goto tr226
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr226:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:122
+		lex.act = 22
 		goto st162
 	st162:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof162
 		}
 	st_case_162:
-//line lex.go:5882
+//line lex.go:5905
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st163
+		case 10:
+			goto tr229
+		case 13:
+			goto st163
+		case 32:
+			goto st163
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 115:
-			goto tr227
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr227:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:122
-		lex.act = 22
+		goto tr227
+	tr229:
+//line lex.rl:59
+		lex.line++
 		goto st163
 	st163:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof163
 		}
 	st_case_163:
-//line lex.go:5916
+//line lex.go:5942
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st164
+			goto st163
 		case 10:
-			goto tr230
+			goto tr229
 		case 13:
-			goto st164
+			goto st163
 		case 32:
-			goto st164
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st163
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr228
-	tr230:
-//line lex.rl:59
-		lex.line++
+		goto tr227
+	tr221:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st164
 	st164:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof164
 		}
 	st_case_164:
-//line lex.go:5953
+//line lex.go:5966
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st164
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 117:
 			goto tr230
-		case 13:
-			goto st164
-		case 32:
-			goto st164
 		}
-		goto tr228
-	tr222:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr230:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -6426,124 +6449,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof165
 		}
 	st_case_165:
-//line lex.go:5977
+//line lex.go:6000
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 117:
+			goto tr18
+		case 101:
 			goto tr231
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr231:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:128
+		lex.act = 28
 		goto st166
 	st166:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof166
 		}
 	st_case_166:
-//line lex.go:6011
+//line lex.go:6034
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st167
+		case 10:
+			goto tr234
+		case 13:
+			goto st167
+		case 32:
+			goto st167
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
-			goto tr232
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr232:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:128
-		lex.act = 28
+		goto tr232
+	tr234:
+//line lex.rl:59
+		lex.line++
 		goto st167
 	st167:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof167
 		}
 	st_case_167:
-//line lex.go:6045
+//line lex.go:6071
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st168
+			goto st167
 		case 10:
-			goto tr235
+			goto tr234
 		case 13:
-			goto st168
+			goto st167
 		case 32:
-			goto st168
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st167
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr233
-	tr235:
-//line lex.rl:59
-		lex.line++
+		goto tr232
+	tr222:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st168
 	st168:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof168
 		}
 	st_case_168:
-//line lex.go:6082
+//line lex.go:6095
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st168
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 112:
 			goto tr235
-		case 13:
-			goto st168
-		case 32:
-			goto st168
 		}
-		goto tr233
-	tr223:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr235:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -6555,28 +6578,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof169
 		}
 	st_case_169:
-//line lex.go:6106
+//line lex.go:6129
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 112:
+			goto tr18
+		case 101:
 			goto tr236
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr236:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -6589,28 +6612,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof170
 		}
 	st_case_170:
-//line lex.go:6140
+//line lex.go:6163
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
+			goto tr18
+		case 100:
 			goto tr237
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr237:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -6623,28 +6646,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof171
 		}
 	st_case_171:
-//line lex.go:6174
+//line lex.go:6197
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 100:
+			goto tr18
+		case 101:
 			goto tr238
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr238:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -6657,124 +6680,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof172
 		}
 	st_case_172:
-//line lex.go:6208
+//line lex.go:6231
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 101:
+			goto tr18
+		case 102:
 			goto tr239
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr239:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:117
+		lex.act = 17
 		goto st173
 	st173:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof173
 		}
 	st_case_173:
-//line lex.go:6242
+//line lex.go:6265
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st174
+		case 10:
+			goto tr242
+		case 13:
+			goto st174
+		case 32:
+			goto st174
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 102:
-			goto tr240
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr240:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:117
-		lex.act = 17
+		goto tr240
+	tr242:
+//line lex.rl:59
+		lex.line++
 		goto st174
 	st174:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof174
 		}
 	st_case_174:
-//line lex.go:6276
+//line lex.go:6302
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st175
+			goto st174
 		case 10:
-			goto tr243
+			goto tr242
 		case 13:
-			goto st175
+			goto st174
 		case 32:
-			goto st175
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st174
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr241
-	tr243:
-//line lex.rl:59
-		lex.line++
+		goto tr240
+	tr38:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st175
 	st175:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof175
 		}
 	st_case_175:
-//line lex.go:6313
+//line lex.go:6326
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st175
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 110:
 			goto tr243
-		case 13:
-			goto st175
-		case 32:
-			goto st175
 		}
-		goto tr241
-	tr39:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr243:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -6786,28 +6809,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof176
 		}
 	st_case_176:
-//line lex.go:6337
+//line lex.go:6360
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
+			goto tr18
+		case 105:
 			goto tr244
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr244:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -6820,28 +6843,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof177
 		}
 	st_case_177:
-//line lex.go:6371
+//line lex.go:6394
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 105:
+			goto tr18
+		case 111:
 			goto tr245
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr245:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -6854,124 +6877,124 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof178
 		}
 	st_case_178:
-//line lex.go:6405
+//line lex.go:6428
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 111:
+			goto tr18
+		case 110:
 			goto tr246
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr246:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:119
+		lex.act = 19
 		goto st179
 	st179:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof179
 		}
 	st_case_179:
-//line lex.go:6439
+//line lex.go:6462
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st180
+		case 10:
+			goto tr249
+		case 13:
+			goto st180
+		case 32:
+			goto st180
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 110:
-			goto tr247
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr247:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:119
-		lex.act = 19
+		goto tr247
+	tr249:
+//line lex.rl:59
+		lex.line++
 		goto st180
 	st180:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof180
 		}
 	st_case_180:
-//line lex.go:6473
+//line lex.go:6499
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st181
+			goto st180
 		case 10:
-			goto tr250
+			goto tr249
 		case 13:
-			goto st181
+			goto st180
 		case 32:
-			goto st181
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st180
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr248
-	tr250:
-//line lex.rl:59
-		lex.line++
+		goto tr247
+	tr39:
+//line NONE:1
+		lex.te = (lex.p) + 1
+
+//line lex.rl:191
+		lex.act = 38
 		goto st181
 	st181:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof181
 		}
 	st_case_181:
-//line lex.go:6510
+//line lex.go:6523
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st181
-		case 10:
+		case 46:
+			goto st12
+		case 95:
+			goto tr18
+		case 111:
 			goto tr250
-		case 13:
-			goto st181
-		case 32:
-			goto st181
 		}
-		goto tr248
-	tr40:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr18
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr18
+			}
+		default:
+			goto tr18
+		}
+		goto tr46
+	tr250:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
@@ -6983,28 +7006,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof182
 		}
 	st_case_182:
-//line lex.go:6534
+//line lex.go:6557
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 111:
+			goto tr18
+		case 105:
 			goto tr251
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr251:
 //line NONE:1
 		lex.te = (lex.p) + 1
@@ -7017,126 +7040,92 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto _test_eof183
 		}
 	st_case_183:
-//line lex.go:6568
+//line lex.go:6591
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 105:
+			goto tr18
+		case 100:
 			goto tr252
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
+		goto tr46
 	tr252:
 //line NONE:1
 		lex.te = (lex.p) + 1
 
-//line lex.rl:191
-		lex.act = 38
+//line lex.rl:103
+		lex.act = 3
 		goto st184
 	st184:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof184
 		}
 	st_case_184:
-//line lex.go:6602
+//line lex.go:6625
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st185
+		case 10:
+			goto tr255
+		case 13:
+			goto st185
+		case 32:
+			goto st185
 		case 46:
-			goto st13
+			goto st12
 		case 95:
-			goto tr19
-		case 100:
-			goto tr253
+			goto tr18
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
+				goto tr18
 			}
 		case lex.data[(lex.p)] > 90:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
+				goto tr18
 			}
 		default:
-			goto tr19
+			goto tr18
 		}
-		goto tr47
-	tr253:
-//line NONE:1
-		lex.te = (lex.p) + 1
-
-//line lex.rl:103
-		lex.act = 3
+		goto tr253
+	tr255:
+//line lex.rl:59
+		lex.line++
 		goto st185
 	st185:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof185
 		}
 	st_case_185:
-//line lex.go:6636
+//line lex.go:6662
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st186
+			goto st185
 		case 10:
-			goto tr256
+			goto tr255
 		case 13:
-			goto st186
+			goto st185
 		case 32:
-			goto st186
-		case 46:
-			goto st13
-		case 95:
-			goto tr19
+			goto st185
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr19
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr19
-			}
-		default:
-			goto tr19
-		}
-		goto tr254
-	tr256:
-//line lex.rl:59
-		lex.line++
-		goto st186
-	st186:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof186
-		}
-	st_case_186:
-//line lex.go:6673
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st186
-		case 10:
-			goto tr256
-		case 13:
-			goto st186
-		case 32:
-			goto st186
-		}
-		goto tr254
+		goto tr253
 	st_out:
-	_test_eof14:
-		lex.cs = 14
+	_test_eof13:
+		lex.cs = 13
 		goto _test_eof
 	_test_eof1:
 		lex.cs = 1
@@ -7144,11 +7133,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 	_test_eof2:
 		lex.cs = 2
 		goto _test_eof
+	_test_eof14:
+		lex.cs = 14
+		goto _test_eof
 	_test_eof3:
 		lex.cs = 3
-		goto _test_eof
-	_test_eof15:
-		lex.cs = 15
 		goto _test_eof
 	_test_eof4:
 		lex.cs = 4
@@ -7156,23 +7145,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 	_test_eof5:
 		lex.cs = 5
 		goto _test_eof
-	_test_eof6:
-		lex.cs = 6
+	_test_eof15:
+		lex.cs = 15
 		goto _test_eof
 	_test_eof16:
 		lex.cs = 16
 		goto _test_eof
-	_test_eof17:
-		lex.cs = 17
+	_test_eof6:
+		lex.cs = 6
 		goto _test_eof
 	_test_eof7:
 		lex.cs = 7
 		goto _test_eof
+	_test_eof17:
+		lex.cs = 17
+		goto _test_eof
 	_test_eof8:
 		lex.cs = 8
-		goto _test_eof
-	_test_eof18:
-		lex.cs = 18
 		goto _test_eof
 	_test_eof9:
 		lex.cs = 9
@@ -7180,23 +7169,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 	_test_eof10:
 		lex.cs = 10
 		goto _test_eof
+	_test_eof18:
+		lex.cs = 18
+		goto _test_eof
 	_test_eof11:
 		lex.cs = 11
 		goto _test_eof
 	_test_eof19:
 		lex.cs = 19
 		goto _test_eof
-	_test_eof12:
-		lex.cs = 12
-		goto _test_eof
 	_test_eof20:
 		lex.cs = 20
 		goto _test_eof
+	_test_eof12:
+		lex.cs = 12
+		goto _test_eof
 	_test_eof21:
 		lex.cs = 21
-		goto _test_eof
-	_test_eof13:
-		lex.cs = 13
 		goto _test_eof
 	_test_eof22:
 		lex.cs = 22
@@ -7690,367 +7679,364 @@ func (lex *lexer) Lex(out *yySymType) int {
 	_test_eof185:
 		lex.cs = 185
 		goto _test_eof
-	_test_eof186:
-		lex.cs = 186
-		goto _test_eof
 
 	_test_eof:
 		{
 		}
 		if (lex.p) == eof {
 			switch lex.cs {
+			case 14:
+				goto tr40
 			case 15:
 				goto tr41
 			case 16:
-				goto tr42
-			case 17:
-				goto tr44
+				goto tr43
+			case 6:
+				goto tr7
 			case 7:
-				goto tr8
-			case 8:
-				goto tr8
+				goto tr7
+			case 17:
+				goto tr43
 			case 18:
-				goto tr44
+				goto tr41
+			case 11:
+				goto tr15
 			case 19:
-				goto tr42
-			case 12:
-				goto tr16
+				goto tr41
 			case 20:
-				goto tr42
+				goto tr46
+			case 12:
+				goto tr17
 			case 21:
-				goto tr47
-			case 13:
-				goto tr18
+				goto tr46
 			case 22:
-				goto tr47
+				goto tr46
 			case 23:
-				goto tr47
+				goto tr46
 			case 24:
-				goto tr47
+				goto tr46
 			case 25:
-				goto tr47
+				goto tr46
 			case 26:
-				goto tr47
+				goto tr55
 			case 27:
-				goto tr56
+				goto tr55
 			case 28:
-				goto tr56
+				goto tr46
 			case 29:
-				goto tr47
+				goto tr46
 			case 30:
-				goto tr47
+				goto tr60
 			case 31:
-				goto tr61
+				goto tr60
 			case 32:
-				goto tr61
+				goto tr46
 			case 33:
-				goto tr47
+				goto tr46
 			case 34:
-				goto tr47
+				goto tr65
 			case 35:
-				goto tr66
+				goto tr65
 			case 36:
-				goto tr66
+				goto tr46
 			case 37:
-				goto tr47
+				goto tr46
 			case 38:
-				goto tr47
+				goto tr46
 			case 39:
-				goto tr47
+				goto tr46
 			case 40:
-				goto tr47
+				goto tr72
 			case 41:
-				goto tr73
+				goto tr72
 			case 42:
-				goto tr73
+				goto tr46
 			case 43:
-				goto tr47
+				goto tr46
 			case 44:
-				goto tr47
+				goto tr46
 			case 45:
-				goto tr47
+				goto tr46
 			case 46:
-				goto tr47
+				goto tr46
 			case 47:
-				goto tr47
+				goto tr80
 			case 48:
-				goto tr81
+				goto tr80
 			case 49:
-				goto tr81
+				goto tr46
 			case 50:
-				goto tr47
+				goto tr46
 			case 51:
-				goto tr47
+				goto tr46
 			case 52:
-				goto tr47
+				goto tr87
 			case 53:
-				goto tr88
+				goto tr87
 			case 54:
-				goto tr88
+				goto tr46
 			case 55:
-				goto tr47
+				goto tr46
 			case 56:
-				goto tr47
+				goto tr46
 			case 57:
-				goto tr47
+				goto tr46
 			case 58:
-				goto tr47
+				goto tr46
 			case 59:
-				goto tr47
+				goto tr46
 			case 60:
-				goto tr47
+				goto tr46
 			case 61:
-				goto tr47
+				goto tr98
 			case 62:
-				goto tr99
+				goto tr98
 			case 63:
-				goto tr99
+				goto tr46
 			case 64:
-				goto tr47
+				goto tr46
 			case 65:
-				goto tr47
+				goto tr46
 			case 66:
-				goto tr47
+				goto tr46
 			case 67:
-				goto tr47
+				goto tr105
 			case 68:
-				goto tr106
+				goto tr105
 			case 69:
-				goto tr106
+				goto tr46
 			case 70:
-				goto tr47
+				goto tr46
 			case 71:
-				goto tr47
+				goto tr46
 			case 72:
-				goto tr47
+				goto tr46
 			case 73:
-				goto tr47
+				goto tr112
 			case 74:
-				goto tr113
+				goto tr112
 			case 75:
-				goto tr113
+				goto tr46
 			case 76:
-				goto tr47
+				goto tr46
 			case 77:
-				goto tr47
+				goto tr121
 			case 78:
-				goto tr122
+				goto tr121
 			case 79:
-				goto tr122
+				goto tr46
 			case 80:
-				goto tr47
+				goto tr125
 			case 81:
-				goto tr126
+				goto tr125
 			case 82:
-				goto tr126
+				goto tr46
 			case 83:
-				goto tr47
+				goto tr129
 			case 84:
-				goto tr130
+				goto tr129
 			case 85:
-				goto tr130
+				goto tr132
 			case 86:
-				goto tr133
+				goto tr132
 			case 87:
-				goto tr133
+				goto tr46
 			case 88:
-				goto tr47
+				goto tr46
 			case 89:
-				goto tr47
+				goto tr46
 			case 90:
-				goto tr47
+				goto tr46
 			case 91:
-				goto tr47
+				goto tr46
 			case 92:
-				goto tr47
+				goto tr140
 			case 93:
-				goto tr141
+				goto tr140
 			case 94:
-				goto tr141
+				goto tr46
 			case 95:
-				goto tr47
+				goto tr46
 			case 96:
-				goto tr47
+				goto tr46
 			case 97:
-				goto tr47
+				goto tr146
 			case 98:
-				goto tr147
+				goto tr146
 			case 99:
-				goto tr147
+				goto tr46
 			case 100:
-				goto tr47
+				goto tr46
 			case 101:
-				goto tr47
+				goto tr151
 			case 102:
-				goto tr152
+				goto tr151
 			case 103:
-				goto tr152
+				goto tr46
 			case 104:
-				goto tr47
+				goto tr46
 			case 105:
-				goto tr47
+				goto tr46
 			case 106:
-				goto tr47
+				goto tr46
 			case 107:
-				goto tr47
+				goto tr46
 			case 108:
-				goto tr47
+				goto tr46
 			case 109:
-				goto tr47
+				goto tr46
 			case 110:
-				goto tr47
+				goto tr46
 			case 111:
-				goto tr47
+				goto tr162
 			case 112:
-				goto tr163
+				goto tr162
 			case 113:
-				goto tr163
+				goto tr46
 			case 114:
-				goto tr47
+				goto tr46
 			case 115:
-				goto tr47
+				goto tr46
 			case 116:
-				goto tr47
+				goto tr46
 			case 117:
-				goto tr47
+				goto tr46
 			case 118:
-				goto tr47
+				goto tr171
 			case 119:
-				goto tr172
+				goto tr171
 			case 120:
-				goto tr172
+				goto tr46
 			case 121:
-				goto tr47
+				goto tr46
 			case 122:
-				goto tr47
+				goto tr46
 			case 123:
-				goto tr47
+				goto tr46
 			case 124:
-				goto tr47
+				goto tr46
 			case 125:
-				goto tr47
+				goto tr46
 			case 126:
-				goto tr47
+				goto tr180
 			case 127:
-				goto tr181
+				goto tr180
 			case 128:
-				goto tr181
+				goto tr46
 			case 129:
-				goto tr47
+				goto tr46
 			case 130:
-				goto tr47
+				goto tr46
 			case 131:
-				goto tr47
+				goto tr46
 			case 132:
-				goto tr47
+				goto tr46
 			case 133:
-				goto tr47
+				goto tr46
 			case 134:
-				goto tr47
+				goto tr46
 			case 135:
-				goto tr47
+				goto tr190
 			case 136:
-				goto tr191
+				goto tr190
 			case 137:
-				goto tr191
+				goto tr46
 			case 138:
-				goto tr47
+				goto tr46
 			case 139:
-				goto tr47
+				goto tr46
 			case 140:
-				goto tr47
+				goto tr46
 			case 141:
-				goto tr47
+				goto tr46
 			case 142:
-				goto tr47
+				goto tr46
 			case 143:
-				goto tr47
+				goto tr201
 			case 144:
-				goto tr202
+				goto tr201
 			case 145:
-				goto tr202
+				goto tr204
 			case 146:
-				goto tr205
+				goto tr204
 			case 147:
-				goto tr205
+				goto tr46
 			case 148:
-				goto tr47
+				goto tr46
 			case 149:
-				goto tr47
+				goto tr46
 			case 150:
-				goto tr47
+				goto tr46
 			case 151:
-				goto tr47
+				goto tr212
 			case 152:
-				goto tr213
+				goto tr212
 			case 153:
-				goto tr213
+				goto tr46
 			case 154:
-				goto tr47
+				goto tr46
 			case 155:
-				goto tr47
+				goto tr217
 			case 156:
-				goto tr218
+				goto tr217
 			case 157:
-				goto tr218
+				goto tr46
 			case 158:
-				goto tr47
+				goto tr46
 			case 159:
-				goto tr47
+				goto tr46
 			case 160:
-				goto tr47
+				goto tr46
 			case 161:
-				goto tr47
+				goto tr46
 			case 162:
-				goto tr47
+				goto tr227
 			case 163:
-				goto tr228
+				goto tr227
 			case 164:
-				goto tr228
+				goto tr46
 			case 165:
-				goto tr47
+				goto tr46
 			case 166:
-				goto tr47
+				goto tr232
 			case 167:
-				goto tr233
+				goto tr232
 			case 168:
-				goto tr233
+				goto tr46
 			case 169:
-				goto tr47
+				goto tr46
 			case 170:
-				goto tr47
+				goto tr46
 			case 171:
-				goto tr47
+				goto tr46
 			case 172:
-				goto tr47
+				goto tr46
 			case 173:
-				goto tr47
+				goto tr240
 			case 174:
-				goto tr241
+				goto tr240
 			case 175:
-				goto tr241
+				goto tr46
 			case 176:
-				goto tr47
+				goto tr46
 			case 177:
-				goto tr47
+				goto tr46
 			case 178:
-				goto tr47
+				goto tr46
 			case 179:
-				goto tr47
+				goto tr247
 			case 180:
-				goto tr248
+				goto tr247
 			case 181:
-				goto tr248
+				goto tr46
 			case 182:
-				goto tr47
+				goto tr46
 			case 183:
-				goto tr47
+				goto tr46
 			case 184:
-				goto tr47
+				goto tr253
 			case 185:
-				goto tr254
-			case 186:
-				goto tr254
+				goto tr253
 			}
 		}
 

--- a/idl/internal/lex.rl
+++ b/idl/internal/lex.rl
@@ -61,7 +61,7 @@ func (lex *lexer) Lex(out *yySymType) int {
         __ = (ws | newline)*;
 
         # Comments
-        line_comment = ('#'|'//') [^\n]+;
+        line_comment = ('#'|'//') [^\n]*;
         multiline_comment = '/*' (newline | any)* :>> '*/';
 
         # Symbols are sent to the parser as-is.

--- a/idl/parser_test.go
+++ b/idl/parser_test.go
@@ -58,6 +58,12 @@ func TestParseEmpty(t *testing.T) {
 	}
 }
 
+func TestParseComments(t *testing.T) {
+	s := "// foo\n//\n//bar"
+	_, err := Parse([]byte(s))
+	assert.NoError(t, err, "Failed to parse:\n%s", s)
+}
+
 func TestParseErrors(t *testing.T) {
 	tests := []string{
 		"namespace foo \x00",


### PR DESCRIPTION
This would fail for, "//\n", for example.
