### PR TITLE
Don't count vendored code in coverage.

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -24,6 +24,7 @@ for pkg in "$@"; do
 	coverpkg=$(go list -json "$pkg" | jq -r '
 		.Deps
 		| map(select(startswith("'"$ROOT_PKG"'")))
+		| map(select(contains("/vendor/") | not))
 		| . + ["'"$pkg"'"]
 		| join(",")
 	')


### PR DESCRIPTION
This wasn't a problem for thriftrw so far because we only have test
dependencies vendored right now.

@prashantv 