### PR TITLE
Abstract filesystem access from compiler into an interface that can be overriden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PACKAGES := $(shell glide novendor)
 
 .PHONY: build
 build:
-	go build
+	go build -i
 
 .PHONY: test
 test: build

--- a/compile/compiler_test.go
+++ b/compile/compiler_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package compile
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thriftrw/thriftrw-go/wire"
+)
+
+type dummyFS struct {
+	prefix string
+	files  map[string]string
+}
+
+func (fs dummyFS) Abs(p string) (string, error) {
+	if strings.HasPrefix(p, "/") {
+		return p, nil
+	}
+	return fs.prefix + p, nil
+}
+
+func (fs dummyFS) Read(path string) ([]byte, error) {
+	if contents, ok := fs.files[path]; ok {
+		return []byte(contents), nil
+	}
+
+	return nil, fmt.Errorf("file not found: %v", path)
+}
+
+func TestFilesystem(t *testing.T) {
+	files := map[string]string{
+		"/some/prefix/main.thrift": `
+			include "./shared/shared.thrift"
+
+			struct S {
+				1: optional shared.UUID uuid;
+			}
+		`,
+		"/some/prefix/shared/shared.thrift": `
+			typedef string UUID;
+		`,
+	}
+
+	fs := dummyFS{"/some/prefix/", files}
+
+	module, err := Compile("main.thrift", Filesystem(fs))
+	require.NoError(t, err, "Compile failed")
+
+	sType, err := module.LookupType("S")
+	require.NoError(t, err, "Lookup S failed")
+	require.NotNil(t, sType, "Type S is nil")
+	assert.Equal(t, wire.TStruct, sType.TypeCode(), "Type mismatch")
+}
+
+func TestCompile(t *testing.T) {
+	module, err := Compile("../gen/testdata/thrift/services.thrift")
+	require.NoError(t, err, "Compile failed")
+
+	kvSvc, err := module.LookupService("KeyValue")
+	require.NoError(t, err, "Lookup KeyValue failed")
+	require.NotNil(t, kvSvc, "KeyValue service is nil")
+}

--- a/compile/doc.go
+++ b/compile/doc.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package compile provides specifications for the types and services defined
+// in a Thrift file.
+//
+// Files are parsed using the Compile method, which will return a Module that
+// contains the types and services defined in the Thrift file.
+package compile

--- a/compile/options.go
+++ b/compile/options.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package compile
+
+import (
+	"io/ioutil"
+	"path/filepath"
+)
+
+// Option represents a compiler option.
+type Option func(*compiler)
+
+// FS is used by the compiler to interact with the filesystem.
+type FS interface {
+	// Read reads the file named by filename and returns the contents.
+	// See: https://golang.org/pkg/io/ioutil/#ReadFile
+	Read(filename string) ([]byte, error)
+	// Abs returns an absolute representation of path.
+	// See: https://golang.org/pkg/path/filepath/#Abs
+	Abs(p string) (string, error)
+}
+
+type realFS struct{}
+
+func (realFS) Read(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename)
+}
+
+func (realFS) Abs(p string) (string, error) {
+	return filepath.Abs(p)
+}
+
+// Filesystem controls how the Thrift compiler accesses the filesystem.
+func Filesystem(fs FS) Option {
+	return func(c *compiler) {
+		c.fs = fs
+	}
+}


### PR DESCRIPTION
This allows callers of `Compile` to specify an alternate filesystem interface that can read from other sources (e.g. directly from memory).