### PR TITLE
Detect and fail on complex typedef cycles

### DIFF
--- a/compile/container.go
+++ b/compile/container.go
@@ -75,6 +75,17 @@ func (m *MapSpec) TypeCode() wire.Type {
 	return wire.TMap
 }
 
+// ForEachTypeReference for MapSpec
+func (m *MapSpec) ForEachTypeReference(f func(TypeSpec) error) error {
+	if err := f(m.KeySpec); err != nil {
+		return err
+	}
+	if err := f(m.ValueSpec); err != nil {
+		return err
+	}
+	return nil
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 // ListSpec represents lists of values of the same type.
@@ -111,6 +122,11 @@ func (l *ListSpec) ThriftName() string {
 	return fmt.Sprintf("list<%s>", l.ValueSpec.ThriftName())
 }
 
+// ForEachTypeReference for ListSpec
+func (l *ListSpec) ForEachTypeReference(f func(TypeSpec) error) error {
+	return f(l.ValueSpec)
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 // SetSpec represents sets of values of the same type.
@@ -145,4 +161,9 @@ func (s *SetSpec) TypeCode() wire.Type {
 // ThriftName for SetSpec.
 func (s *SetSpec) ThriftName() string {
 	return fmt.Sprintf("set<%s>", s.ValueSpec.ThriftName())
+}
+
+// ForEachTypeReference for SetSpec
+func (s *SetSpec) ForEachTypeReference(f func(TypeSpec) error) error {
+	return f(s.ValueSpec)
 }

--- a/compile/cycle.go
+++ b/compile/cycle.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package compile
+
+// findTypeCycles look for invalid type reference cycles in the given
+// TypeSpec.
+func findTypeCycles(t TypeSpec) error {
+	return make(typeCycleFinder, 0).Visit(t)
+}
+
+type typeCycleFinder []TypeSpec
+
+// visited returns true if the given TypeSpec has already been visited.
+// Otherwise it returns false, and marks the TypeSpec as visited.
+func (f typeCycleFinder) visited(s TypeSpec) bool {
+	for _, t := range f {
+		if t == s {
+			return true
+		}
+	}
+	return false
+}
+
+// cloneWithPart creates a copy of this typeCycleFinder with the given
+// TypeSpec added to the chain.
+func (f typeCycleFinder) cloneWithPart(s TypeSpec) typeCycleFinder {
+	newf := make(typeCycleFinder, 0, len(f)+1)
+	newf = append(newf, f...)
+	newf = append(newf, s)
+	return newf
+}
+
+func (f typeCycleFinder) Visit(s TypeSpec) error {
+	_, isTypedef := s.(*TypedefSpec)
+
+	if f.visited(s) {
+		// cycles are errors only for typedefs
+		if isTypedef {
+			return typeReferenceCycleError{Nodes: append(f, s)}
+		}
+		return nil
+	}
+
+	return s.ForEachTypeReference(f.cloneWithPart(s).Visit)
+}

--- a/compile/cycle_test.go
+++ b/compile/cycle_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package compile
+
+import (
+	"testing"
+
+	"github.com/thriftrw/thriftrw-go/ast"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper to create typedefs with cyclic references inside the test table.
+func withTypedef(f func(t *TypedefSpec)) TypeSpec {
+	t := &TypedefSpec{File: "test.thrift"}
+	f(t)
+	return t
+}
+
+func TestFindTypeCycles(t *testing.T) {
+	tests := []struct {
+		desc string
+		typ  TypeSpec
+		msgs []string
+	}{
+		{
+			desc: "self-referential typedef",
+			typ: withTypedef(func(t *TypedefSpec) {
+				t.Name = "foo"
+				t.Target = t
+			}),
+			msgs: []string{
+				"found a type reference cycle",
+				"   foo",
+				"-> foo",
+			},
+		},
+		{
+			desc: "mutually recursive references",
+			typ: withTypedef(func(x *TypedefSpec) {
+				x.Name = "foo"
+				x.Target = &TypedefSpec{
+					Name:   "bar",
+					File:   "test.thrift",
+					Target: x,
+				}
+			}),
+			msgs: []string{
+				"found a type reference cycle",
+				"   foo",
+				"-> bar",
+				"-> foo",
+			},
+		},
+		{
+			desc: "recurse from map",
+			typ: withTypedef(func(t *TypedefSpec) {
+				t.Name = "foo"
+				t.Target = &MapSpec{
+					KeySpec:   StringSpec,
+					ValueSpec: t,
+				}
+			}),
+			msgs: []string{
+				"found a type reference cycle",
+				"   foo",
+				"-> map<string, foo>",
+				"-> foo",
+			},
+		},
+		{
+			desc: "recurse from list",
+			typ: withTypedef(func(t *TypedefSpec) {
+				t.Name = "foo"
+				t.Target = &ListSpec{ValueSpec: t}
+			}),
+			msgs: []string{
+				"found a type reference cycle",
+				"   foo",
+				"-> list<foo>",
+				"-> foo",
+			},
+		},
+		{
+			desc: "recurse from set",
+			typ: withTypedef(func(t *TypedefSpec) {
+				t.Name = "foo"
+				t.Target = &SetSpec{ValueSpec: t}
+			}),
+			msgs: []string{
+				"found a type reference cycle",
+				"   foo",
+				"-> set<foo>",
+				"-> foo",
+			},
+		},
+		{
+			desc: "recurse from struct",
+			typ: withTypedef(func(t *TypedefSpec) {
+				t.Name = "foo"
+				t.Target = &StructSpec{
+					Name: "bar",
+					File: "test.thrift",
+					Type: ast.StructType,
+					Fields: FieldGroup{
+						"foo": {
+							ID:       1,
+							Name:     "foo",
+							Type:     t,
+							Required: true,
+						},
+					},
+				}
+			}),
+			msgs: []string{
+				"found a type reference cycle",
+				"   foo",
+				"-> bar",
+				"-> foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		typ := mustLink(t, tt.typ, scope())
+
+		err := findTypeCycles(typ)
+		if assert.Error(t, err, tt.desc) {
+			for _, msg := range tt.msgs {
+				assert.Contains(t, err.Error(), msg)
+			}
+		}
+	}
+}

--- a/compile/enum.go
+++ b/compile/enum.go
@@ -94,6 +94,11 @@ func (e *EnumSpec) ThriftFile() string {
 	return e.File
 }
 
+// ForEachTypeReference for EnumSpec
+func (e *EnumSpec) ForEachTypeReference(func(TypeSpec) error) error {
+	return nil
+}
+
 // TypeCode for EnumSpec.
 //
 // Enums are represented as i32 over the wire.

--- a/compile/field.go
+++ b/compile/field.go
@@ -187,3 +187,14 @@ func (fg FieldGroup) Link(scope Scope) error {
 
 	return nil
 }
+
+// ForEachTypeReference applies the given function on each TypeSpec in the
+// FieldGroup.
+func (fg FieldGroup) ForEachTypeReference(f func(TypeSpec) error) error {
+	for _, field := range fg {
+		if err := f(field.Type); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/compile/primitive.go
+++ b/compile/primitive.go
@@ -57,6 +57,11 @@ func (t primitiveTypeSpec) ThriftName() string {
 	return t.Name
 }
 
+// ForEachTypeReference of the primitive type.
+func (t primitiveTypeSpec) ForEachTypeReference(func(TypeSpec) error) error {
+	return nil
+}
+
 // Link for primitive types is a no-op because primitive types don't make any
 // references.
 func (t primitiveTypeSpec) Link(Scope) (TypeSpec, error) {

--- a/compile/struct.go
+++ b/compile/struct.go
@@ -91,3 +91,8 @@ func (s *StructSpec) ThriftFile() string {
 func (s *StructSpec) IsExceptionType() bool {
 	return s.Type == ast.ExceptionType
 }
+
+// ForEachTypeReference for StructSpec
+func (s *StructSpec) ForEachTypeReference(f func(TypeSpec) error) error {
+	return s.Fields.ForEachTypeReference(f)
+}

--- a/compile/type.go
+++ b/compile/type.go
@@ -43,6 +43,14 @@ type TypeSpec interface {
 	// defined. This may be an empty string if this type is a native Thrift
 	// type.
 	ThriftFile() string
+
+	// Applies the given function to each TypeSpec referenced by this
+	// TypeSpec. This function MUST NOT be automatically called recursively on
+	// the TypeSpecs referenced by the child TypeSpecs. The decision to make
+	// that call is up to the caller of this function.
+	//
+	// Returns the first error returned by the function call or nil.
+	ForEachTypeReference(func(TypeSpec) error) error
 }
 
 // nativeThriftType is the common parent for all TypeSpecs that are native
@@ -109,6 +117,15 @@ func (r typeSpecReference) TypeCode() wire.Type {
 func (r typeSpecReference) ThriftFile() string {
 	panic(fmt.Sprintf(
 		"ThriftFile() requested for unresolved TypeSpec reference %v."+
+			"Make sure you called Link().", r,
+	))
+}
+
+// ForEachTypeReference on an unresolved typeSpecReference will cause a system
+// panic.
+func (r typeSpecReference) ForEachTypeReference(func(TypeSpec) error) error {
+	panic(fmt.Sprintf(
+		"ForEachTypeReference() called on unresolved TypeSpec reference %v."+
 			"Make sure you called Link().", r,
 	))
 }

--- a/compile/typedef.go
+++ b/compile/typedef.go
@@ -68,3 +68,8 @@ func (t *TypedefSpec) ThriftName() string {
 func (t *TypedefSpec) ThriftFile() string {
 	return t.File
 }
+
+// ForEachTypeReference for TypedefSpec
+func (t *TypedefSpec) ForEachTypeReference(f func(TypeSpec) error) error {
+	return f(t.Target)
+}


### PR DESCRIPTION
After the link stage, this will walk all `typedef` reference trees and look
for any cyclic references.

The full reference cycle is printed in the error message. For example, given
the input,

    typedef x foo
    struct x { 1: required y a }
    struct y { 1: optional map<string, z> b }
    struct z { 1: optional foo c }

The error is:

    cannot compile "[..]/tmp.thrift": cannot compile "foo": found a type reference cycle:
        foo
     -> x
     -> y
     -> map<string, z>
     -> z
     -> foo

If the cyclic references are spread across multiple files, the output also
includes the file names.

    cannot compile "[..]/tmp.thrift": cannot compile "foo": found a type reference cycle:
        foo ([..]/tmp.thrift)
     -> x ([..]/tmp.thrift)
     -> y ([..]/tmp.thrift)
     -> map<string, z>
     -> z ([..]/b.thrift)
     -> foo ([..]/tmp.thrift)