### PR TITLE
FunctionSpec.ResultSpec should always be set

### DIFF
--- a/compile/service.go
+++ b/compile/service.go
@@ -230,21 +230,22 @@ type ResultSpec struct {
 }
 
 func compileResultSpec(returnType ast.Type, exceptions []*ast.Field) (*ResultSpec, error) {
-	if len(exceptions) == 0 && returnType == nil {
-		// No result
-		return nil, nil
+	var excFields FieldGroup
+
+	if len(exceptions) > 0 {
+		var err error
+		excFields, err = compileFields(
+			exceptions,
+			fieldOptions{
+				requiredness:         noRequiredFields,
+				disallowDefaultValue: true,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	excFields, err := compileFields(
-		exceptions,
-		fieldOptions{
-			requiredness:         noRequiredFields,
-			disallowDefaultValue: true,
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
 	return &ResultSpec{
 		ReturnType: compileTypeReference(returnType),
 		Exceptions: excFields,

--- a/compile/service_test.go
+++ b/compile/service_test.go
@@ -77,6 +77,7 @@ func TestCompileService(t *testing.T) {
 						Type: BinarySpec,
 					},
 				},
+				ResultSpec: &ResultSpec{},
 			},
 			"getValue": {
 				Name: "getValue",
@@ -165,6 +166,7 @@ func TestCompileService(t *testing.T) {
 								},
 							},
 						},
+						ResultSpec: &ResultSpec{},
 					},
 				},
 			},


### PR DESCRIPTION
@prashantv 
