### PR TITLE
compile/TypeSpec: Track original file names

### DIFF
--- a/compile/compiler.go
+++ b/compile/compiler.go
@@ -172,25 +172,25 @@ func (c compiler) gather(m *Module, prog *ast.Program) error {
 
 		switch definition := d.(type) {
 		case *ast.Constant:
-			constant := compileConstant(definition)
+			constant := compileConstant(m.ThriftPath, definition)
 			m.Constants[constant.Name] = constant
 		case *ast.Typedef:
-			typedef := compileTypedef(definition)
+			typedef := compileTypedef(m.ThriftPath, definition)
 			m.Types[typedef.ThriftName()] = typedef
 		case *ast.Enum:
-			enum, err := compileEnum(definition)
+			enum, err := compileEnum(m.ThriftPath, definition)
 			if err != nil {
 				return definitionError{Definition: d, Reason: err}
 			}
 			m.Types[enum.ThriftName()] = enum
 		case *ast.Struct:
-			s, err := compileStruct(definition)
+			s, err := compileStruct(m.ThriftPath, definition)
 			if err != nil {
 				return definitionError{Definition: d, Reason: err}
 			}
 			m.Types[s.ThriftName()] = s
 		case *ast.Service:
-			service, err := compileService(definition)
+			service, err := compileService(m.ThriftPath, definition)
 			if err != nil {
 				return definitionError{Definition: d, Reason: err}
 			}

--- a/compile/constant.go
+++ b/compile/constant.go
@@ -27,15 +27,17 @@ type Constant struct {
 	linkOnce
 
 	Name  string
+	File  string
 	Type  TypeSpec
 	Value ConstantValue
 }
 
 // compileConstant builds a Constant from the given AST constant.
-func compileConstant(src *ast.Constant) *Constant {
+func compileConstant(file string, src *ast.Constant) *Constant {
 	return &Constant{
 		Name:  src.Name,
-		Type:  compileType(src.Type),
+		File:  file,
+		Type:  compileTypeReference(src.Type),
 		Value: compileConstantValue(src.Value),
 	}
 }

--- a/compile/constant_test.go
+++ b/compile/constant_test.go
@@ -61,6 +61,7 @@ func TestCompileConstant(t *testing.T) {
 			nil,
 			&Constant{
 				Name:  "version",
+				File:  "test.thrift",
 				Type:  I32Spec,
 				Value: ConstantInt(1),
 			},
@@ -70,6 +71,7 @@ func TestCompileConstant(t *testing.T) {
 			nil,
 			&Constant{
 				Name:  "foo",
+				File:  "test.thrift",
 				Type:  StringSpec,
 				Value: ConstantString("hello world"),
 			},
@@ -79,6 +81,7 @@ func TestCompileConstant(t *testing.T) {
 			nil,
 			&Constant{
 				Name: "foo",
+				File: "test.thrift",
 				Type: &ListSpec{ValueSpec: StringSpec},
 				Value: ConstantList([]ConstantValue{
 					ConstantString("hello"),
@@ -91,6 +94,7 @@ func TestCompileConstant(t *testing.T) {
 			scope("y", y),
 			&Constant{
 				Name: "foo",
+				File: "test.thrift",
 				Type: &ListSpec{ValueSpec: StringSpec},
 				Value: ConstantList([]ConstantValue{
 					ConstantString("x"),
@@ -109,7 +113,7 @@ func TestCompileConstant(t *testing.T) {
 			"invalid test: expected spec failed to link",
 		)
 
-		constant := compileConstant(src)
+		constant := compileConstant("test.thrift", src)
 		if assert.NoError(t, constant.Link(scope)) {
 			assert.Equal(t, tt.constant, constant)
 		}
@@ -165,7 +169,7 @@ func TestCompileConstantFailure(t *testing.T) {
 	for _, tt := range tests {
 		src := parseConstant(tt.src)
 		scope := scopeOrDefault(tt.scope)
-		constant := compileConstant(src)
+		constant := compileConstant("test.thrift", src)
 
 		err := constant.Link(scope)
 		if assert.Error(t, err) {

--- a/compile/container.go
+++ b/compile/container.go
@@ -30,6 +30,7 @@ import (
 // MapSpec represents a key-value mapping between two types.
 type MapSpec struct {
 	linkOnce
+	nativeThriftType
 
 	KeySpec, ValueSpec TypeSpec
 }
@@ -37,8 +38,8 @@ type MapSpec struct {
 // compileMapType compiles the given MapType AST into a MapSpec.
 func compileMapType(src ast.MapType) *MapSpec {
 	return &MapSpec{
-		KeySpec:   compileType(src.KeyType),
-		ValueSpec: compileType(src.ValueType),
+		KeySpec:   compileTypeReference(src.KeyType),
+		ValueSpec: compileTypeReference(src.ValueType),
 	}
 }
 
@@ -79,13 +80,14 @@ func (m *MapSpec) TypeCode() wire.Type {
 // ListSpec represents lists of values of the same type.
 type ListSpec struct {
 	linkOnce
+	nativeThriftType
 
 	ValueSpec TypeSpec
 }
 
 // compileListSpec compiles the given ListType AST into a ListSpec.
 func compileListType(src ast.ListType) *ListSpec {
-	return &ListSpec{ValueSpec: compileType(src.ValueType)}
+	return &ListSpec{ValueSpec: compileTypeReference(src.ValueType)}
 }
 
 // Link resolves the type references in the ListSpec.
@@ -114,13 +116,14 @@ func (l *ListSpec) ThriftName() string {
 // SetSpec represents sets of values of the same type.
 type SetSpec struct {
 	linkOnce
+	nativeThriftType
 
 	ValueSpec TypeSpec
 }
 
 // compileSetSpec compiles the given SetType AST into a SetSpec.
 func compileSetType(src ast.SetType) *SetSpec {
-	return &SetSpec{ValueSpec: compileType(src.ValueType)}
+	return &SetSpec{ValueSpec: compileTypeReference(src.ValueType)}
 }
 
 // Link resolves the type references in the SetSpec.

--- a/compile/container_test.go
+++ b/compile/container_test.go
@@ -61,7 +61,7 @@ func TestCompileList(t *testing.T) {
 		output := mustLink(t, tt.output, scope())
 
 		scope := scopeOrDefault(tt.scope)
-		spec, err := compileType(tt.input).Link(scope)
+		spec, err := compileTypeReference(tt.input).Link(scope)
 		if assert.NoError(t, err, tt.desc) {
 			assert.Equal(t, wire.TList, spec.TypeCode(), tt.desc)
 			assert.Equal(t, output, spec, tt.desc)
@@ -81,7 +81,7 @@ func TestLinkListFailure(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		_, err := compileType(tt.input).Link(scope())
+		_, err := compileTypeReference(tt.input).Link(scope())
 		if assert.Error(t, err) {
 			for _, msg := range tt.messages {
 				assert.Contains(t, err.Error(), msg)
@@ -118,7 +118,7 @@ func TestCompileMap(t *testing.T) {
 		output := mustLink(t, tt.output, scope())
 
 		scope := scopeOrDefault(tt.scope)
-		spec, err := compileType(tt.input).Link(scope)
+		spec, err := compileTypeReference(tt.input).Link(scope)
 		if assert.NoError(t, err, tt.desc) {
 			assert.Equal(t, wire.TMap, spec.TypeCode(), tt.desc)
 			assert.Equal(t, output, spec, tt.desc)
@@ -148,7 +148,7 @@ func TestLinkMapFailure(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		_, err := compileType(tt.input).Link(scope())
+		_, err := compileTypeReference(tt.input).Link(scope())
 		if assert.Error(t, err) {
 			for _, msg := range tt.messages {
 				assert.Contains(t, err.Error(), msg)
@@ -176,7 +176,7 @@ func TestCompileSet(t *testing.T) {
 		output := mustLink(t, tt.output, scope())
 
 		scope := scopeOrDefault(tt.scope)
-		spec, err := compileType(tt.input).Link(scope)
+		spec, err := compileTypeReference(tt.input).Link(scope)
 		if assert.NoError(t, err, tt.desc) {
 			assert.Equal(t, wire.TSet, spec.TypeCode(), tt.desc)
 			assert.Equal(t, output, spec, tt.desc)
@@ -196,7 +196,7 @@ func TestLinkSetFailure(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		_, err := compileType(tt.input).Link(scope())
+		_, err := compileTypeReference(tt.input).Link(scope())
 		if assert.Error(t, err) {
 			for _, msg := range tt.messages {
 				assert.Contains(t, err.Error(), msg)

--- a/compile/enum.go
+++ b/compile/enum.go
@@ -28,6 +28,7 @@ import (
 // EnumSpec represents an enum defined in the Thrift file.
 type EnumSpec struct {
 	Name  string
+	File  string
 	Items []EnumItem
 }
 
@@ -38,7 +39,7 @@ type EnumItem struct {
 }
 
 // compileEnum compiles the given Enum AST into an EnumSpec.
-func compileEnum(src *ast.Enum) (*EnumSpec, error) {
+func compileEnum(file string, src *ast.Enum) (*EnumSpec, error) {
 	enumNS := newNamespace(caseInsensitive)
 	prev := -1
 
@@ -63,7 +64,7 @@ func compileEnum(src *ast.Enum) (*EnumSpec, error) {
 		items = append(items, item)
 	}
 
-	return &EnumSpec{Name: src.Name, Items: items}, nil
+	return &EnumSpec{Name: src.Name, File: file, Items: items}, nil
 }
 
 // LookupItem retrieves the item with the given name from the enum.
@@ -86,6 +87,11 @@ func (e *EnumSpec) Link(scope Scope) (TypeSpec, error) {
 // ThriftName for EnumSpec
 func (e *EnumSpec) ThriftName() string {
 	return e.Name
+}
+
+// ThriftFile for EnumSpec
+func (e *EnumSpec) ThriftFile() string {
+	return e.File
 }
 
 // TypeCode for EnumSpec.

--- a/compile/enum_test.go
+++ b/compile/enum_test.go
@@ -58,6 +58,7 @@ func TestCompileEnumSuccess(t *testing.T) {
 			"enum Role { Disabled, User, Moderator, Admin }",
 			&EnumSpec{
 				Name: "Role",
+				File: "test.thrift",
 				Items: []EnumItem{
 					EnumItem{"Disabled", 0},
 					EnumItem{"User", 1},
@@ -71,6 +72,7 @@ func TestCompileEnumSuccess(t *testing.T) {
 			"enum CommentStatus { Visible = 12345, Hidden = 54321 }",
 			&EnumSpec{
 				Name: "CommentStatus",
+				File: "test.thrift",
 				Items: []EnumItem{
 					EnumItem{"Visible", 12345},
 					EnumItem{"Hidden", 54321},
@@ -82,6 +84,7 @@ func TestCompileEnumSuccess(t *testing.T) {
 			"enum foo { A, B, C = 10, D, E }",
 			&EnumSpec{
 				Name: "foo",
+				File: "test.thrift",
 				Items: []EnumItem{
 					EnumItem{"A", 0},
 					EnumItem{"B", 1},
@@ -96,6 +99,7 @@ func TestCompileEnumSuccess(t *testing.T) {
 			"enum bar { A, B = 0, C, D = 0, E }",
 			&EnumSpec{
 				Name: "bar",
+				File: "test.thrift",
 				Items: []EnumItem{
 					EnumItem{"A", 0},
 					EnumItem{"B", 0},
@@ -109,7 +113,7 @@ func TestCompileEnumSuccess(t *testing.T) {
 
 	for _, tt := range tests {
 		src := parseEnum(tt.src)
-		enumspec, err := compileEnum(src)
+		enumspec, err := compileEnum("test.thrift", src)
 		if assert.NoError(t, err) {
 			spec, err := enumspec.Link(scope())
 			assert.NoError(t, err)
@@ -139,7 +143,7 @@ func TestCompileEnumFailure(t *testing.T) {
 
 	for _, tt := range tests {
 		src := parseEnum(tt.src)
-		_, err := compileEnum(src)
+		_, err := compileEnum("test.thrift", src)
 
 		if assert.Error(t, err) {
 			for _, msg := range tt.messages {

--- a/compile/field.go
+++ b/compile/field.go
@@ -110,7 +110,7 @@ func compileField(src *ast.Field, options fieldOptions) (*FieldSpec, error) {
 		// TODO(abg): perform bounds check on field ID
 		ID:       int16(src.ID),
 		Name:     src.Name,
-		Type:     compileType(src.Type),
+		Type:     compileTypeReference(src.Type),
 		Required: required,
 		Default:  compileConstantValue(src.Default),
 	}, nil

--- a/compile/primitive.go
+++ b/compile/primitive.go
@@ -29,17 +29,19 @@ import (
 
 // TypeSpecs for primitive Thrift types.
 var (
-	BoolSpec   TypeSpec = primitiveTypeSpec{"bool", wire.TBool}
-	I8Spec     TypeSpec = primitiveTypeSpec{"byte", wire.TI8}
-	I16Spec    TypeSpec = primitiveTypeSpec{"i16", wire.TI16}
-	I32Spec    TypeSpec = primitiveTypeSpec{"i32", wire.TI32}
-	I64Spec    TypeSpec = primitiveTypeSpec{"i64", wire.TI64}
-	DoubleSpec TypeSpec = primitiveTypeSpec{"double", wire.TDouble}
-	StringSpec TypeSpec = primitiveTypeSpec{"string", wire.TBinary}
-	BinarySpec TypeSpec = primitiveTypeSpec{"binary", wire.TBinary}
+	BoolSpec   TypeSpec = primitiveTypeSpec{Name: "bool", Code: wire.TBool}
+	I8Spec     TypeSpec = primitiveTypeSpec{Name: "byte", Code: wire.TI8}
+	I16Spec    TypeSpec = primitiveTypeSpec{Name: "i16", Code: wire.TI16}
+	I32Spec    TypeSpec = primitiveTypeSpec{Name: "i32", Code: wire.TI32}
+	I64Spec    TypeSpec = primitiveTypeSpec{Name: "i64", Code: wire.TI64}
+	DoubleSpec TypeSpec = primitiveTypeSpec{Name: "double", Code: wire.TDouble}
+	StringSpec TypeSpec = primitiveTypeSpec{Name: "string", Code: wire.TBinary}
+	BinarySpec TypeSpec = primitiveTypeSpec{Name: "binary", Code: wire.TBinary}
 )
 
 type primitiveTypeSpec struct {
+	nativeThriftType
+
 	Name string
 	Code wire.Type
 	// TODO(abg): We'll want to expose type annotations here

--- a/compile/service.go
+++ b/compile/service.go
@@ -27,13 +27,14 @@ type ServiceSpec struct {
 	linkOnce
 
 	Name      string
+	File      string
 	Parent    *ServiceSpec
 	Functions map[string]*FunctionSpec
 
 	parentSrc *ast.ServiceReference
 }
 
-func compileService(src *ast.Service) (*ServiceSpec, error) {
+func compileService(file string, src *ast.Service) (*ServiceSpec, error) {
 	serviceNS := newNamespace(caseInsensitive)
 
 	functions := make(map[string]*FunctionSpec)
@@ -60,6 +61,7 @@ func compileService(src *ast.Service) (*ServiceSpec, error) {
 
 	return &ServiceSpec{
 		Name:      src.Name,
+		File:      file,
 		Functions: functions,
 		parentSrc: src.Parent,
 	}, nil
@@ -134,6 +136,11 @@ func (s *ServiceSpec) Link(scope Scope) error {
 	}
 
 	return nil
+}
+
+// ThriftFile is the Thrift file in which this service was defined.
+func (s *ServiceSpec) ThriftFile() string {
+	return s.File
 }
 
 // FunctionSpec is a single function inside a Service.
@@ -239,7 +246,7 @@ func compileResultSpec(returnType ast.Type, exceptions []*ast.Field) (*ResultSpe
 		return nil, err
 	}
 	return &ResultSpec{
-		ReturnType: compileType(returnType),
+		ReturnType: compileTypeReference(returnType),
 		Exceptions: excFields,
 	}, nil
 }

--- a/compile/service_test.go
+++ b/compile/service_test.go
@@ -47,18 +47,21 @@ func parseService(s string) *ast.Service {
 func TestCompileService(t *testing.T) {
 	keyDoesNotExistSpec := &StructSpec{
 		Name:   "KeyDoesNotExist",
+		File:   "test.thrift",
 		Type:   ast.ExceptionType,
 		Fields: make(FieldGroup),
 	}
 
 	internalErrorSpec := &StructSpec{
 		Name:   "InternalServiceError",
+		File:   "test.thrift",
 		Type:   ast.ExceptionType,
 		Fields: make(FieldGroup),
 	}
 
 	keyValueSpec := &ServiceSpec{
 		Name: "KeyValue",
+		File: "test.thrift",
 		Functions: map[string]*FunctionSpec{
 			"setValue": {
 				Name: "setValue",
@@ -115,6 +118,7 @@ func TestCompileService(t *testing.T) {
 			nil,
 			&ServiceSpec{
 				Name:      "Foo",
+				File:      "test.thrift",
 				Functions: make(map[string]*FunctionSpec),
 			},
 		},
@@ -146,6 +150,7 @@ func TestCompileService(t *testing.T) {
 			scope("KeyValue", keyValueSpec),
 			&ServiceSpec{
 				Name:   "BulkKeyValue",
+				File:   "test.thrift",
 				Parent: keyValueSpec,
 				Functions: map[string]*FunctionSpec{
 					"setValues": {
@@ -170,6 +175,7 @@ func TestCompileService(t *testing.T) {
 			scope("shared", scope("KeyValue", keyValueSpec)),
 			&ServiceSpec{
 				Name:      "AnotherKeyValue",
+				File:      "test.thrift",
 				Parent:    keyValueSpec,
 				Functions: make(map[string]*FunctionSpec),
 			},
@@ -184,7 +190,8 @@ func TestCompileService(t *testing.T) {
 		scope := scopeOrDefault(tt.scope)
 
 		src := parseService(tt.src)
-		if spec, err := compileService(src); assert.NoError(t, err, tt.desc) {
+		spec, err := compileService("test.thrift", src)
+		if assert.NoError(t, err, tt.desc) {
 			if assert.NoError(t, spec.Link(scope), tt.desc) {
 				assert.Equal(t, tt.spec, spec, tt.desc)
 			}
@@ -275,7 +282,7 @@ func TestCompileServiceFailure(t *testing.T) {
 
 	for _, tt := range tests {
 		src := parseService(tt.src)
-		_, err := compileService(src)
+		_, err := compileService("test.thrift", src)
 		if assert.Error(t, err, tt.desc) {
 			for _, msg := range tt.messages {
 				assert.Contains(t, err.Error(), msg, tt.desc)
@@ -392,7 +399,7 @@ func TestLinkServiceFailure(t *testing.T) {
 		src := parseService(tt.src)
 		scope := scopeOrDefault(tt.scope)
 
-		spec, err := compileService(src)
+		spec, err := compileService("test.thrift", src)
 		if assert.NoError(t, err, tt.desc) {
 			if err := spec.Link(scope); assert.Error(t, err) {
 				for _, msg := range tt.messages {

--- a/compile/struct.go
+++ b/compile/struct.go
@@ -30,12 +30,13 @@ type StructSpec struct {
 	linkOnce
 
 	Name   string
+	File   string
 	Type   ast.StructureType
 	Fields FieldGroup
 }
 
 // compileStruct compiles a struct AST into a StructSpec.
-func compileStruct(src *ast.Struct) (*StructSpec, error) {
+func compileStruct(file string, src *ast.Struct) (*StructSpec, error) {
 	opts := fieldOptions{requiredness: explicitRequiredness}
 
 	if src.Type == ast.UnionType {
@@ -54,6 +55,7 @@ func compileStruct(src *ast.Struct) (*StructSpec, error) {
 
 	return &StructSpec{
 		Name:   src.Name,
+		File:   file,
 		Type:   src.Type,
 		Fields: fields,
 	}, nil
@@ -77,6 +79,11 @@ func (s *StructSpec) TypeCode() wire.Type {
 // ThriftName of the StructSpec.
 func (s *StructSpec) ThriftName() string {
 	return s.Name
+}
+
+// ThriftFile of the StructSpec.
+func (s *StructSpec) ThriftFile() string {
+	return s.File
 }
 
 // IsExceptionType returns true if the StructSpec represents an exception

--- a/compile/struct_test.go
+++ b/compile/struct_test.go
@@ -55,6 +55,7 @@ func TestCompileStructSuccess(t *testing.T) {
 			nil,
 			&StructSpec{
 				Name: "Health",
+				File: "test.thrift",
 				Type: ast.StructType,
 				Fields: map[string]*FieldSpec{
 					"healthy": {
@@ -75,6 +76,7 @@ func TestCompileStructSuccess(t *testing.T) {
 			scope("Key", &TypedefSpec{Name: "Key", Target: StringSpec}),
 			&StructSpec{
 				Name: "KeyNotFoundError",
+				File: "test.thrift",
 				Type: ast.ExceptionType,
 				Fields: map[string]*FieldSpec{
 					"message": {
@@ -100,6 +102,7 @@ func TestCompileStructSuccess(t *testing.T) {
 			nil,
 			&StructSpec{
 				Name: "Body",
+				File: "test.thrift",
 				Type: ast.UnionType,
 				Fields: map[string]*FieldSpec{
 					"plainText": {
@@ -123,7 +126,7 @@ func TestCompileStructSuccess(t *testing.T) {
 		expected := mustLink(t, tt.spec, scope())
 
 		src := parseStruct(tt.src)
-		structSpec, err := compileStruct(src)
+		structSpec, err := compileStruct("test.thrift", src)
 		scope := scopeOrDefault(tt.scope)
 		if assert.NoError(t, err) {
 			spec, err := structSpec.Link(scope)
@@ -196,7 +199,7 @@ func TestCompileStructFailure(t *testing.T) {
 
 	for _, tt := range tests {
 		src := parseStruct(tt.src)
-		_, err := compileStruct(src)
+		_, err := compileStruct("test.thrift", src)
 
 		if assert.Error(t, err, tt.desc) {
 			for _, msg := range tt.messages {
@@ -237,7 +240,7 @@ func TestLinkStructFailure(t *testing.T) {
 		src := parseStruct(tt.src)
 		scope := scopeOrDefault(tt.scope)
 
-		spec, err := compileStruct(src)
+		spec, err := compileStruct("test.thrift", src)
 		if assert.NoError(t, err, tt.desc) {
 			_, err := spec.Link(scope)
 			if assert.Error(t, err, tt.desc) {

--- a/compile/type_test.go
+++ b/compile/type_test.go
@@ -40,7 +40,7 @@ func mustLink(t *testing.T, spec TypeSpec, scope Scope) TypeSpec {
 
 func TestCompileTypeWithNil(t *testing.T) {
 	// make sure compileType(nil) doesn't explode.
-	assert.Nil(t, compileType(nil))
+	assert.Nil(t, compileTypeReference(nil))
 }
 
 func TestResolveBaseType(t *testing.T) {
@@ -59,7 +59,7 @@ func TestResolveBaseType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		spec := compileType(tt.input)
+		spec := compileTypeReference(tt.input)
 		linked, err := spec.Link(scope())
 
 		assert.NoError(t, err)
@@ -70,7 +70,7 @@ func TestResolveBaseType(t *testing.T) {
 
 func TestResolveInvalidBaseType(t *testing.T) {
 	assert.Panics(t, func() {
-		compileType(ast.BaseType{ID: ast.BaseTypeID(42)})
+		compileTypeReference(ast.BaseType{ID: ast.BaseTypeID(42)})
 	})
 }
 

--- a/compile/typedef.go
+++ b/compile/typedef.go
@@ -30,12 +30,17 @@ type TypedefSpec struct {
 	linkOnce
 
 	Name   string
+	File   string
 	Target TypeSpec
 }
 
 // compileTypedef compiles the given Typedef AST into a TypedefSpec.
-func compileTypedef(src *ast.Typedef) *TypedefSpec {
-	return &TypedefSpec{Name: src.Name, Target: compileType(src.Type)}
+func compileTypedef(file string, src *ast.Typedef) *TypedefSpec {
+	return &TypedefSpec{
+		Name:   src.Name,
+		File:   file,
+		Target: compileTypeReference(src.Type),
+	}
 }
 
 // TypeCode gets the wire type for the typedef.
@@ -57,4 +62,9 @@ func (t *TypedefSpec) Link(scope Scope) (TypeSpec, error) {
 // ThriftName is the name of the typedef as it appears in the Thrift file.
 func (t *TypedefSpec) ThriftName() string {
 	return t.Name
+}
+
+// ThriftFile for TypedefSpec.
+func (t *TypedefSpec) ThriftFile() string {
+	return t.File
 }

--- a/compile/typedef_test.go
+++ b/compile/typedef_test.go
@@ -55,15 +55,28 @@ func TestCompileTypedef(t *testing.T) {
 			"typedef i64 timestamp",
 			nil,
 			wire.TI64,
-			&TypedefSpec{Name: "timestamp", Target: I64Spec},
+			&TypedefSpec{
+				Name:   "timestamp",
+				File:   "test.thrift",
+				Target: I64Spec,
+			},
 		},
 		{
 			"typedef Bar Foo",
-			scope("Bar", &TypedefSpec{Name: "Bar", Target: I32Spec}),
+			scope("Bar", &TypedefSpec{
+				Name:   "Bar",
+				File:   "test.thrift",
+				Target: I32Spec,
+			}),
 			wire.TI32,
 			&TypedefSpec{
-				Name:   "Foo",
-				Target: &TypedefSpec{Name: "Bar", Target: I32Spec},
+				Name: "Foo",
+				File: "test.thrift",
+				Target: &TypedefSpec{
+					Name:   "Bar",
+					File:   "test.thrift",
+					Target: I32Spec,
+				},
 			},
 		},
 	}
@@ -72,7 +85,7 @@ func TestCompileTypedef(t *testing.T) {
 		expected := mustLink(t, tt.spec, scope())
 
 		src := parseTypedef(tt.src)
-		typedefSpec := compileTypedef(src)
+		typedefSpec := compileTypedef("test.thrift", src)
 		scope := scopeOrDefault(tt.scope)
 		spec, err := typedefSpec.Link(scope)
 		if assert.NoError(t, err) {
@@ -103,7 +116,7 @@ func TestCompileTypedefFailure(t *testing.T) {
 		src := parseTypedef(tt.src)
 		scope := scopeOrDefault(tt.scope)
 
-		_, err := compileTypedef(src).Link(scope)
+		_, err := compileTypedef("test.thrift", src).Link(scope)
 		if assert.Error(t, err, tt.desc) {
 			for _, msg := range tt.messages {
 				assert.Contains(t, err.Error(), msg, tt.desc)


### PR DESCRIPTION
This changes TypeSpec to track and expose the name of each file in which a
type was defined.

We need this to be able to import the corresponding generated modules correctly.