### PR TITLE
Maintain field order in generated code

### DIFF
--- a/compile/cycle_test.go
+++ b/compile/cycle_test.go
@@ -121,7 +121,7 @@ func TestFindTypeCycles(t *testing.T) {
 					File: "test.thrift",
 					Type: ast.StructType,
 					Fields: FieldGroup{
-						"foo": {
+						{
 							ID:       1,
 							Name:     "foo",
 							Type:     t,

--- a/compile/field.go
+++ b/compile/field.go
@@ -133,14 +133,14 @@ func (f *FieldSpec) Link(scope Scope) (err error) {
 }
 
 // FieldGroup represents a collection of fields for struct-like types.
-type FieldGroup map[string]*FieldSpec
+type FieldGroup []*FieldSpec
 
 // compileFields compiles a collection of AST fields into a FieldGroup.
 func compileFields(src []*ast.Field, options fieldOptions) (FieldGroup, error) {
 	fieldsNS := newNamespace(caseInsensitive)
 	usedIDs := make(map[int16]string)
 
-	fields := make(map[string]*FieldSpec)
+	fields := make([]*FieldSpec, 0, len(src))
 	for _, astField := range src {
 		if err := fieldsNS.claim(astField.Name, astField.Line); err != nil {
 			return nil, compileError{
@@ -170,7 +170,7 @@ func compileFields(src []*ast.Field, options fieldOptions) (FieldGroup, error) {
 			}
 		}
 
-		fields[field.Name] = field
+		fields = append(fields, field)
 		usedIDs[field.ID] = field.Name
 	}
 

--- a/compile/service.go
+++ b/compile/service.go
@@ -266,11 +266,11 @@ func (rs *ResultSpec) Link(scope Scope) (err error) {
 	}
 
 	// verify that everything listed under throws is an exception.
-	for name, exception := range rs.Exceptions {
+	for _, exception := range rs.Exceptions {
 		spec, ok := exception.Type.(*StructSpec)
 		if !ok || spec.Type != ast.ExceptionType {
 			return notAnExceptionError{
-				FieldName: name,
+				FieldName: exception.ThriftName(),
 				TypeName:  spec.ThriftName(),
 			}
 		}

--- a/compile/service_test.go
+++ b/compile/service_test.go
@@ -49,14 +49,14 @@ func TestCompileService(t *testing.T) {
 		Name:   "KeyDoesNotExist",
 		File:   "test.thrift",
 		Type:   ast.ExceptionType,
-		Fields: make(FieldGroup),
+		Fields: make(FieldGroup, 0),
 	}
 
 	internalErrorSpec := &StructSpec{
 		Name:   "InternalServiceError",
 		File:   "test.thrift",
 		Type:   ast.ExceptionType,
-		Fields: make(FieldGroup),
+		Fields: make(FieldGroup, 0),
 	}
 
 	keyValueSpec := &ServiceSpec{
@@ -65,13 +65,13 @@ func TestCompileService(t *testing.T) {
 		Functions: map[string]*FunctionSpec{
 			"setValue": {
 				Name: "setValue",
-				ArgsSpec: map[string]*FieldSpec{
-					"key": {
+				ArgsSpec: ArgsSpec{
+					{
 						ID:   1,
 						Name: "key",
 						Type: StringSpec,
 					},
-					"value": {
+					{
 						ID:   2,
 						Name: "value",
 						Type: BinarySpec,
@@ -80,8 +80,8 @@ func TestCompileService(t *testing.T) {
 			},
 			"getValue": {
 				Name: "getValue",
-				ArgsSpec: map[string]*FieldSpec{
-					"key": {
+				ArgsSpec: ArgsSpec{
+					{
 						ID:   1,
 						Name: "key",
 						Type: StringSpec,
@@ -89,13 +89,13 @@ func TestCompileService(t *testing.T) {
 				},
 				ResultSpec: &ResultSpec{
 					ReturnType: BinarySpec,
-					Exceptions: map[string]*FieldSpec{
-						"doesNotExist": {
+					Exceptions: FieldGroup{
+						{
 							ID:   1,
 							Name: "doesNotExist",
 							Type: keyDoesNotExistSpec,
 						},
-						"internalError": {
+						{
 							ID:   2,
 							Name: "internalError",
 							Type: internalErrorSpec,
@@ -155,8 +155,8 @@ func TestCompileService(t *testing.T) {
 				Functions: map[string]*FunctionSpec{
 					"setValues": {
 						Name: "setValues",
-						ArgsSpec: map[string]*FieldSpec{
-							"items": {
+						ArgsSpec: ArgsSpec{
+							{
 								ID:   1,
 								Name: "items",
 								Type: &MapSpec{
@@ -356,12 +356,12 @@ func TestLinkServiceFailure(t *testing.T) {
 				"SomeException", &StructSpec{
 					Name:   "SomeException",
 					Type:   ast.ExceptionType,
-					Fields: make(FieldGroup),
+					Fields: make(FieldGroup, 0),
 				},
 				"NotAnException", &StructSpec{
 					Name:   "NotAnException",
 					Type:   ast.StructType,
-					Fields: make(FieldGroup),
+					Fields: make(FieldGroup, 0),
 				},
 			),
 			[]string{

--- a/compile/struct_test.go
+++ b/compile/struct_test.go
@@ -57,8 +57,8 @@ func TestCompileStructSuccess(t *testing.T) {
 				Name: "Health",
 				File: "test.thrift",
 				Type: ast.StructType,
-				Fields: map[string]*FieldSpec{
-					"healthy": {
+				Fields: FieldGroup{
+					{
 						ID:       1,
 						Name:     "healthy",
 						Type:     BoolSpec,
@@ -78,14 +78,14 @@ func TestCompileStructSuccess(t *testing.T) {
 				Name: "KeyNotFoundError",
 				File: "test.thrift",
 				Type: ast.ExceptionType,
-				Fields: map[string]*FieldSpec{
-					"message": {
+				Fields: FieldGroup{
+					{
 						ID:       1,
 						Name:     "message",
 						Type:     StringSpec,
 						Required: true,
 					},
-					"key": {
+					{
 						ID:       2,
 						Name:     "key",
 						Type:     &TypedefSpec{Name: "Key", Target: StringSpec},
@@ -104,14 +104,14 @@ func TestCompileStructSuccess(t *testing.T) {
 				Name: "Body",
 				File: "test.thrift",
 				Type: ast.UnionType,
-				Fields: map[string]*FieldSpec{
-					"plainText": {
+				Fields: FieldGroup{
+					{
 						ID:       1234,
 						Name:     "plainText",
 						Type:     StringSpec,
 						Required: false,
 					},
-					"richText": {
+					{
 						ID:       5678,
 						Name:     "richText",
 						Type:     BinarySpec,

--- a/compile/type_test.go
+++ b/compile/type_test.go
@@ -78,8 +78,8 @@ func TestLinkTypeReference(t *testing.T) {
 	foo := &StructSpec{
 		Name: "Foo",
 		Type: ast.StructType,
-		Fields: map[string]*FieldSpec{
-			"value": {ID: 1, Name: "value", Type: I32Spec},
+		Fields: FieldGroup{
+			{ID: 1, Name: "value", Type: I32Spec},
 		},
 	}
 

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -275,7 +275,7 @@ func TestNestedStructsRequired(t *testing.T) {
 					}}),
 				},
 			}}),
-			"Frame{Size: Size{Height: 200, Width: 100}, TopLeft: Point{X: 1, Y: 2}}",
+			"Frame{TopLeft: Point{X: 1, Y: 2}, Size: Size{Width: 100, Height: 200}}",
 		},
 	}
 
@@ -319,7 +319,7 @@ func TestNestedStructsOptional(t *testing.T) {
 					{ID: 1, Value: wire.NewValueString("foo@example.com")},
 				}})},
 			}}),
-			"User{Contact: ContactInfo{EmailAddress: foo@example.com}, Name: Foo Bar}",
+			"User{Name: Foo Bar, Contact: ContactInfo{EmailAddress: foo@example.com}}",
 		},
 	}
 
@@ -346,19 +346,19 @@ func TestStructStringWithMissingRequiredFields(t *testing.T) {
 	}{
 		{
 			&ts.Frame{TopLeft: &ts.Point{}},
-			"Frame{Size: <nil>, TopLeft: Point{X: 0, Y: 0}}",
+			"Frame{TopLeft: Point{X: 0, Y: 0}, Size: <nil>}",
 		},
 		{
 			&ts.Frame{Size: &ts.Size{}},
-			"Frame{Size: Size{Height: 0, Width: 0}, TopLeft: <nil>}",
+			"Frame{TopLeft: <nil>, Size: Size{Width: 0, Height: 0}}",
 		},
 		{
 			&ts.Edge{Start: &ts.Point{X: 1, Y: 2}},
-			"Edge{End: <nil>, Start: Point{X: 1, Y: 2}}",
+			"Edge{Start: Point{X: 1, Y: 2}, End: <nil>}",
 		},
 		{
 			&ts.Edge{End: &ts.Point{X: 3, Y: 4}},
-			"Edge{End: Point{X: 3, Y: 4}, Start: <nil>}",
+			"Edge{Start: <nil>, End: Point{X: 3, Y: 4}}",
 		},
 		{
 			&ts.Graph{},

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -41,16 +41,16 @@ func (v *ContactInfo) String() string {
 }
 
 type Edge struct {
-	End   *Point
 	Start *Point
+	End   *Point
 }
 
 func (v *Edge) ToWire() wire.Value {
 	var fields [2]wire.Field
 	i := 0
-	fields[i] = wire.Field{ID: 2, Value: v.End.ToWire()}
-	i++
 	fields[i] = wire.Field{ID: 1, Value: v.Start.ToWire()}
+	i++
+	fields[i] = wire.Field{ID: 2, Value: v.End.ToWire()}
 	i++
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
 }
@@ -63,16 +63,16 @@ func (v *Edge) FromWire(w wire.Value) error {
 	var err error
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
-		case 2:
+		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.End, err = _Point_Read(field.Value)
+				v.Start, err = _Point_Read(field.Value)
 				if err != nil {
 					return err
 				}
 			}
-		case 1:
+		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.Start, err = _Point_Read(field.Value)
+				v.End, err = _Point_Read(field.Value)
 				if err != nil {
 					return err
 				}
@@ -84,9 +84,9 @@ func (v *Edge) FromWire(w wire.Value) error {
 func (v *Edge) String() string {
 	var fields [2]string
 	i := 0
-	fields[i] = fmt.Sprintf("End: %v", v.End)
-	i++
 	fields[i] = fmt.Sprintf("Start: %v", v.Start)
+	i++
+	fields[i] = fmt.Sprintf("End: %v", v.End)
 	i++
 	return fmt.Sprintf("Edge{%v}", strings.Join(fields[:i], ", "))
 }
@@ -112,16 +112,16 @@ func (v *EmptyStruct) String() string {
 }
 
 type Frame struct {
-	Size    *Size
 	TopLeft *Point
+	Size    *Size
 }
 
 func (v *Frame) ToWire() wire.Value {
 	var fields [2]wire.Field
 	i := 0
-	fields[i] = wire.Field{ID: 2, Value: v.Size.ToWire()}
-	i++
 	fields[i] = wire.Field{ID: 1, Value: v.TopLeft.ToWire()}
+	i++
+	fields[i] = wire.Field{ID: 2, Value: v.Size.ToWire()}
 	i++
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
 }
@@ -134,16 +134,16 @@ func (v *Frame) FromWire(w wire.Value) error {
 	var err error
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
-		case 2:
+		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.Size, err = _Size_Read(field.Value)
+				v.TopLeft, err = _Point_Read(field.Value)
 				if err != nil {
 					return err
 				}
 			}
-		case 1:
+		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.TopLeft, err = _Point_Read(field.Value)
+				v.Size, err = _Size_Read(field.Value)
 				if err != nil {
 					return err
 				}
@@ -155,9 +155,9 @@ func (v *Frame) FromWire(w wire.Value) error {
 func (v *Frame) String() string {
 	var fields [2]string
 	i := 0
-	fields[i] = fmt.Sprintf("Size: %v", v.Size)
-	i++
 	fields[i] = fmt.Sprintf("TopLeft: %v", v.TopLeft)
+	i++
+	fields[i] = fmt.Sprintf("Size: %v", v.Size)
 	i++
 	return fmt.Sprintf("Frame{%v}", strings.Join(fields[:i], ", "))
 }
@@ -274,33 +274,25 @@ func (v *Point) String() string {
 }
 
 type PrimitiveOptionalStruct struct {
-	BinaryField []byte
 	BoolField   *bool
 	ByteField   *int8
-	DoubleField *float64
 	Int16Field  *int16
 	Int32Field  *int32
 	Int64Field  *int64
+	DoubleField *float64
 	StringField *string
+	BinaryField []byte
 }
 
 func (v *PrimitiveOptionalStruct) ToWire() wire.Value {
 	var fields [8]wire.Field
 	i := 0
-	if v.BinaryField != nil {
-		fields[i] = wire.Field{ID: 8, Value: wire.NewValueBinary(v.BinaryField)}
-		i++
-	}
 	if v.BoolField != nil {
 		fields[i] = wire.Field{ID: 1, Value: wire.NewValueBool(*(v.BoolField))}
 		i++
 	}
 	if v.ByteField != nil {
 		fields[i] = wire.Field{ID: 2, Value: wire.NewValueI8(*(v.ByteField))}
-		i++
-	}
-	if v.DoubleField != nil {
-		fields[i] = wire.Field{ID: 6, Value: wire.NewValueDouble(*(v.DoubleField))}
 		i++
 	}
 	if v.Int16Field != nil {
@@ -315,8 +307,16 @@ func (v *PrimitiveOptionalStruct) ToWire() wire.Value {
 		fields[i] = wire.Field{ID: 5, Value: wire.NewValueI64(*(v.Int64Field))}
 		i++
 	}
+	if v.DoubleField != nil {
+		fields[i] = wire.Field{ID: 6, Value: wire.NewValueDouble(*(v.DoubleField))}
+		i++
+	}
 	if v.StringField != nil {
 		fields[i] = wire.Field{ID: 7, Value: wire.NewValueString(*(v.StringField))}
+		i++
+	}
+	if v.BinaryField != nil {
+		fields[i] = wire.Field{ID: 8, Value: wire.NewValueBinary(v.BinaryField)}
 		i++
 	}
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
@@ -325,13 +325,6 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 	var err error
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
-		case 8:
-			if field.Value.Type() == wire.TBinary {
-				v.BinaryField, err = field.Value.GetBinary(), error(nil)
-				if err != nil {
-					return err
-				}
-			}
 		case 1:
 			if field.Value.Type() == wire.TBool {
 				var x bool
@@ -346,15 +339,6 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 				var x int8
 				x, err = field.Value.GetI8(), error(nil)
 				v.ByteField = &x
-				if err != nil {
-					return err
-				}
-			}
-		case 6:
-			if field.Value.Type() == wire.TDouble {
-				var x float64
-				x, err = field.Value.GetDouble(), error(nil)
-				v.DoubleField = &x
 				if err != nil {
 					return err
 				}
@@ -386,11 +370,27 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 					return err
 				}
 			}
+		case 6:
+			if field.Value.Type() == wire.TDouble {
+				var x float64
+				x, err = field.Value.GetDouble(), error(nil)
+				v.DoubleField = &x
+				if err != nil {
+					return err
+				}
+			}
 		case 7:
 			if field.Value.Type() == wire.TBinary {
 				var x string
 				x, err = field.Value.GetString(), error(nil)
 				v.StringField = &x
+				if err != nil {
+					return err
+				}
+			}
+		case 8:
+			if field.Value.Type() == wire.TBinary {
+				v.BinaryField, err = field.Value.GetBinary(), error(nil)
 				if err != nil {
 					return err
 				}
@@ -402,20 +402,12 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 func (v *PrimitiveOptionalStruct) String() string {
 	var fields [8]string
 	i := 0
-	if v.BinaryField != nil {
-		fields[i] = fmt.Sprintf("BinaryField: %v", v.BinaryField)
-		i++
-	}
 	if v.BoolField != nil {
 		fields[i] = fmt.Sprintf("BoolField: %v", *(v.BoolField))
 		i++
 	}
 	if v.ByteField != nil {
 		fields[i] = fmt.Sprintf("ByteField: %v", *(v.ByteField))
-		i++
-	}
-	if v.DoubleField != nil {
-		fields[i] = fmt.Sprintf("DoubleField: %v", *(v.DoubleField))
 		i++
 	}
 	if v.Int16Field != nil {
@@ -430,34 +422,38 @@ func (v *PrimitiveOptionalStruct) String() string {
 		fields[i] = fmt.Sprintf("Int64Field: %v", *(v.Int64Field))
 		i++
 	}
+	if v.DoubleField != nil {
+		fields[i] = fmt.Sprintf("DoubleField: %v", *(v.DoubleField))
+		i++
+	}
 	if v.StringField != nil {
 		fields[i] = fmt.Sprintf("StringField: %v", *(v.StringField))
+		i++
+	}
+	if v.BinaryField != nil {
+		fields[i] = fmt.Sprintf("BinaryField: %v", v.BinaryField)
 		i++
 	}
 	return fmt.Sprintf("PrimitiveOptionalStruct{%v}", strings.Join(fields[:i], ", "))
 }
 
 type PrimitiveRequiredStruct struct {
-	BinaryField []byte
 	BoolField   bool
 	ByteField   int8
-	DoubleField float64
 	Int16Field  int16
 	Int32Field  int32
 	Int64Field  int64
+	DoubleField float64
 	StringField string
+	BinaryField []byte
 }
 
 func (v *PrimitiveRequiredStruct) ToWire() wire.Value {
 	var fields [8]wire.Field
 	i := 0
-	fields[i] = wire.Field{ID: 8, Value: wire.NewValueBinary(v.BinaryField)}
-	i++
 	fields[i] = wire.Field{ID: 1, Value: wire.NewValueBool(v.BoolField)}
 	i++
 	fields[i] = wire.Field{ID: 2, Value: wire.NewValueI8(v.ByteField)}
-	i++
-	fields[i] = wire.Field{ID: 6, Value: wire.NewValueDouble(v.DoubleField)}
 	i++
 	fields[i] = wire.Field{ID: 3, Value: wire.NewValueI16(v.Int16Field)}
 	i++
@@ -465,7 +461,11 @@ func (v *PrimitiveRequiredStruct) ToWire() wire.Value {
 	i++
 	fields[i] = wire.Field{ID: 5, Value: wire.NewValueI64(v.Int64Field)}
 	i++
+	fields[i] = wire.Field{ID: 6, Value: wire.NewValueDouble(v.DoubleField)}
+	i++
 	fields[i] = wire.Field{ID: 7, Value: wire.NewValueString(v.StringField)}
+	i++
+	fields[i] = wire.Field{ID: 8, Value: wire.NewValueBinary(v.BinaryField)}
 	i++
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
 }
@@ -473,13 +473,6 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	var err error
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
-		case 8:
-			if field.Value.Type() == wire.TBinary {
-				v.BinaryField, err = field.Value.GetBinary(), error(nil)
-				if err != nil {
-					return err
-				}
-			}
 		case 1:
 			if field.Value.Type() == wire.TBool {
 				v.BoolField, err = field.Value.GetBool(), error(nil)
@@ -490,13 +483,6 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 		case 2:
 			if field.Value.Type() == wire.TI8 {
 				v.ByteField, err = field.Value.GetI8(), error(nil)
-				if err != nil {
-					return err
-				}
-			}
-		case 6:
-			if field.Value.Type() == wire.TDouble {
-				v.DoubleField, err = field.Value.GetDouble(), error(nil)
 				if err != nil {
 					return err
 				}
@@ -522,9 +508,23 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 					return err
 				}
 			}
+		case 6:
+			if field.Value.Type() == wire.TDouble {
+				v.DoubleField, err = field.Value.GetDouble(), error(nil)
+				if err != nil {
+					return err
+				}
+			}
 		case 7:
 			if field.Value.Type() == wire.TBinary {
 				v.StringField, err = field.Value.GetString(), error(nil)
+				if err != nil {
+					return err
+				}
+			}
+		case 8:
+			if field.Value.Type() == wire.TBinary {
+				v.BinaryField, err = field.Value.GetBinary(), error(nil)
 				if err != nil {
 					return err
 				}
@@ -536,13 +536,9 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 func (v *PrimitiveRequiredStruct) String() string {
 	var fields [8]string
 	i := 0
-	fields[i] = fmt.Sprintf("BinaryField: %v", v.BinaryField)
-	i++
 	fields[i] = fmt.Sprintf("BoolField: %v", v.BoolField)
 	i++
 	fields[i] = fmt.Sprintf("ByteField: %v", v.ByteField)
-	i++
-	fields[i] = fmt.Sprintf("DoubleField: %v", v.DoubleField)
 	i++
 	fields[i] = fmt.Sprintf("Int16Field: %v", v.Int16Field)
 	i++
@@ -550,22 +546,26 @@ func (v *PrimitiveRequiredStruct) String() string {
 	i++
 	fields[i] = fmt.Sprintf("Int64Field: %v", v.Int64Field)
 	i++
+	fields[i] = fmt.Sprintf("DoubleField: %v", v.DoubleField)
+	i++
 	fields[i] = fmt.Sprintf("StringField: %v", v.StringField)
+	i++
+	fields[i] = fmt.Sprintf("BinaryField: %v", v.BinaryField)
 	i++
 	return fmt.Sprintf("PrimitiveRequiredStruct{%v}", strings.Join(fields[:i], ", "))
 }
 
 type Size struct {
-	Height float64
 	Width  float64
+	Height float64
 }
 
 func (v *Size) ToWire() wire.Value {
 	var fields [2]wire.Field
 	i := 0
-	fields[i] = wire.Field{ID: 2, Value: wire.NewValueDouble(v.Height)}
-	i++
 	fields[i] = wire.Field{ID: 1, Value: wire.NewValueDouble(v.Width)}
+	i++
+	fields[i] = wire.Field{ID: 2, Value: wire.NewValueDouble(v.Height)}
 	i++
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
 }
@@ -573,16 +573,16 @@ func (v *Size) FromWire(w wire.Value) error {
 	var err error
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
-		case 2:
+		case 1:
 			if field.Value.Type() == wire.TDouble {
-				v.Height, err = field.Value.GetDouble(), error(nil)
+				v.Width, err = field.Value.GetDouble(), error(nil)
 				if err != nil {
 					return err
 				}
 			}
-		case 1:
+		case 2:
 			if field.Value.Type() == wire.TDouble {
-				v.Width, err = field.Value.GetDouble(), error(nil)
+				v.Height, err = field.Value.GetDouble(), error(nil)
 				if err != nil {
 					return err
 				}
@@ -594,27 +594,27 @@ func (v *Size) FromWire(w wire.Value) error {
 func (v *Size) String() string {
 	var fields [2]string
 	i := 0
-	fields[i] = fmt.Sprintf("Height: %v", v.Height)
-	i++
 	fields[i] = fmt.Sprintf("Width: %v", v.Width)
+	i++
+	fields[i] = fmt.Sprintf("Height: %v", v.Height)
 	i++
 	return fmt.Sprintf("Size{%v}", strings.Join(fields[:i], ", "))
 }
 
 type User struct {
-	Contact *ContactInfo
 	Name    string
+	Contact *ContactInfo
 }
 
 func (v *User) ToWire() wire.Value {
 	var fields [2]wire.Field
 	i := 0
+	fields[i] = wire.Field{ID: 1, Value: wire.NewValueString(v.Name)}
+	i++
 	if v.Contact != nil {
 		fields[i] = wire.Field{ID: 2, Value: v.Contact.ToWire()}
 		i++
 	}
-	fields[i] = wire.Field{ID: 1, Value: wire.NewValueString(v.Name)}
-	i++
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
 }
 func _ContactInfo_Read(w wire.Value) (*ContactInfo, error) {
@@ -626,16 +626,16 @@ func (v *User) FromWire(w wire.Value) error {
 	var err error
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
-		case 2:
-			if field.Value.Type() == wire.TStruct {
-				v.Contact, err = _ContactInfo_Read(field.Value)
+		case 1:
+			if field.Value.Type() == wire.TBinary {
+				v.Name, err = field.Value.GetString(), error(nil)
 				if err != nil {
 					return err
 				}
 			}
-		case 1:
-			if field.Value.Type() == wire.TBinary {
-				v.Name, err = field.Value.GetString(), error(nil)
+		case 2:
+			if field.Value.Type() == wire.TStruct {
+				v.Contact, err = _ContactInfo_Read(field.Value)
 				if err != nil {
 					return err
 				}
@@ -647,11 +647,11 @@ func (v *User) FromWire(w wire.Value) error {
 func (v *User) String() string {
 	var fields [2]string
 	i := 0
+	fields[i] = fmt.Sprintf("Name: %v", v.Name)
+	i++
 	if v.Contact != nil {
 		fields[i] = fmt.Sprintf("Contact: %v", v.Contact)
 		i++
 	}
-	fields[i] = fmt.Sprintf("Name: %v", v.Name)
-	i++
 	return fmt.Sprintf("User{%v}", strings.Join(fields[:i], ", "))
 }

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -9,47 +9,47 @@ import (
 )
 
 type Event struct {
-	Time *Timestamp
 	UUID *UUID
+	Time *Timestamp
 }
 
 func (v *Event) ToWire() wire.Value {
 	var fields [2]wire.Field
 	i := 0
+	fields[i] = wire.Field{ID: 1, Value: v.UUID.ToWire()}
+	i++
 	if v.Time != nil {
 		fields[i] = wire.Field{ID: 2, Value: v.Time.ToWire()}
 		i++
 	}
-	fields[i] = wire.Field{ID: 1, Value: v.UUID.ToWire()}
-	i++
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
-}
-func _Timestamp_Read(w wire.Value) (Timestamp, error) {
-	var x Timestamp
-	err := x.FromWire(w)
-	return x, err
 }
 func _UUID_Read(w wire.Value) (*UUID, error) {
 	var x UUID
 	err := x.FromWire(w)
 	return &x, err
 }
+func _Timestamp_Read(w wire.Value) (Timestamp, error) {
+	var x Timestamp
+	err := x.FromWire(w)
+	return x, err
+}
 func (v *Event) FromWire(w wire.Value) error {
 	var err error
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
+		case 1:
+			if field.Value.Type() == wire.TStruct {
+				v.UUID, err = _UUID_Read(field.Value)
+				if err != nil {
+					return err
+				}
+			}
 		case 2:
 			if field.Value.Type() == wire.TI64 {
 				var x Timestamp
 				x, err = _Timestamp_Read(field.Value)
 				v.Time = &x
-				if err != nil {
-					return err
-				}
-			}
-		case 1:
-			if field.Value.Type() == wire.TStruct {
-				v.UUID, err = _UUID_Read(field.Value)
 				if err != nil {
 					return err
 				}
@@ -61,12 +61,12 @@ func (v *Event) FromWire(w wire.Value) error {
 func (v *Event) String() string {
 	var fields [2]string
 	i := 0
+	fields[i] = fmt.Sprintf("UUID: %v", v.UUID)
+	i++
 	if v.Time != nil {
 		fields[i] = fmt.Sprintf("Time: %v", *(v.Time))
 		i++
 	}
-	fields[i] = fmt.Sprintf("UUID: %v", v.UUID)
-	i++
 	return fmt.Sprintf("Event{%v}", strings.Join(fields[:i], ", "))
 }
 
@@ -154,31 +154,31 @@ func (v *Timestamp) FromWire(w wire.Value) error {
 }
 
 type Transition struct {
-	Events EventGroup
 	From   State
 	To     State
+	Events EventGroup
 }
 
 func (v *Transition) ToWire() wire.Value {
 	var fields [3]wire.Field
 	i := 0
-	if v.Events != nil {
-		fields[i] = wire.Field{ID: 3, Value: v.Events.ToWire()}
-		i++
-	}
 	fields[i] = wire.Field{ID: 1, Value: v.From.ToWire()}
 	i++
 	fields[i] = wire.Field{ID: 2, Value: v.To.ToWire()}
 	i++
+	if v.Events != nil {
+		fields[i] = wire.Field{ID: 3, Value: v.Events.ToWire()}
+		i++
+	}
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
-}
-func _EventGroup_Read(w wire.Value) (EventGroup, error) {
-	var x EventGroup
-	err := x.FromWire(w)
-	return x, err
 }
 func _State_Read(w wire.Value) (State, error) {
 	var x State
+	err := x.FromWire(w)
+	return x, err
+}
+func _EventGroup_Read(w wire.Value) (EventGroup, error) {
+	var x EventGroup
 	err := x.FromWire(w)
 	return x, err
 }
@@ -186,13 +186,6 @@ func (v *Transition) FromWire(w wire.Value) error {
 	var err error
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
-		case 3:
-			if field.Value.Type() == wire.TList {
-				v.Events, err = _EventGroup_Read(field.Value)
-				if err != nil {
-					return err
-				}
-			}
 		case 1:
 			if field.Value.Type() == wire.TBinary {
 				v.From, err = _State_Read(field.Value)
@@ -207,6 +200,13 @@ func (v *Transition) FromWire(w wire.Value) error {
 					return err
 				}
 			}
+		case 3:
+			if field.Value.Type() == wire.TList {
+				v.Events, err = _EventGroup_Read(field.Value)
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil
@@ -214,14 +214,14 @@ func (v *Transition) FromWire(w wire.Value) error {
 func (v *Transition) String() string {
 	var fields [3]string
 	i := 0
-	if v.Events != nil {
-		fields[i] = fmt.Sprintf("Events: %v", v.Events)
-		i++
-	}
 	fields[i] = fmt.Sprintf("From: %v", v.From)
 	i++
 	fields[i] = fmt.Sprintf("To: %v", v.To)
 	i++
+	if v.Events != nil {
+		fields[i] = fmt.Sprintf("Events: %v", v.Events)
+		i++
+	}
 	return fmt.Sprintf("Transition{%v}", strings.Join(fields[:i], ", "))
 }
 

--- a/gen/testdata/unions/types.go
+++ b/gen/testdata/unions/types.go
@@ -12,9 +12,9 @@ import (
 type ArbitraryValue struct {
 	BoolValue   *bool
 	Int64Value  *int64
+	StringValue *string
 	ListValue   []*ArbitraryValue
 	MapValue    map[string]*ArbitraryValue
-	StringValue *string
 }
 type _List_ArbitraryValue_ValueList []*ArbitraryValue
 
@@ -54,16 +54,16 @@ func (v *ArbitraryValue) ToWire() wire.Value {
 		fields[i] = wire.Field{ID: 2, Value: wire.NewValueI64(*(v.Int64Value))}
 		i++
 	}
+	if v.StringValue != nil {
+		fields[i] = wire.Field{ID: 3, Value: wire.NewValueString(*(v.StringValue))}
+		i++
+	}
 	if v.ListValue != nil {
 		fields[i] = wire.Field{ID: 4, Value: wire.NewValueList(wire.List{ValueType: wire.TStruct, Size: len(v.ListValue), Items: _List_ArbitraryValue_ValueList(v.ListValue)})}
 		i++
 	}
 	if v.MapValue != nil {
 		fields[i] = wire.Field{ID: 5, Value: wire.NewValueMap(wire.Map{KeyType: wire.TBinary, ValueType: wire.TStruct, Size: len(v.MapValue), Items: _Map_String_ArbitraryValue_MapItemList(v.MapValue)})}
-		i++
-	}
-	if v.StringValue != nil {
-		fields[i] = wire.Field{ID: 3, Value: wire.NewValueString(*(v.StringValue))}
 		i++
 	}
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
@@ -134,6 +134,15 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 					return err
 				}
 			}
+		case 3:
+			if field.Value.Type() == wire.TBinary {
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.StringValue = &x
+				if err != nil {
+					return err
+				}
+			}
 		case 4:
 			if field.Value.Type() == wire.TList {
 				v.ListValue, err = _List_ArbitraryValue_Read(field.Value.GetList())
@@ -144,15 +153,6 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 		case 5:
 			if field.Value.Type() == wire.TMap {
 				v.MapValue, err = _Map_String_ArbitraryValue_Read(field.Value.GetMap())
-				if err != nil {
-					return err
-				}
-			}
-		case 3:
-			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.StringValue = &x
 				if err != nil {
 					return err
 				}
@@ -172,16 +172,16 @@ func (v *ArbitraryValue) String() string {
 		fields[i] = fmt.Sprintf("Int64Value: %v", *(v.Int64Value))
 		i++
 	}
+	if v.StringValue != nil {
+		fields[i] = fmt.Sprintf("StringValue: %v", *(v.StringValue))
+		i++
+	}
 	if v.ListValue != nil {
 		fields[i] = fmt.Sprintf("ListValue: %v", v.ListValue)
 		i++
 	}
 	if v.MapValue != nil {
 		fields[i] = fmt.Sprintf("MapValue: %v", v.MapValue)
-		i++
-	}
-	if v.StringValue != nil {
-		fields[i] = fmt.Sprintf("StringValue: %v", *(v.StringValue))
 		i++
 	}
 	return fmt.Sprintf("ArbitraryValue{%v}", strings.Join(fields[:i], ", "))


### PR DESCRIPTION
Instead of using `map[string]*FieldSpec`, use a `[]*FieldSpec` so that we
maintain field order when generating code. This is especially required for
method parameters.