### PR TITLE
Implement FromWire for container types.

### DIFF
--- a/gen/container.go
+++ b/gen/container.go
@@ -80,6 +80,55 @@ func (g *Generator) listValueList(spec *compile.ListSpec) (string, error) {
 	return name, nil
 }
 
+func (g *Generator) listReader(spec *compile.ListSpec) (string, error) {
+	name := "_" + valueName(spec) + "_Read"
+	if _, ok := g.listReaders[name]; ok {
+		return name, nil
+	}
+
+	err := g.DeclareFromTemplate(
+		`
+			<$wire := import "github.com/uber/thriftrw-go/wire">
+			<$listType := typeReference .Spec Required>
+
+			<$l := newVar "l">
+			<$i := newVar "i">
+			<$o := newVar "o">
+			<$x := newVar "x">
+			func <.Name>(<$l> <$wire>.List) <$listType> {
+				if <$l>.ValueType != <typeCode .Spec.ValueSpec> {
+					return nil
+				}
+
+				<$o> := make(<$listType>, 0, <$l>.Size)
+				<$l>.Items.ForEach(func(<$x> <$wire>.Value) error {
+					var <$i> <typeReference .Spec.ValueSpec Required>
+					<fromWire .Spec.ValueSpec $i $x>
+					// TODO error handling
+					<$o> = append(<$o>, <$i>)
+					return nil
+				})
+				<$l>.Items.Close()
+				return <$o>
+			}
+		`,
+		struct {
+			Name string
+			Spec *compile.ListSpec
+		}{Name: name, Spec: spec},
+	)
+
+	if err != nil {
+		return "", generateError{
+			Name:   typeReference(spec, Required),
+			Reason: err,
+		}
+	}
+
+	g.listReaders[name] = struct{}{}
+	return name, nil
+}
+
 // setValueList generates a new ValueList type alias for the given set.
 //
 // The following is generated:
@@ -132,6 +181,55 @@ func (g *Generator) setValueList(spec *compile.SetSpec) (string, error) {
 	}
 
 	g.setValueLists[name] = struct{}{}
+	return name, nil
+}
+
+func (g *Generator) setReader(spec *compile.SetSpec) (string, error) {
+	name := "_" + valueName(spec) + "_Read"
+	if _, ok := g.setReaders[name]; ok {
+		return name, nil
+	}
+
+	err := g.DeclareFromTemplate(
+		`
+			<$wire := import "github.com/uber/thriftrw-go/wire">
+			<$setType := typeReference .Spec Required>
+
+			<$s := newVar "s">
+			<$i := newVar "i">
+			<$o := newVar "o">
+			<$x := newVar "x">
+			func <.Name>(<$s> <$wire>.Set) <$setType> {
+				if <$s>.ValueType != <typeCode .Spec.ValueSpec> {
+					return nil
+				}
+
+				<$o> := make(<$setType>, <$s>.Size)
+				<$s>.Items.ForEach(func(<$x> <$wire>.Value) error {
+					var <$i> <typeReference .Spec.ValueSpec Required>
+					<fromWire .Spec.ValueSpec $i $x>
+					// TODO error handling
+					<$o>[<$i>] = struct{}{}
+					return nil
+				})
+				<$s>.Items.Close()
+				return <$o>
+			}
+		`,
+		struct {
+			Name string
+			Spec *compile.SetSpec
+		}{Name: name, Spec: spec},
+	)
+
+	if err != nil {
+		return "", generateError{
+			Name:   typeReference(spec, Required),
+			Reason: err,
+		}
+	}
+
+	g.setReaders[name] = struct{}{}
 	return name, nil
 }
 
@@ -191,6 +289,62 @@ func (g *Generator) mapItemList(spec *compile.MapSpec) (string, error) {
 	}
 
 	g.mapItemLists[name] = struct{}{}
+	return name, nil
+}
+
+func (g *Generator) mapReader(spec *compile.MapSpec) (string, error) {
+	name := "_" + valueName(spec) + "_Read"
+	if _, ok := g.mapReaders[name]; ok {
+		return name, nil
+	}
+
+	err := g.DeclareFromTemplate(
+		`
+			<$wire := import "github.com/uber/thriftrw-go/wire">
+			<$mapType := typeReference .Spec Required>
+
+			<$m := newVar "m">
+			<$o := newVar "o">
+			<$x := newVar "x">
+			<$k := newVar "k">
+			<$v := newVar "v">
+			func <.Name>(<$m> <$wire>.Map) <$mapType> {
+				if <$m>.KeyType != <typeCode .Spec.KeySpec> {
+					return nil
+				}
+
+				if <$m>.ValueType != <typeCode .Spec.ValueSpec> {
+					return nil
+				}
+
+				<$o> := make(<$mapType>, <$m>.Size)
+				<$m>.Items.ForEach(func(<$x> <$wire>.MapItem) error {
+					var <$k> <typeReference .Spec.KeySpec Required>
+					var <$v> <typeReference .Spec.ValueSpec Required>
+					<fromWire .Spec.KeySpec $k (printf "%s.Key" $x)>
+					<fromWire .Spec.ValueSpec $v (printf "%s.Value" $x)>
+					// TODO error handling
+					<$o>[<$k>] = <$v>
+					return nil
+				})
+				<$m>.Items.Close()
+				return <$o>
+			}
+		`,
+		struct {
+			Name string
+			Spec *compile.MapSpec
+		}{Name: name, Spec: spec},
+	)
+
+	if err != nil {
+		return "", generateError{
+			Name:   typeReference(spec, Required),
+			Reason: err,
+		}
+	}
+
+	g.mapReaders[name] = struct{}{}
 	return name, nil
 }
 

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -42,6 +42,10 @@ type Generator struct {
 	setValueLists  map[string]struct{}
 	mapItemLists   map[string]struct{}
 
+	listReaders map[string]struct{}
+	setReaders  map[string]struct{}
+	mapReaders  map[string]struct{}
+
 	// TODO use something to group related decls together
 }
 
@@ -52,8 +56,11 @@ func NewGenerator() *Generator {
 		namespace:      namespace,
 		importer:       newImporter(namespace),
 		listValueLists: make(map[string]struct{}),
+		listReaders:    make(map[string]struct{}),
 		setValueLists:  make(map[string]struct{}),
+		setReaders:     make(map[string]struct{}),
 		mapItemLists:   make(map[string]struct{}),
+		mapReaders:     make(map[string]struct{}),
 	}
 }
 


### PR DESCRIPTION
Depends on #46.

For a container `[]$foo`, approximately the following is generated:

```
func _List_$foo_Read(l wire.List) []$foo {
    o := make([]string, 0, l.Size)
    l.Items.ForEach(func(x wire.Value) error {
        var i $foo
        $i = $fromWire($foo)
        o = append(o, i)
        return nil
    })
    l.Items.Close()
    return o
}
```

For example, for a `[]string`

```
func _List_String_Read(l wire.List) []string {
    if l.ValueType != wire.TBinary {
        return nil
    }
    o := make([]string, 0, l.Size)
    l.Items.ForEach(func(x wire.Value) error {
        var i string
        i = x.GetString()
        o = append(o, i)
        return nil
    })
    l.Items.Close()
    return o
}
```

Note that we didn't do `i := x.GetString()`. That's because if `i` is a custom
type, we'll have to do `i.FromWire(x)` rather than `i := something`.

Similar functions are generated for sets and maps.
