### PR TITLE
Fill type codes in generated code.

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -56,16 +56,17 @@ func NewGenerator() *Generator {
 // TextTemplate renders the given template with the given template context.
 func (g *Generator) TextTemplate(s string, data interface{}) (string, error) {
 	templateFuncs := template.FuncMap{
-		"goCase":   goCase,
-		"import":   g.Import,
-		"defName":  typeDeclName,
-		"newVar":   g.namespace.Child().NewName,
-		"toWire":   g.toWire,
-		"fromWire": g.fromWire,
-
+		"goCase":        goCase,
+		"import":        g.Import,
+		"defName":       typeDeclName,
+		"newVar":        g.namespace.Child().NewName,
+		"toWire":        g.toWire,
+		"fromWire":      g.fromWire,
+		"typeCode":      g.typeCode,
 		"typeReference": typeReference,
-		"Required":      func() fieldRequired { return Required },
-		"Optional":      func() fieldRequired { return Optional },
+
+		"Required": func() fieldRequired { return Required },
+		"Optional": func() fieldRequired { return Optional },
 		"required": func(b bool) fieldRequired {
 			if b {
 				return Required
@@ -191,6 +192,9 @@ func (g *Generator) recordGenDeclNames(d *ast.GenDecl) error {
 // if the value was optional.
 //
 // 	<typeReference $someType Required>
+//
+// typeCode(TypeSpec): Gets the wire.Type for the given TypeSpec, importing
+// the wire module if necessary.
 func (g *Generator) DeclareFromTemplate(s string, data interface{}) error {
 	bs, err := g.renderTemplate(s, data)
 	if err != nil {

--- a/gen/struct.go
+++ b/gen/struct.go
@@ -57,7 +57,7 @@ func (g *Generator) structure(spec *compile.StructSpec) error {
 				switch <$f>.ID {
 				<range .Fields>
 				case <.ID>:
-					if <$f>.Value.Type() == nil { // TODO
+					if <$f>.Value.Type() == <typeCode .Type> {
 						<$t := printf "%s.%s" $v (goCase .Name)>
 						<fromWire .Type $t (printf "%s.Value" $f)>
 						// TODO read errors


### PR DESCRIPTION
We now have `wire.TBool/TI8/whatever` checks in appropriate places.

For example, when parsing fields, the generated code now looks like this:

```
for _, f := range w.GetStruct().Fields {
    switch f.ID {
    case 6:
        if f.Value.Type() == wire.TList {
            v.Annotations = f.Value.GetMap().TODO()
        }
    case 9:
        if f.Value.Type() == wire.TBool {
            v.Debug = f.Value.GetBool()
        }
```

(If the type code and the field ID don't match, then the field is ignored and the remote is assumed to have an outdated/incompatible Thrift file.)
