### PR TITLE
Make service function helpers top-level functions

### DIFF
--- a/gen/testdata/services/keyvalue/deletevalue.go
+++ b/gen/testdata/services/keyvalue/deletevalue.go
@@ -116,49 +116,39 @@ func (v *DeleteValueResult) String() string {
 	}
 	return fmt.Sprintf("DeleteValueResult{%v}", strings.Join(fields[:i], ", "))
 }
-
-var DeleteValue = struct {
-	IsException    func(error) bool
-	Args           func(key *services.Key) *DeleteValueArgs
-	WrapResponse   func(error) (*DeleteValueResult, error)
-	UnwrapResponse func(*DeleteValueResult) error
-}{}
-
-func init() {
-	DeleteValue.IsException = func(err error) bool {
-		switch err.(type) {
-		case *exceptions.DoesNotExistException:
-			return true
-		case *services.InternalError:
-			return true
-		default:
-			return false
-		}
+func IsDeleteValueException(err error) bool {
+	switch err.(type) {
+	case *exceptions.DoesNotExistException:
+		return true
+	case *services.InternalError:
+		return true
+	default:
+		return false
 	}
-	DeleteValue.Args = func(key *services.Key) *DeleteValueArgs {
-		return &DeleteValueArgs{Key: key}
+}
+func MakeDeleteValueArgs(key *services.Key) *DeleteValueArgs {
+	return &DeleteValueArgs{Key: key}
+}
+func WrapDeleteValueResponse(err error) (*DeleteValueResult, error) {
+	if err == nil {
+		return &DeleteValueResult{}, nil
 	}
-	DeleteValue.WrapResponse = func(err error) (*DeleteValueResult, error) {
-		if err == nil {
-			return &DeleteValueResult{}, nil
-		}
-		switch e := err.(type) {
-		case *exceptions.DoesNotExistException:
-			return &DeleteValueResult{DoesNotExist: e}, nil
-		case *services.InternalError:
-			return &DeleteValueResult{InternalError: e}, nil
-		}
-		return nil, err
+	switch e := err.(type) {
+	case *exceptions.DoesNotExistException:
+		return &DeleteValueResult{DoesNotExist: e}, nil
+	case *services.InternalError:
+		return &DeleteValueResult{InternalError: e}, nil
 	}
-	DeleteValue.UnwrapResponse = func(result *DeleteValueResult) (err error) {
-		if result.DoesNotExist != nil {
-			err = result.DoesNotExist
-			return
-		}
-		if result.InternalError != nil {
-			err = result.InternalError
-			return
-		}
+	return nil, err
+}
+func UnwrapDeleteValueResponse(result *DeleteValueResult) (err error) {
+	if result.DoesNotExist != nil {
+		err = result.DoesNotExist
 		return
 	}
+	if result.InternalError != nil {
+		err = result.InternalError
+		return
+	}
+	return
 }

--- a/gen/testdata/services/keyvalue/setvalue.go
+++ b/gen/testdata/services/keyvalue/setvalue.go
@@ -85,31 +85,21 @@ func (v *SetValueResult) String() string {
 	i := 0
 	return fmt.Sprintf("SetValueResult{%v}", strings.Join(fields[:i], ", "))
 }
-
-var SetValue = struct {
-	IsException    func(error) bool
-	Args           func(key *services.Key, value *unions.ArbitraryValue) *SetValueArgs
-	WrapResponse   func(error) (*SetValueResult, error)
-	UnwrapResponse func(*SetValueResult) error
-}{}
-
-func init() {
-	SetValue.IsException = func(err error) bool {
-		switch err.(type) {
-		default:
-			return false
-		}
+func IsSetValueException(err error) bool {
+	switch err.(type) {
+	default:
+		return false
 	}
-	SetValue.Args = func(key *services.Key, value *unions.ArbitraryValue) *SetValueArgs {
-		return &SetValueArgs{Key: key, Value: value}
+}
+func MakeSetValueArgs(key *services.Key, value *unions.ArbitraryValue) *SetValueArgs {
+	return &SetValueArgs{Key: key, Value: value}
+}
+func WrapSetValueResponse(err error) (*SetValueResult, error) {
+	if err == nil {
+		return &SetValueResult{}, nil
 	}
-	SetValue.WrapResponse = func(err error) (*SetValueResult, error) {
-		if err == nil {
-			return &SetValueResult{}, nil
-		}
-		return nil, err
-	}
-	SetValue.UnwrapResponse = func(result *SetValueResult) (err error) {
-		return
-	}
+	return nil, err
+}
+func UnwrapSetValueResponse(result *SetValueResult) (err error) {
+	return
 }


### PR DESCRIPTION
This takes away the possibility of name clashes with method names.

Other options:

- Prepend/append something to the helper name. Like, `GetValueHelper`, `SetValueHelper`. (Open to better names than `Helper`.)

- Create a top-level object to hold the helper structs:

        var Helper = struct{
            GetValue struct{
                IsException func(..)
                // ...
            }
            SetValue struct{
                // ...
            }
        }

        keyvalue.Helper.GetValue.Args(...)