### PR TITLE
Add json:".." tags to generated structs

### DIFF
--- a/gen/field.go
+++ b/gen/field.go
@@ -65,15 +65,16 @@ func (f fieldGroupGenerator) DefineStruct(g Generator) error {
 		}`,
 		f,
 		TemplateFunc("tag", func(f *compile.FieldSpec) string {
-			// We want to add omitempty if the field is a struct or if it's an
-			// optional primitive so that we don't have "null" noise in the
-			// output. Note that binary is not a primitive.
+			// We want to add omitempty if the field is an optional struct or
+			// primitive to redure "null" noise. We won't add omitempty for
+			// optional collections because omitempty doesn't differentiate
+			// between nil and empty collections.
 
-			if isStructType(f.Type) || (isPrimitiveType(f.Type) && !f.Required) {
+			if (isStructType(f.Type) || isPrimitiveType(f.Type)) && !f.Required {
 				return fmt.Sprintf("`json:\"%s,omitempty\"`", f.Name)
 			}
 
-			return fmt.Sprintf("`json:\"%s\"`", f.Name)
+			return fmt.Sprintf("`json:%q`", f.Name)
 			// TODO(abg): Take go.tag and js.name annotations into account
 		}),
 	)

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -687,6 +687,17 @@ func TestStructJSON(t *testing.T) {
 	}{
 		{&ts.Point{X: 0, Y: 0}, `{"x":0,"y":0}`},
 		{&ts.Point{X: 1, Y: 2}, `{"x":1,"y":2}`},
+		{
+			&ts.Edge{
+				Start: &ts.Point{X: 1, Y: 2},
+				End:   &ts.Point{X: 3, Y: 4},
+			},
+			`{"start":{"x":1,"y":2},"end":{"x":3,"y":4}}`,
+		},
+		{
+			&ts.Edge{Start: &ts.Point{X: 1, Y: 1}},
+			`{"start":{"x":1,"y":1},"end":null}`,
+		},
 		{&ts.User{Name: ""}, `{"name":""}`},
 		{&ts.User{Name: "foo"}, `{"name":"foo"}`},
 		{

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -21,7 +21,9 @@
 package gen
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	tc "github.com/thriftrw/thriftrw-go/gen/testdata/containers"
@@ -675,5 +677,99 @@ func TestEmptyException(t *testing.T) {
 	assert.Equal(t, x.ToWire(), v)
 	if assert.NoError(t, y.FromWire(v)) {
 		assert.Equal(t, x, y)
+	}
+}
+
+func TestStructJSON(t *testing.T) {
+	tests := []struct {
+		v interface{}
+		j string
+	}{
+		{&ts.Point{X: 0, Y: 0}, `{"x":0,"y":0}`},
+		{&ts.Point{X: 1, Y: 2}, `{"x":1,"y":2}`},
+		{&ts.User{Name: ""}, `{"name":""}`},
+		{&ts.User{Name: "foo"}, `{"name":"foo"}`},
+		{
+			&ts.User{
+				Name:    "foo",
+				Contact: &ts.ContactInfo{EmailAddress: "bar@example.com"},
+			},
+			`{"name":"foo","contact":{"emailAddress":"bar@example.com"}}`,
+		},
+		{
+			&ts.User{
+				Name:    "foo",
+				Contact: &ts.ContactInfo{EmailAddress: ""},
+			},
+			`{"name":"foo","contact":{"emailAddress":""}}`,
+		},
+		{&tu.EmptyUnion{}, "{}"},
+		{&tu.Document{Pdf: td.Pdf("hello")}, `{"pdf":"aGVsbG8="}`},
+		{&tu.Document{Pdf: td.Pdf{}}, `{"pdf":""}`},
+		{
+			&tu.Document{PlainText: stringp("hello")},
+			`{"pdf":null,"plainText":"hello"}`,
+		},
+		{&tu.Document{PlainText: stringp("")}, `{"pdf":null,"plainText":""}`},
+		{
+			&tu.ArbitraryValue{BoolValue: boolp(true)},
+			`{"boolValue":true,"listValue":null,"mapValue":null}`,
+		},
+		{
+			&tu.ArbitraryValue{BoolValue: boolp(false)},
+			`{"boolValue":false,"listValue":null,"mapValue":null}`,
+		},
+		{
+			&tu.ArbitraryValue{Int64Value: int64p(42)},
+			`{"int64Value":42,"listValue":null,"mapValue":null}`,
+		},
+		{
+			&tu.ArbitraryValue{Int64Value: int64p(0)},
+			`{"int64Value":0,"listValue":null,"mapValue":null}`,
+		},
+		{
+			&tu.ArbitraryValue{StringValue: stringp("foo")},
+			`{"stringValue":"foo","listValue":null,"mapValue":null}`,
+		},
+		{
+			&tu.ArbitraryValue{StringValue: stringp("")},
+			`{"stringValue":"","listValue":null,"mapValue":null}`,
+		},
+		{
+			&tu.ArbitraryValue{ListValue: []*tu.ArbitraryValue{
+				{BoolValue: boolp(true)},
+				{Int64Value: int64p(42)},
+				{StringValue: stringp("foo")},
+			}},
+			`{"listValue":[` +
+				`{"boolValue":true,"listValue":null,"mapValue":null},` +
+				`{"int64Value":42,"listValue":null,"mapValue":null},` +
+				`{"stringValue":"foo","listValue":null,"mapValue":null}` +
+				`],"mapValue":null}`,
+		},
+		{
+			&tu.ArbitraryValue{MapValue: map[string]*tu.ArbitraryValue{
+				"bool":   {BoolValue: boolp(true)},
+				"int64":  {Int64Value: int64p(42)},
+				"string": {StringValue: stringp("foo")},
+			}},
+			`{"listValue":null,"mapValue":{` +
+				`"bool":{"boolValue":true,"listValue":null,"mapValue":null},` +
+				`"int64":{"int64Value":42,"listValue":null,"mapValue":null},` +
+				`"string":{"stringValue":"foo","listValue":null,"mapValue":null}` +
+				`}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		encoded, err := json.Marshal(tt.v)
+		if assert.NoError(t, err, "failed to JSON encode %v", tt.v) {
+			assert.Equal(t, tt.j, string(encoded))
+		}
+
+		v := reflect.New(reflect.TypeOf(tt.v).Elem()).Interface()
+		if assert.NoError(t, json.Unmarshal([]byte(tt.j), v), "failed to decode %q", tt.j) {
+			assert.Equal(t, tt.v, v)
+		}
 	}
 }

--- a/gen/testdata/containers/types.go
+++ b/gen/testdata/containers/types.go
@@ -10,9 +10,9 @@ import (
 )
 
 type EnumContainers struct {
-	ListOfEnums []enums.EnumDefault
-	SetOfEnums  map[enums.EnumWithValues]struct{}
-	MapOfEnums  map[enums.EnumWithDuplicateValues]int32
+	ListOfEnums []enums.EnumDefault                     `json:"listOfEnums"`
+	SetOfEnums  map[enums.EnumWithValues]struct{}       `json:"setOfEnums"`
+	MapOfEnums  map[enums.EnumWithDuplicateValues]int32 `json:"mapOfEnums"`
 }
 
 type _List_EnumDefault_ValueList []enums.EnumDefault
@@ -203,12 +203,12 @@ func (v *EnumContainers) String() string {
 }
 
 type PrimitiveContainers struct {
-	ListOfBinary      [][]byte
-	ListOfInts        []int64
-	SetOfStrings      map[string]struct{}
-	SetOfBytes        map[int8]struct{}
-	MapOfIntToString  map[int32]string
-	MapOfStringToBool map[string]bool
+	ListOfBinary      [][]byte            `json:"listOfBinary"`
+	ListOfInts        []int64             `json:"listOfInts"`
+	SetOfStrings      map[string]struct{} `json:"setOfStrings"`
+	SetOfBytes        map[int8]struct{}   `json:"setOfBytes"`
+	MapOfIntToString  map[int32]string    `json:"mapOfIntToString"`
+	MapOfStringToBool map[string]bool     `json:"mapOfStringToBool"`
 }
 
 type _List_Binary_ValueList [][]byte
@@ -529,9 +529,9 @@ func (v *PrimitiveContainers) String() string {
 }
 
 type PrimitiveContainersRequired struct {
-	ListOfStrings      []string
-	SetOfInts          map[int32]struct{}
-	MapOfIntsToDoubles map[int64]float64
+	ListOfStrings      []string           `json:"listOfStrings"`
+	SetOfInts          map[int32]struct{} `json:"setOfInts"`
+	MapOfIntsToDoubles map[int64]float64  `json:"mapOfIntsToDoubles"`
 }
 
 type _List_String_ValueList []string

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -95,7 +95,9 @@ func (v *EnumWithValues) FromWire(w wire.Value) error {
 	return nil
 }
 
-type StructWithOptionalEnum struct{ E *EnumDefault }
+type StructWithOptionalEnum struct {
+	E *EnumDefault `json:"e,omitempty"`
+}
 
 func (v *StructWithOptionalEnum) ToWire() wire.Value {
 	var fields [1]wire.Field

--- a/gen/testdata/exceptions/types.go
+++ b/gen/testdata/exceptions/types.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 )
 
-type DoesNotExistException struct{ Key string }
+type DoesNotExistException struct {
+	Key string `json:"key"`
+}
 
 func (v *DoesNotExistException) ToWire() wire.Value {
 	var fields [1]wire.Field

--- a/gen/testdata/services/service/keyvalue/deletevalue.go
+++ b/gen/testdata/services/service/keyvalue/deletevalue.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 )
 
-type DeleteValueArgs struct{ Key *services.Key }
+type DeleteValueArgs struct {
+	Key *services.Key `json:"key,omitempty"`
+}
 
 func (v *DeleteValueArgs) ToWire() wire.Value {
 	var fields [1]wire.Field
@@ -58,8 +60,8 @@ func (v *DeleteValueArgs) String() string {
 }
 
 type DeleteValueResult struct {
-	DoesNotExist  *exceptions.DoesNotExistException
-	InternalError *services.InternalError
+	DoesNotExist  *exceptions.DoesNotExistException `json:"doesNotExist,omitempty"`
+	InternalError *services.InternalError           `json:"internalError,omitempty"`
 }
 
 func (v *DeleteValueResult) ToWire() wire.Value {

--- a/gen/testdata/services/service/keyvalue/getmanyvalues.go
+++ b/gen/testdata/services/service/keyvalue/getmanyvalues.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 )
 
-type GetManyValuesArgs struct{ Range []services.Key }
+type GetManyValuesArgs struct {
+	Range []services.Key `json:"range"`
+}
 
 type _List_Key_ValueList []services.Key
 
@@ -83,8 +85,8 @@ func (v *GetManyValuesArgs) String() string {
 }
 
 type GetManyValuesResult struct {
-	Success      []*unions.ArbitraryValue
-	DoesNotExist *exceptions.DoesNotExistException
+	Success      []*unions.ArbitraryValue          `json:"success"`
+	DoesNotExist *exceptions.DoesNotExistException `json:"doesNotExist,omitempty"`
 }
 
 type _List_ArbitraryValue_ValueList []*unions.ArbitraryValue

--- a/gen/testdata/services/service/keyvalue/getvalue.go
+++ b/gen/testdata/services/service/keyvalue/getvalue.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 )
 
-type GetValueArgs struct{ Key *services.Key }
+type GetValueArgs struct {
+	Key *services.Key `json:"key,omitempty"`
+}
 
 func (v *GetValueArgs) ToWire() wire.Value {
 	var fields [1]wire.Field
@@ -53,8 +55,8 @@ func (v *GetValueArgs) String() string {
 }
 
 type GetValueResult struct {
-	Success      *unions.ArbitraryValue
-	DoesNotExist *exceptions.DoesNotExistException
+	Success      *unions.ArbitraryValue            `json:"success,omitempty"`
+	DoesNotExist *exceptions.DoesNotExistException `json:"doesNotExist,omitempty"`
 }
 
 func (v *GetValueResult) ToWire() wire.Value {

--- a/gen/testdata/services/service/keyvalue/setvalue.go
+++ b/gen/testdata/services/service/keyvalue/setvalue.go
@@ -11,8 +11,8 @@ import (
 )
 
 type SetValueArgs struct {
-	Key   *services.Key
-	Value *unions.ArbitraryValue
+	Key   *services.Key          `json:"key,omitempty"`
+	Value *unions.ArbitraryValue `json:"value,omitempty"`
 }
 
 func (v *SetValueArgs) ToWire() wire.Value {

--- a/gen/testdata/services/service/keyvalue/size.go
+++ b/gen/testdata/services/service/keyvalue/size.go
@@ -31,7 +31,9 @@ func (v *SizeArgs) String() string {
 	return fmt.Sprintf("SizeArgs{%v}", strings.Join(fields[:i], ", "))
 }
 
-type SizeResult struct{ Success *int64 }
+type SizeResult struct {
+	Success *int64 `json:"success,omitempty"`
+}
 
 func (v *SizeResult) ToWire() wire.Value {
 	var fields [1]wire.Field

--- a/gen/testdata/services/types.go
+++ b/gen/testdata/services/types.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 )
 
-type InternalError struct{ Message *string }
+type InternalError struct {
+	Message *string `json:"message,omitempty"`
+}
 
 func (v *InternalError) ToWire() wire.Value {
 	var fields [1]wire.Field

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 )
 
-type ContactInfo struct{ EmailAddress string }
+type ContactInfo struct {
+	EmailAddress string `json:"emailAddress"`
+}
 
 func (v *ContactInfo) ToWire() wire.Value {
 	var fields [1]wire.Field
@@ -43,8 +45,8 @@ func (v *ContactInfo) String() string {
 }
 
 type Edge struct {
-	Start *Point
-	End   *Point
+	Start *Point `json:"start,omitempty"`
+	End   *Point `json:"end,omitempty"`
 }
 
 func (v *Edge) ToWire() wire.Value {
@@ -119,8 +121,8 @@ func (v *EmptyStruct) String() string {
 }
 
 type Frame struct {
-	TopLeft *Point
-	Size    *Size
+	TopLeft *Point `json:"topLeft,omitempty"`
+	Size    *Size  `json:"size,omitempty"`
 }
 
 func (v *Frame) ToWire() wire.Value {
@@ -172,7 +174,9 @@ func (v *Frame) String() string {
 	return fmt.Sprintf("Frame{%v}", strings.Join(fields[:i], ", "))
 }
 
-type Graph struct{ Edges []*Edge }
+type Graph struct {
+	Edges []*Edge `json:"edges"`
+}
 
 type _List_Edge_ValueList []*Edge
 
@@ -245,8 +249,8 @@ func (v *Graph) String() string {
 }
 
 type Point struct {
-	X float64
-	Y float64
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
 }
 
 func (v *Point) ToWire() wire.Value {
@@ -293,14 +297,14 @@ func (v *Point) String() string {
 }
 
 type PrimitiveOptionalStruct struct {
-	BoolField   *bool
-	ByteField   *int8
-	Int16Field  *int16
-	Int32Field  *int32
-	Int64Field  *int64
-	DoubleField *float64
-	StringField *string
-	BinaryField []byte
+	BoolField   *bool    `json:"boolField,omitempty"`
+	ByteField   *int8    `json:"byteField,omitempty"`
+	Int16Field  *int16   `json:"int16Field,omitempty"`
+	Int32Field  *int32   `json:"int32Field,omitempty"`
+	Int64Field  *int64   `json:"int64Field,omitempty"`
+	DoubleField *float64 `json:"doubleField,omitempty"`
+	StringField *string  `json:"stringField,omitempty"`
+	BinaryField []byte   `json:"binaryField"`
 }
 
 func (v *PrimitiveOptionalStruct) ToWire() wire.Value {
@@ -459,14 +463,14 @@ func (v *PrimitiveOptionalStruct) String() string {
 }
 
 type PrimitiveRequiredStruct struct {
-	BoolField   bool
-	ByteField   int8
-	Int16Field  int16
-	Int32Field  int32
-	Int64Field  int64
-	DoubleField float64
-	StringField string
-	BinaryField []byte
+	BoolField   bool    `json:"boolField"`
+	ByteField   int8    `json:"byteField"`
+	Int16Field  int16   `json:"int16Field"`
+	Int32Field  int32   `json:"int32Field"`
+	Int64Field  int64   `json:"int64Field"`
+	DoubleField float64 `json:"doubleField"`
+	StringField string  `json:"stringField"`
+	BinaryField []byte  `json:"binaryField"`
 }
 
 func (v *PrimitiveRequiredStruct) ToWire() wire.Value {
@@ -579,8 +583,8 @@ func (v *PrimitiveRequiredStruct) String() string {
 }
 
 type Size struct {
-	Width  float64
-	Height float64
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
 }
 
 func (v *Size) ToWire() wire.Value {
@@ -627,8 +631,8 @@ func (v *Size) String() string {
 }
 
 type User struct {
-	Name    string
-	Contact *ContactInfo
+	Name    string       `json:"name"`
+	Contact *ContactInfo `json:"contact,omitempty"`
 }
 
 func (v *User) ToWire() wire.Value {

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -45,8 +45,8 @@ func (v *ContactInfo) String() string {
 }
 
 type Edge struct {
-	Start *Point `json:"start,omitempty"`
-	End   *Point `json:"end,omitempty"`
+	Start *Point `json:"start"`
+	End   *Point `json:"end"`
 }
 
 func (v *Edge) ToWire() wire.Value {
@@ -121,8 +121,8 @@ func (v *EmptyStruct) String() string {
 }
 
 type Frame struct {
-	TopLeft *Point `json:"topLeft,omitempty"`
-	Size    *Size  `json:"size,omitempty"`
+	TopLeft *Point `json:"topLeft"`
+	Size    *Size  `json:"size"`
 }
 
 func (v *Frame) ToWire() wire.Value {

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Event struct {
-	UUID *UUID      `json:"uuid,omitempty"`
+	UUID *UUID      `json:"uuid"`
 	Time *Timestamp `json:"time,omitempty"`
 }
 

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Event struct {
-	UUID *UUID
-	Time *Timestamp
+	UUID *UUID      `json:"uuid,omitempty"`
+	Time *Timestamp `json:"time,omitempty"`
 }
 
 func (v *Event) ToWire() wire.Value {
@@ -165,9 +165,9 @@ func (v *Timestamp) FromWire(w wire.Value) error {
 }
 
 type Transition struct {
-	From   State
-	To     State
-	Events EventGroup
+	From   State      `json:"from"`
+	To     State      `json:"to"`
+	Events EventGroup `json:"events"`
 }
 
 func (v *Transition) ToWire() wire.Value {
@@ -252,8 +252,8 @@ func (v *UUID) FromWire(w wire.Value) error {
 }
 
 type I128 struct {
-	High int64
-	Low  int64
+	High int64 `json:"high"`
+	Low  int64 `json:"low"`
 }
 
 func (v *I128) ToWire() wire.Value {

--- a/gen/testdata/unions/types.go
+++ b/gen/testdata/unions/types.go
@@ -10,11 +10,11 @@ import (
 )
 
 type ArbitraryValue struct {
-	BoolValue   *bool
-	Int64Value  *int64
-	StringValue *string
-	ListValue   []*ArbitraryValue
-	MapValue    map[string]*ArbitraryValue
+	BoolValue   *bool                      `json:"boolValue,omitempty"`
+	Int64Value  *int64                     `json:"int64Value,omitempty"`
+	StringValue *string                    `json:"stringValue,omitempty"`
+	ListValue   []*ArbitraryValue          `json:"listValue"`
+	MapValue    map[string]*ArbitraryValue `json:"mapValue"`
 }
 
 type _List_ArbitraryValue_ValueList []*ArbitraryValue
@@ -197,8 +197,8 @@ func (v *ArbitraryValue) String() string {
 }
 
 type Document struct {
-	Pdf       typedefs.Pdf
-	PlainText *string
+	Pdf       typedefs.Pdf `json:"pdf"`
+	PlainText *string      `json:"plainText,omitempty"`
 }
 
 func (v *Document) ToWire() wire.Value {


### PR DESCRIPTION
An `omitempty` is added if the field is a pointer to a struct or an optional primitive.

Resolves https://github.com/thriftrw/thriftrw-go/issues/77