### PR TITLE
Code generation cleanup

### DIFF
--- a/gen/constant.go
+++ b/gen/constant.go
@@ -26,7 +26,7 @@ import "github.com/thriftrw/thriftrw-go/compile"
 func Constant(g Generator, c *compile.Constant) error {
 	err := g.DeclareFromTemplate(
 		`
-		const <goCase .Name> <typeReference .Type Required> = nil // TODO
+		const <goCase .Name> <typeReference .Type> = nil // TODO
 		`,
 		c,
 	)

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -28,7 +28,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		`
 		<$wire := import "github.com/thriftrw/thriftrw-go/wire">
 
-		<$enumName := defName .Spec>
+		<$enumName := typeName .Spec>
 		type <$enumName> int32
 
 		const (

--- a/gen/list.go
+++ b/gen/list.go
@@ -60,7 +60,7 @@ func (l listGenerator) ValueList(g Generator, spec *compile.ListSpec) (string, e
 	err := g.DeclareFromTemplate(
 		`
 			<$wire := import "github.com/thriftrw/thriftrw-go/wire">
-			type <.Name> <typeReference .Spec Required>
+			type <.Name> <typeReference .Spec>
 
 			<$v := newVar "v">
 			<$x := newVar "x">
@@ -84,7 +84,7 @@ func (l listGenerator) ValueList(g Generator, spec *compile.ListSpec) (string, e
 	)
 	if err != nil {
 		return "", generateError{
-			Name:   typeReference(spec, Required),
+			Name:   typeReference(spec),
 			Reason: err,
 		}
 	}
@@ -110,7 +110,7 @@ func (l listGenerator) Reader(g Generator, spec *compile.ListSpec) (string, erro
 	err := g.DeclareFromTemplate(
 		`
 			<$wire := import "github.com/thriftrw/thriftrw-go/wire">
-			<$listType := typeReference .Spec Required>
+			<$listType := typeReference .Spec>
 
 			<$l := newVar "l">
 			<$i := newVar "i">
@@ -142,7 +142,7 @@ func (l listGenerator) Reader(g Generator, spec *compile.ListSpec) (string, erro
 
 	if err != nil {
 		return "", generateError{
-			Name:   typeReference(spec, Required),
+			Name:   typeReference(spec),
 			Reason: err,
 		}
 	}

--- a/gen/literal.go
+++ b/gen/literal.go
@@ -21,15 +21,10 @@
 package gen
 
 import (
-	"fmt"
 	"go/ast"
 	"go/token"
 	"strconv"
 )
-
-func intLiteral(i int64) *ast.BasicLit {
-	return &ast.BasicLit{Kind: token.INT, Value: fmt.Sprint(i)}
-}
 
 func stringLiteral(s string) *ast.BasicLit {
 	return &ast.BasicLit{

--- a/gen/map.go
+++ b/gen/map.go
@@ -65,7 +65,7 @@ func (m mapGenerator) ItemList(g Generator, spec *compile.MapSpec) (string, erro
 	err := g.DeclareFromTemplate(
 		`
 			<$wire := import "github.com/thriftrw/thriftrw-go/wire">
-			type <.Name> <typeReference .Spec Required>
+			type <.Name> <typeReference .Spec>
 
 			<$m := newVar "m">
 			<$f := newVar "f">
@@ -93,7 +93,7 @@ func (m mapGenerator) ItemList(g Generator, spec *compile.MapSpec) (string, erro
 	)
 	if err != nil {
 		return "", generateError{
-			Name:   typeReference(spec, Required),
+			Name:   typeReference(spec),
 			Reason: err,
 		}
 	}
@@ -111,7 +111,7 @@ func (m mapGenerator) Reader(g Generator, spec *compile.MapSpec) (string, error)
 	err := g.DeclareFromTemplate(
 		`
 			<$wire := import "github.com/thriftrw/thriftrw-go/wire">
-			<$mapType := typeReference .Spec Required>
+			<$mapType := typeReference .Spec>
 
 			<$m := newVar "m">
 			<$o := newVar "o">
@@ -154,7 +154,7 @@ func (m mapGenerator) Reader(g Generator, spec *compile.MapSpec) (string, error)
 
 	if err != nil {
 		return "", generateError{
-			Name:   typeReference(spec, Required),
+			Name:   typeReference(spec),
 			Reason: err,
 		}
 	}

--- a/gen/set.go
+++ b/gen/set.go
@@ -61,7 +61,7 @@ func (s setGenerator) ValueList(g Generator, spec *compile.SetSpec) (string, err
 	err := g.DeclareFromTemplate(
 		`
 			<$wire := import "github.com/thriftrw/thriftrw-go/wire">
-			type <.Name> <typeReference .Spec Required>
+			type <.Name> <typeReference .Spec>
 
 			<$v := newVar "v">
 			<$x := newVar "x">
@@ -85,7 +85,7 @@ func (s setGenerator) ValueList(g Generator, spec *compile.SetSpec) (string, err
 	)
 	if err != nil {
 		return "", generateError{
-			Name:   typeReference(spec, Required),
+			Name:   typeReference(spec),
 			Reason: err,
 		}
 	}
@@ -103,7 +103,7 @@ func (s setGenerator) Reader(g Generator, spec *compile.SetSpec) (string, error)
 	err := g.DeclareFromTemplate(
 		`
 			<$wire := import "github.com/thriftrw/thriftrw-go/wire">
-			<$setType := typeReference .Spec Required>
+			<$setType := typeReference .Spec>
 
 			<$s := newVar "s">
 			<$i := newVar "i">
@@ -135,7 +135,7 @@ func (s setGenerator) Reader(g Generator, spec *compile.SetSpec) (string, error)
 
 	if err != nil {
 		return "", generateError{
-			Name:   typeReference(spec, Required),
+			Name:   typeReference(spec),
 			Reason: err,
 		}
 	}

--- a/gen/struct.go
+++ b/gen/struct.go
@@ -113,9 +113,13 @@ func structure(g Generator, spec *compile.StructSpec) error {
 			<range .Spec.Fields>
 				<$f := printf "%s.%s" $v (goCase .Name)>
 
-				<if and (not .Required) (isPrimitiveType .Type)>
+				<if not .Required>
 					if <$f> != nil {
-						<$fields>[<$i>] = <$fmt>.Sprintf("<goCase .Name>: %v", *(<$f>))
+						<if isPrimitiveType .Type>
+							<$fields>[<$i>] = <$fmt>.Sprintf("<goCase .Name>: %v", *(<$f>))
+						<else>
+							<$fields>[<$i>] = <$fmt>.Sprintf("<goCase .Name>: %v", <$f>)
+						<end>
 						<$i>++
 					}
 				<else>

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -302,7 +302,7 @@ func TestNestedStructsOptional(t *testing.T) {
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{ID: 1, Value: wire.NewValueString("Foo Bar")},
 			}}),
-			"User{Contact: <nil>, Name: Foo Bar}",
+			"User{Name: Foo Bar}",
 		},
 		{
 			testdata.User{
@@ -405,18 +405,21 @@ func TestUnionSimple(t *testing.T) {
 	tests := []struct {
 		s testdata.Document
 		v wire.Value
+		o string
 	}{
 		{
 			testdata.Document{Pdf: []byte{1, 2, 3}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{ID: 1, Value: wire.NewValueBinary([]byte{1, 2, 3})},
 			}}),
+			"Document{Pdf: [1 2 3]}",
 		},
 		{
 			testdata.Document{PlainText: stringp("hello")},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{ID: 2, Value: wire.NewValueString("hello")},
 			}}),
+			"Document{PlainText: hello}",
 		},
 	}
 
@@ -431,6 +434,8 @@ func TestUnionSimple(t *testing.T) {
 		if assert.NoError(t, s.FromWire(tt.v)) {
 			assert.Equal(t, tt.s, s)
 		}
+
+		assert.Equal(t, tt.o, tt.s.String())
 	}
 }
 
@@ -438,24 +443,28 @@ func TestUnionComplex(t *testing.T) {
 	tests := []struct {
 		s testdata.ArbitraryValue
 		v wire.Value
+		o string
 	}{
 		{
 			testdata.ArbitraryValue{BoolValue: boolp(true)},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{ID: 1, Value: wire.NewValueBool(true)},
 			}}),
+			"ArbitraryValue{BoolValue: true}",
 		},
 		{
 			testdata.ArbitraryValue{Int64Value: int64p(42)},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{ID: 2, Value: wire.NewValueI64(42)},
 			}}),
+			"ArbitraryValue{Int64Value: 42}",
 		},
 		{
 			testdata.ArbitraryValue{StringValue: stringp("hello")},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{ID: 3, Value: wire.NewValueString("hello")},
 			}}),
+			"ArbitraryValue{StringValue: hello}",
 		},
 		{
 			testdata.ArbitraryValue{ListValue: []*testdata.ArbitraryValue{
@@ -480,6 +489,7 @@ func TestUnionComplex(t *testing.T) {
 					}),
 				})},
 			}}),
+			"ArbitraryValue{ListValue: [ArbitraryValue{BoolValue: true} ArbitraryValue{Int64Value: 42} ArbitraryValue{StringValue: hello}]}",
 		},
 		{
 			testdata.ArbitraryValue{MapValue: map[string]*testdata.ArbitraryValue{
@@ -514,6 +524,7 @@ func TestUnionComplex(t *testing.T) {
 					}),
 				})},
 			}}),
+			"",
 		},
 	}
 
@@ -527,6 +538,10 @@ func TestUnionComplex(t *testing.T) {
 		var s testdata.ArbitraryValue
 		if assert.NoError(t, s.FromWire(tt.v)) {
 			assert.Equal(t, tt.s, s)
+		}
+
+		if tt.o != "" {
+			assert.Equal(t, tt.o, tt.s.String())
 		}
 	}
 }

--- a/gen/testdata/test.thrift.go
+++ b/gen/testdata/test.thrift.go
@@ -114,7 +114,8 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 		switch f.ID {
 		case 1:
 			if f.Value.Type() == wire.TBool {
-				x, err := f.Value.GetBool(), error(nil)
+				var x bool
+				x, err = f.Value.GetBool(), error(nil)
 				v.BoolValue = &x
 				if err != nil {
 					return err
@@ -122,8 +123,9 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if f.Value.Type() == wire.TI64 {
-				x2, err := f.Value.GetI64(), error(nil)
-				v.Int64Value = &x2
+				var x int64
+				x, err = f.Value.GetI64(), error(nil)
+				v.Int64Value = &x
 				if err != nil {
 					return err
 				}
@@ -144,8 +146,9 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 			}
 		case 3:
 			if f.Value.Type() == wire.TBinary {
-				x3, err := f.Value.GetString(), error(nil)
-				v.StringValue = &x3
+				var x string
+				x, err = f.Value.GetString(), error(nil)
+				v.StringValue = &x
 				if err != nil {
 					return err
 				}
@@ -249,7 +252,8 @@ func (v *Document) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if f.Value.Type() == wire.TBinary {
-				x, err := f.Value.GetString(), error(nil)
+				var x string
+				x, err = f.Value.GetString(), error(nil)
 				v.PlainText = &x
 				if err != nil {
 					return err
@@ -645,7 +649,8 @@ func (v *Event) FromWire(w wire.Value) error {
 		switch f.ID {
 		case 2:
 			if f.Value.Type() == wire.TI64 {
-				x, err := _Timestamp_Read(f.Value)
+				var x Timestamp
+				x, err = _Timestamp_Read(f.Value)
 				v.Time = &x
 				if err != nil {
 					return err
@@ -1438,7 +1443,8 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 			}
 		case 1:
 			if f.Value.Type() == wire.TBool {
-				x, err := f.Value.GetBool(), error(nil)
+				var x bool
+				x, err = f.Value.GetBool(), error(nil)
 				v.BoolField = &x
 				if err != nil {
 					return err
@@ -1446,48 +1452,54 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if f.Value.Type() == wire.TI8 {
-				x2, err := f.Value.GetI8(), error(nil)
-				v.ByteField = &x2
+				var x int8
+				x, err = f.Value.GetI8(), error(nil)
+				v.ByteField = &x
 				if err != nil {
 					return err
 				}
 			}
 		case 6:
 			if f.Value.Type() == wire.TDouble {
-				x3, err := f.Value.GetDouble(), error(nil)
-				v.DoubleField = &x3
+				var x float64
+				x, err = f.Value.GetDouble(), error(nil)
+				v.DoubleField = &x
 				if err != nil {
 					return err
 				}
 			}
 		case 3:
 			if f.Value.Type() == wire.TI16 {
-				x4, err := f.Value.GetI16(), error(nil)
-				v.Int16Field = &x4
+				var x int16
+				x, err = f.Value.GetI16(), error(nil)
+				v.Int16Field = &x
 				if err != nil {
 					return err
 				}
 			}
 		case 4:
 			if f.Value.Type() == wire.TI32 {
-				x5, err := f.Value.GetI32(), error(nil)
-				v.Int32Field = &x5
+				var x int32
+				x, err = f.Value.GetI32(), error(nil)
+				v.Int32Field = &x
 				if err != nil {
 					return err
 				}
 			}
 		case 5:
 			if f.Value.Type() == wire.TI64 {
-				x6, err := f.Value.GetI64(), error(nil)
-				v.Int64Field = &x6
+				var x int64
+				x, err = f.Value.GetI64(), error(nil)
+				v.Int64Field = &x
 				if err != nil {
 					return err
 				}
 			}
 		case 7:
 			if f.Value.Type() == wire.TBinary {
-				x7, err := f.Value.GetString(), error(nil)
-				v.StringField = &x7
+				var x string
+				x, err = f.Value.GetString(), error(nil)
+				v.StringField = &x
 				if err != nil {
 					return err
 				}

--- a/gen/testdata/test.thrift.go
+++ b/gen/testdata/test.thrift.go
@@ -173,10 +173,14 @@ func (v *ArbitraryValue) String() string {
 		fs[i] = fmt.Sprintf("Int64Value: %v", *(v.Int64Value))
 		i++
 	}
-	fs[i] = fmt.Sprintf("ListValue: %v", v.ListValue)
-	i++
-	fs[i] = fmt.Sprintf("MapValue: %v", v.MapValue)
-	i++
+	if v.ListValue != nil {
+		fs[i] = fmt.Sprintf("ListValue: %v", v.ListValue)
+		i++
+	}
+	if v.MapValue != nil {
+		fs[i] = fmt.Sprintf("MapValue: %v", v.MapValue)
+		i++
+	}
 	if v.StringValue != nil {
 		fs[i] = fmt.Sprintf("StringValue: %v", *(v.StringValue))
 		i++
@@ -271,8 +275,10 @@ func _Document_Read(w wire.Value) (*Document, error) {
 func (v *Document) String() string {
 	var fs [2]string
 	i := 0
-	fs[i] = fmt.Sprintf("Pdf: %v", v.Pdf)
-	i++
+	if v.Pdf != nil {
+		fs[i] = fmt.Sprintf("Pdf: %v", v.Pdf)
+		i++
+	}
 	if v.PlainText != nil {
 		fs[i] = fmt.Sprintf("PlainText: %v", *(v.PlainText))
 		i++
@@ -528,12 +534,18 @@ func _EnumContainers_Read(w wire.Value) (*EnumContainers, error) {
 func (v *EnumContainers) String() string {
 	var fs [3]string
 	i := 0
-	fs[i] = fmt.Sprintf("ListOfEnums: %v", v.ListOfEnums)
-	i++
-	fs[i] = fmt.Sprintf("MapOfEnums: %v", v.MapOfEnums)
-	i++
-	fs[i] = fmt.Sprintf("SetOfEnums: %v", v.SetOfEnums)
-	i++
+	if v.ListOfEnums != nil {
+		fs[i] = fmt.Sprintf("ListOfEnums: %v", v.ListOfEnums)
+		i++
+	}
+	if v.MapOfEnums != nil {
+		fs[i] = fmt.Sprintf("MapOfEnums: %v", v.MapOfEnums)
+		i++
+	}
+	if v.SetOfEnums != nil {
+		fs[i] = fmt.Sprintf("SetOfEnums: %v", v.SetOfEnums)
+		i++
+	}
 	return fmt.Sprintf("EnumContainers{%v}", strings.Join(fs[:i], ", "))
 }
 
@@ -1207,18 +1219,30 @@ func _PrimitiveContainers_Read(w wire.Value) (*PrimitiveContainers, error) {
 func (v *PrimitiveContainers) String() string {
 	var fs [6]string
 	i := 0
-	fs[i] = fmt.Sprintf("ListOfBinary: %v", v.ListOfBinary)
-	i++
-	fs[i] = fmt.Sprintf("ListOfInts: %v", v.ListOfInts)
-	i++
-	fs[i] = fmt.Sprintf("MapOfIntToString: %v", v.MapOfIntToString)
-	i++
-	fs[i] = fmt.Sprintf("MapOfStringToBool: %v", v.MapOfStringToBool)
-	i++
-	fs[i] = fmt.Sprintf("SetOfBytes: %v", v.SetOfBytes)
-	i++
-	fs[i] = fmt.Sprintf("SetOfStrings: %v", v.SetOfStrings)
-	i++
+	if v.ListOfBinary != nil {
+		fs[i] = fmt.Sprintf("ListOfBinary: %v", v.ListOfBinary)
+		i++
+	}
+	if v.ListOfInts != nil {
+		fs[i] = fmt.Sprintf("ListOfInts: %v", v.ListOfInts)
+		i++
+	}
+	if v.MapOfIntToString != nil {
+		fs[i] = fmt.Sprintf("MapOfIntToString: %v", v.MapOfIntToString)
+		i++
+	}
+	if v.MapOfStringToBool != nil {
+		fs[i] = fmt.Sprintf("MapOfStringToBool: %v", v.MapOfStringToBool)
+		i++
+	}
+	if v.SetOfBytes != nil {
+		fs[i] = fmt.Sprintf("SetOfBytes: %v", v.SetOfBytes)
+		i++
+	}
+	if v.SetOfStrings != nil {
+		fs[i] = fmt.Sprintf("SetOfStrings: %v", v.SetOfStrings)
+		i++
+	}
 	return fmt.Sprintf("PrimitiveContainers{%v}", strings.Join(fs[:i], ", "))
 }
 
@@ -1516,8 +1540,10 @@ func _PrimitiveOptionalStruct_Read(w wire.Value) (*PrimitiveOptionalStruct, erro
 func (v *PrimitiveOptionalStruct) String() string {
 	var fs [8]string
 	i := 0
-	fs[i] = fmt.Sprintf("BinaryField: %v", v.BinaryField)
-	i++
+	if v.BinaryField != nil {
+		fs[i] = fmt.Sprintf("BinaryField: %v", v.BinaryField)
+		i++
+	}
 	if v.BoolField != nil {
 		fs[i] = fmt.Sprintf("BoolField: %v", *(v.BoolField))
 		i++
@@ -1813,8 +1839,10 @@ func _Transition_Read(w wire.Value) (*Transition, error) {
 func (v *Transition) String() string {
 	var fs [3]string
 	i := 0
-	fs[i] = fmt.Sprintf("Events: %v", v.Events)
-	i++
+	if v.Events != nil {
+		fs[i] = fmt.Sprintf("Events: %v", v.Events)
+		i++
+	}
 	fs[i] = fmt.Sprintf("From: %v", v.From)
 	i++
 	fs[i] = fmt.Sprintf("To: %v", v.To)
@@ -1882,8 +1910,10 @@ func _User_Read(w wire.Value) (*User, error) {
 func (v *User) String() string {
 	var fs [2]string
 	i := 0
-	fs[i] = fmt.Sprintf("Contact: %v", v.Contact)
-	i++
+	if v.Contact != nil {
+		fs[i] = fmt.Sprintf("Contact: %v", v.Contact)
+		i++
+	}
 	fs[i] = fmt.Sprintf("Name: %v", v.Name)
 	i++
 	return fmt.Sprintf("User{%v}", strings.Join(fs[:i], ", "))

--- a/gen/typedef.go
+++ b/gen/typedef.go
@@ -27,21 +27,21 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 	err := g.DeclareFromTemplate(
 		`
 		<$wire := import "github.com/thriftrw/thriftrw-go/wire">
-		<$typedefType := typeReference .Spec Required>
+		<$typedefType := typeReference .Spec>
 
-		type <defName .Spec> <typeName .Spec.Target>
+		type <typeName .Spec> <typeName .Spec.Target>
 
 		<$v := newVar "v">
 		<$x := newVar "x">
 		func (<$v> <$typedefType>) ToWire() <$wire>.Value {
-			<$x> := (<typeReference .Spec.Target Required>)(<$v>)
+			<$x> := (<typeReference .Spec.Target>)(<$v>)
 			return <toWire .Spec.Target $x>
 		}
 
 		<$w := newVar "w">
 		<if isStructType .Spec>
 			func (<$v> <$typedefType>) FromWire(<$w> <$wire>.Value) error {
-				return (<typeReference .Spec.Target Required>)(<$v>).FromWire(<$w>)
+				return (<typeReference .Spec.Target>)(<$v>).FromWire(<$w>)
 			}
 		<else>
 			func (<$v> *<$typedefType>) FromWire(<$w> <$wire>.Value) error {
@@ -67,6 +67,5 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 			Reader string
 		}{Spec: spec, Reader: typeReader(spec)},
 	)
-	// TODO(abg): To/FromWire.
 	return wrapGenerateError(spec.Name, err)
 }


### PR DESCRIPTION
This includes a bunch of refactoring for code generation logic that makes it easier to read. Especially the complex if expressions -- I got rid of them.

The following are the two actual code generation changes:

1.  In struct FromWire, for optional primitive fields, we'll do:

        x, err := f.Value.GetBool(), error(nil)
        v.BoolValue = &x

    We'll do,

        var x bool
        x, err = f.Value.GetBool(), error(nil)
        v.BoolValue = &x

    That is, the err variable will be picked up from the surrounding scope rather
    than being declared anew. This makes the contract for this snippet similar to
    that for the other `FromWire` logic:

        v.Contact, err = _ContactInfo_Read(f.Value)
        v.EmailAddress, err = f.Value.GetString(), error(nil)

2.  We won't include optional fields that are unset in the `String()` output.
