### PR TITLE
Retry submission to coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
 
 script:
     - make test_ci
+    - travis_retry goveralls -coverprofile=cover.out -service=travis-ci
     - rm -rf vendor/*

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,3 @@ build_ci: build
 .PHONY: test_ci
 test_ci: build_ci
 	./scripts/cover.sh $(shell go list $(PACKAGES))
-	goveralls -coverprofile=cover.out -service=travis-ci


### PR DESCRIPTION
Something causes coveralls to randomly fail with

    Bad response status from coveralls: 422 - {"message":"Couldn't find a repository matching this job.","error":true}

`travis_retry` will retry the command three times if it exits with non-zero
exit codes.