### PR TITLE
Support for unhashable types

### DIFF
--- a/gen/container_test.go
+++ b/gen/container_test.go
@@ -415,12 +415,12 @@ func TestCrazyTown(t *testing.T) {
 			"ListOfSets",
 			tc.ContainersOfContainers{
 				ListOfSets: []map[int32]struct{}{
-					map[int32]struct{}{
+					{
 						1: struct{}{},
 						2: struct{}{},
 						3: struct{}{},
 					},
-					map[int32]struct{}{
+					{
 						4: struct{}{},
 						5: struct{}{},
 						6: struct{}{},
@@ -458,12 +458,12 @@ func TestCrazyTown(t *testing.T) {
 			"ListOfMaps",
 			tc.ContainersOfContainers{
 				ListOfMaps: []map[int32]int32{
-					map[int32]int32{
+					{
 						1: 100,
 						2: 200,
 						3: 300,
 					},
-					map[int32]int32{
+					{
 						4: 400,
 						5: 500,
 						6: 600,
@@ -503,12 +503,12 @@ func TestCrazyTown(t *testing.T) {
 			"SetOfSets",
 			tc.ContainersOfContainers{
 				SetOfSets: []map[string]struct{}{
-					map[string]struct{}{
+					{
 						"1": struct{}{},
 						"2": struct{}{},
 						"3": struct{}{},
 					},
-					map[string]struct{}{
+					{
 						"4": struct{}{},
 						"5": struct{}{},
 						"6": struct{}{},
@@ -581,12 +581,12 @@ func TestCrazyTown(t *testing.T) {
 			"SetOfMaps",
 			tc.ContainersOfContainers{
 				SetOfMaps: []map[string]string{
-					map[string]string{
+					{
 						"1": "one",
 						"2": "two",
 						"3": "three",
 					},
-					map[string]string{
+					{
 						"4": "four",
 						"5": "five",
 						"6": "six",

--- a/gen/container_test.go
+++ b/gen/container_test.go
@@ -369,3 +369,465 @@ func TestListOfStructs(t *testing.T) {
 		assertRoundTrip(t, &tt.s, tt.v, "Graph")
 	}
 }
+
+func TestCrazyTown(t *testing.T) {
+	tests := []struct {
+		desc string
+		x    tc.ContainersOfContainers
+		v    wire.Value
+	}{
+		{
+			"ListOfLists",
+			tc.ContainersOfContainers{
+				ListOfLists: [][]int32{
+					{1, 2, 3},
+					{4, 5, 6},
+				},
+			},
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 1, Value: wire.NewValueList(wire.List{
+					ValueType: wire.TList,
+					Size:      2,
+					Items: wire.ValueListFromSlice([]wire.Value{
+						wire.NewValueList(wire.List{
+							ValueType: wire.TI32,
+							Size:      3,
+							Items: wire.ValueListFromSlice([]wire.Value{
+								wire.NewValueI32(1),
+								wire.NewValueI32(2),
+								wire.NewValueI32(3),
+							}),
+						}),
+						wire.NewValueList(wire.List{
+							ValueType: wire.TI32,
+							Size:      3,
+							Items: wire.ValueListFromSlice([]wire.Value{
+								wire.NewValueI32(4),
+								wire.NewValueI32(5),
+								wire.NewValueI32(6),
+							}),
+						}),
+					}),
+				})},
+			}}),
+		},
+		{
+			"ListOfSets",
+			tc.ContainersOfContainers{
+				ListOfSets: []map[int32]struct{}{
+					map[int32]struct{}{
+						1: struct{}{},
+						2: struct{}{},
+						3: struct{}{},
+					},
+					map[int32]struct{}{
+						4: struct{}{},
+						5: struct{}{},
+						6: struct{}{},
+					},
+				},
+			},
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 2, Value: wire.NewValueList(wire.List{
+					ValueType: wire.TSet,
+					Size:      2,
+					Items: wire.ValueListFromSlice([]wire.Value{
+						wire.NewValueSet(wire.Set{
+							ValueType: wire.TI32,
+							Size:      3,
+							Items: wire.ValueListFromSlice([]wire.Value{
+								wire.NewValueI32(1),
+								wire.NewValueI32(2),
+								wire.NewValueI32(3),
+							}),
+						}),
+						wire.NewValueSet(wire.Set{
+							ValueType: wire.TI32,
+							Size:      3,
+							Items: wire.ValueListFromSlice([]wire.Value{
+								wire.NewValueI32(4),
+								wire.NewValueI32(5),
+								wire.NewValueI32(6),
+							}),
+						}),
+					}),
+				})},
+			}}),
+		},
+		{
+			"ListOfMaps",
+			tc.ContainersOfContainers{
+				ListOfMaps: []map[int32]int32{
+					map[int32]int32{
+						1: 100,
+						2: 200,
+						3: 300,
+					},
+					map[int32]int32{
+						4: 400,
+						5: 500,
+						6: 600,
+					},
+				},
+			},
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 3, Value: wire.NewValueList(wire.List{
+					ValueType: wire.TMap,
+					Size:      2,
+					Items: wire.ValueListFromSlice([]wire.Value{
+						wire.NewValueMap(wire.Map{
+							KeyType:   wire.TI32,
+							ValueType: wire.TI32,
+							Size:      3,
+							Items: wire.MapItemListFromSlice([]wire.MapItem{
+								{Key: wire.NewValueI32(1), Value: wire.NewValueI32(100)},
+								{Key: wire.NewValueI32(2), Value: wire.NewValueI32(200)},
+								{Key: wire.NewValueI32(3), Value: wire.NewValueI32(300)},
+							}),
+						}),
+						wire.NewValueMap(wire.Map{
+							KeyType:   wire.TI32,
+							ValueType: wire.TI32,
+							Size:      3,
+							Items: wire.MapItemListFromSlice([]wire.MapItem{
+								{Key: wire.NewValueI32(4), Value: wire.NewValueI32(400)},
+								{Key: wire.NewValueI32(5), Value: wire.NewValueI32(500)},
+								{Key: wire.NewValueI32(6), Value: wire.NewValueI32(600)},
+							}),
+						}),
+					}),
+				})},
+			}}),
+		},
+		{
+			"SetOfSets",
+			tc.ContainersOfContainers{
+				SetOfSets: []map[string]struct{}{
+					map[string]struct{}{
+						"1": struct{}{},
+						"2": struct{}{},
+						"3": struct{}{},
+					},
+					map[string]struct{}{
+						"4": struct{}{},
+						"5": struct{}{},
+						"6": struct{}{},
+					},
+				},
+			},
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 4, Value: wire.NewValueSet(wire.Set{
+					ValueType: wire.TSet,
+					Size:      2,
+					Items: wire.ValueListFromSlice([]wire.Value{
+						wire.NewValueSet(wire.Set{
+							ValueType: wire.TBinary,
+							Size:      3,
+							Items: wire.ValueListFromSlice([]wire.Value{
+								wire.NewValueString("1"),
+								wire.NewValueString("2"),
+								wire.NewValueString("3"),
+							}),
+						}),
+						wire.NewValueSet(wire.Set{
+							ValueType: wire.TBinary,
+							Size:      3,
+							Items: wire.ValueListFromSlice([]wire.Value{
+								wire.NewValueString("4"),
+								wire.NewValueString("5"),
+								wire.NewValueString("6"),
+							}),
+						}),
+					}),
+				})},
+			}}),
+		},
+		{
+			"SetOfLists",
+			tc.ContainersOfContainers{
+				SetOfLists: [][]string{
+					{"1", "2", "3"},
+					{"4", "5", "6"},
+				},
+			},
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 5, Value: wire.NewValueSet(wire.Set{
+					ValueType: wire.TList,
+					Size:      2,
+					Items: wire.ValueListFromSlice([]wire.Value{
+						wire.NewValueList(wire.List{
+							ValueType: wire.TBinary,
+							Size:      3,
+							Items: wire.ValueListFromSlice([]wire.Value{
+								wire.NewValueString("1"),
+								wire.NewValueString("2"),
+								wire.NewValueString("3"),
+							}),
+						}),
+						wire.NewValueList(wire.List{
+							ValueType: wire.TBinary,
+							Size:      3,
+							Items: wire.ValueListFromSlice([]wire.Value{
+								wire.NewValueString("4"),
+								wire.NewValueString("5"),
+								wire.NewValueString("6"),
+							}),
+						}),
+					}),
+				})},
+			}}),
+		},
+		{
+			"SetOfMaps",
+			tc.ContainersOfContainers{
+				SetOfMaps: []map[string]string{
+					map[string]string{
+						"1": "one",
+						"2": "two",
+						"3": "three",
+					},
+					map[string]string{
+						"4": "four",
+						"5": "five",
+						"6": "six",
+					},
+				},
+			},
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 6, Value: wire.NewValueSet(wire.Set{
+					ValueType: wire.TMap,
+					Size:      2,
+					Items: wire.ValueListFromSlice([]wire.Value{
+						wire.NewValueMap(wire.Map{
+							KeyType:   wire.TBinary,
+							ValueType: wire.TBinary,
+							Size:      3,
+							Items: wire.MapItemListFromSlice([]wire.MapItem{
+								{Key: wire.NewValueString("1"), Value: wire.NewValueString("one")},
+								{Key: wire.NewValueString("2"), Value: wire.NewValueString("two")},
+								{Key: wire.NewValueString("3"), Value: wire.NewValueString("three")},
+							}),
+						}),
+						wire.NewValueMap(wire.Map{
+							KeyType:   wire.TBinary,
+							ValueType: wire.TBinary,
+							Size:      3,
+							Items: wire.MapItemListFromSlice([]wire.MapItem{
+								{Key: wire.NewValueString("4"), Value: wire.NewValueString("four")},
+								{Key: wire.NewValueString("5"), Value: wire.NewValueString("five")},
+								{Key: wire.NewValueString("6"), Value: wire.NewValueString("six")},
+							}),
+						}),
+					}),
+				})},
+			}}),
+		},
+		{
+			"MapOfMapToInt",
+			tc.ContainersOfContainers{
+				MapOfMapToInt: []struct {
+					Key   map[string]int32
+					Value int64
+				}{
+					{
+						Key:   map[string]int32{"1": 1, "2": 2, "3": 3},
+						Value: 123,
+					},
+					{
+						Key:   map[string]int32{"4": 4, "5": 5, "6": 6},
+						Value: 456,
+					},
+				},
+			},
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 7, Value: wire.NewValueMap(wire.Map{
+					KeyType:   wire.TMap,
+					ValueType: wire.TI64,
+					Size:      2,
+					Items: wire.MapItemListFromSlice([]wire.MapItem{
+						{
+							Key: wire.NewValueMap(wire.Map{
+								KeyType:   wire.TBinary,
+								ValueType: wire.TI32,
+								Size:      3,
+								Items: wire.MapItemListFromSlice([]wire.MapItem{
+									{Key: wire.NewValueString("1"), Value: wire.NewValueI32(1)},
+									{Key: wire.NewValueString("2"), Value: wire.NewValueI32(2)},
+									{Key: wire.NewValueString("3"), Value: wire.NewValueI32(3)},
+								}),
+							}),
+							Value: wire.NewValueI64(123),
+						},
+						{
+							Key: wire.NewValueMap(wire.Map{
+								KeyType:   wire.TBinary,
+								ValueType: wire.TI32,
+								Size:      3,
+								Items: wire.MapItemListFromSlice([]wire.MapItem{
+									{Key: wire.NewValueString("4"), Value: wire.NewValueI32(4)},
+									{Key: wire.NewValueString("5"), Value: wire.NewValueI32(5)},
+									{Key: wire.NewValueString("6"), Value: wire.NewValueI32(6)},
+								}),
+							}),
+							Value: wire.NewValueI64(456),
+						},
+					}),
+				})},
+			}}),
+		},
+		{
+			"MapOfListToSet",
+			tc.ContainersOfContainers{
+				MapOfListToSet: []struct {
+					Key   []int32
+					Value map[int64]struct{}
+				}{
+					{
+						Key: []int32{1, 2, 3},
+						Value: map[int64]struct{}{
+							1: struct{}{},
+							2: struct{}{},
+							3: struct{}{},
+						},
+					},
+					{
+						Key: []int32{4, 5, 6},
+						Value: map[int64]struct{}{
+							4: struct{}{},
+							5: struct{}{},
+							6: struct{}{},
+						},
+					},
+				},
+			},
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 8, Value: wire.NewValueMap(wire.Map{
+					KeyType:   wire.TList,
+					ValueType: wire.TSet,
+					Size:      2,
+					Items: wire.MapItemListFromSlice([]wire.MapItem{
+						{
+							Key: wire.NewValueList(wire.List{
+								ValueType: wire.TI32,
+								Size:      3,
+								Items: wire.ValueListFromSlice([]wire.Value{
+									wire.NewValueI32(1),
+									wire.NewValueI32(2),
+									wire.NewValueI32(3),
+								}),
+							}),
+							Value: wire.NewValueSet(wire.Set{
+								ValueType: wire.TI64,
+								Size:      3,
+								Items: wire.ValueListFromSlice([]wire.Value{
+									wire.NewValueI64(1),
+									wire.NewValueI64(2),
+									wire.NewValueI64(3),
+								}),
+							}),
+						},
+						{
+							Key: wire.NewValueList(wire.List{
+								ValueType: wire.TI32,
+								Size:      3,
+								Items: wire.ValueListFromSlice([]wire.Value{
+									wire.NewValueI32(4),
+									wire.NewValueI32(5),
+									wire.NewValueI32(6),
+								}),
+							}),
+							Value: wire.NewValueSet(wire.Set{
+								ValueType: wire.TI64,
+								Size:      3,
+								Items: wire.ValueListFromSlice([]wire.Value{
+									wire.NewValueI64(4),
+									wire.NewValueI64(5),
+									wire.NewValueI64(6),
+								}),
+							}),
+						},
+					}),
+				})},
+			}}),
+		},
+		{
+			"MapOfSetToListOfDouble",
+			tc.ContainersOfContainers{
+				MapOfSetToListOfDouble: []struct {
+					Key   map[int32]struct{}
+					Value []float64
+				}{
+					{
+						Key: map[int32]struct{}{
+							1: struct{}{},
+							2: struct{}{},
+							3: struct{}{},
+						},
+						Value: []float64{1.0, 2.0, 3.0},
+					},
+					{
+						Key: map[int32]struct{}{
+							4: struct{}{},
+							5: struct{}{},
+							6: struct{}{},
+						},
+						Value: []float64{4.0, 5.0, 6.0},
+					},
+				},
+			},
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 9, Value: wire.NewValueMap(wire.Map{
+					KeyType:   wire.TSet,
+					ValueType: wire.TList,
+					Size:      2,
+					Items: wire.MapItemListFromSlice([]wire.MapItem{
+						{
+							Key: wire.NewValueSet(wire.Set{
+								ValueType: wire.TI32,
+								Size:      3,
+								Items: wire.ValueListFromSlice([]wire.Value{
+									wire.NewValueI32(1),
+									wire.NewValueI32(2),
+									wire.NewValueI32(3),
+								}),
+							}),
+							Value: wire.NewValueList(wire.List{
+								ValueType: wire.TDouble,
+								Size:      3,
+								Items: wire.ValueListFromSlice([]wire.Value{
+									wire.NewValueDouble(1.0),
+									wire.NewValueDouble(2.0),
+									wire.NewValueDouble(3.0),
+								}),
+							}),
+						},
+						{
+							Key: wire.NewValueSet(wire.Set{
+								ValueType: wire.TI32,
+								Size:      3,
+								Items: wire.ValueListFromSlice([]wire.Value{
+									wire.NewValueI32(4),
+									wire.NewValueI32(5),
+									wire.NewValueI32(6),
+								}),
+							}),
+							Value: wire.NewValueList(wire.List{
+								ValueType: wire.TDouble,
+								Size:      3,
+								Items: wire.ValueListFromSlice([]wire.Value{
+									wire.NewValueDouble(4.0),
+									wire.NewValueDouble(5.0),
+									wire.NewValueDouble(6.0),
+								}),
+							}),
+						},
+					}),
+				})},
+			}}),
+		},
+	}
+
+	for _, tt := range tests {
+		assertRoundTrip(t, &tt.x, tt.v, tt.desc)
+	}
+}

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -162,6 +162,7 @@ func (g *generator) TextTemplate(s string, data interface{}, opts ...TemplateOpt
 	templateFuncs := template.FuncMap{
 		"goCase":           goCase,
 		"import":           g.Import,
+		"isHashable":       isHashable,
 		"isPrimitiveType":  isPrimitiveType,
 		"isStructType":     isStructType,
 		"newNamespace":     g.Namespace.Child,
@@ -284,6 +285,9 @@ func (g *generator) recordGenDeclNames(d *ast.GenDecl) error {
 //
 // 	<$fmt := import "fmt">
 // 	<$fmt>.Println("hello world")
+//
+// isHashable(TypeSpec): Returns true if the given TypeSpec is for a type that
+// is hashable.
 //
 // isPrimitiveType(TypeSpec): Returns true if the given TypeSpec is for a
 // primitive type.

--- a/gen/map.go
+++ b/gen/map.go
@@ -63,7 +63,7 @@ func (m *mapGenerator) ItemList(g Generator, spec *compile.MapSpec) (string, err
 			<$v := newVar "v">
 			<$i := newVar "i">
 			func (<$m> <.Name>) ForEach(<$f> func(<$wire>.MapItem) error) error {
-				<if isPrimitiveType .Spec.KeySpec>
+				<if isHashable .Spec.KeySpec>
 					for <$k>, <$v> := range <$m> {
 				<else>
 					for _, <$i> := range <$m> {
@@ -117,7 +117,7 @@ func (m *mapGenerator) Reader(g Generator, spec *compile.MapSpec) (string, error
 					return nil, nil
 				}
 
-				<if isPrimitiveType .Spec.KeySpec>
+				<if isHashable .Spec.KeySpec>
 					<$o> := make(<$mapType>, <$m>.Size)
 				<else>
 					<$o> := make(<$mapType>, 0, <$m>.Size)
@@ -133,7 +133,7 @@ func (m *mapGenerator) Reader(g Generator, spec *compile.MapSpec) (string, error
 						return err
 					}
 
-					<if isPrimitiveType .Spec.KeySpec>
+					<if isHashable .Spec.KeySpec>
 						<$o>[<$k>] = <$v>
 					<else>
 						<$o> = append(<$o>, struct {

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -48,6 +48,7 @@ func TestQuickRoundTrip(t *testing.T) {
 		// reflect.TypeOf(testdata.Graph{}),
 		reflect.TypeOf(ts.ContactInfo{}),
 		reflect.TypeOf(ts.User{}),
+		reflect.TypeOf(tc.ContainersOfContainers{}),
 	}
 
 	rand := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/gen/set.go
+++ b/gen/set.go
@@ -57,7 +57,7 @@ func (s *setGenerator) ValueList(g Generator, spec *compile.SetSpec) (string, er
 			<$x := newVar "x">
 			<$f := newVar "f">
 			func (<$v> <.Name>) ForEach(<$f> func(<$wire>.Value) error) error {
-				<if isPrimitiveType .Spec.ValueSpec>
+				<if isHashable .Spec.ValueSpec>
 					for <$x> := range <$v> {
 				<else>
 					for _, <$x> := range <$v> {
@@ -101,7 +101,7 @@ func (s *setGenerator) Reader(g Generator, spec *compile.SetSpec) (string, error
 					return nil, nil
 				}
 
-				<if isPrimitiveType .Spec.ValueSpec>
+				<if isHashable .Spec.ValueSpec>
 					<$o> := make(<$setType>, <$s>.Size)
 				<else>
 					<$o> := make(<$setType>, 0, <$s>.Size)
@@ -111,7 +111,7 @@ func (s *setGenerator) Reader(g Generator, spec *compile.SetSpec) (string, error
 					if err != nil {
 						return err
 					}
-					<if isPrimitiveType .Spec.ValueSpec>
+					<if isHashable .Spec.ValueSpec>
 						<$o>[<$i>] = struct{}{}
 					<else>
 						<$o> = append(<$o>, <$i>)

--- a/gen/set.go
+++ b/gen/set.go
@@ -57,12 +57,16 @@ func (s *setGenerator) ValueList(g Generator, spec *compile.SetSpec) (string, er
 			<$x := newVar "x">
 			<$f := newVar "f">
 			func (<$v> <.Name>) ForEach(<$f> func(<$wire>.Value) error) error {
-				for <$x> := range <$v> {
-					err := <$f>(<toWire .Spec.ValueSpec $x>)
-					if err != nil {
-						return err
+				<if isPrimitiveType .Spec.ValueSpec>
+					for <$x> := range <$v> {
+				<else>
+					for _, <$x> := range <$v> {
+				<end>
+						err := <$f>(<toWire .Spec.ValueSpec $x>)
+						if err != nil {
+							return err
+						}
 					}
-				}
 				return nil
 			}
 
@@ -97,13 +101,21 @@ func (s *setGenerator) Reader(g Generator, spec *compile.SetSpec) (string, error
 					return nil, nil
 				}
 
-				<$o> := make(<$setType>, <$s>.Size)
+				<if isPrimitiveType .Spec.ValueSpec>
+					<$o> := make(<$setType>, <$s>.Size)
+				<else>
+					<$o> := make(<$setType>, 0, <$s>.Size)
+				<end>
 				err := <$s>.Items.ForEach(func(<$x> <$wire>.Value) error {
 					<$i>, err := <fromWire .Spec.ValueSpec $x>
 					if err != nil {
 						return err
 					}
-					<$o>[<$i>] = struct{}{}
+					<if isPrimitiveType .Spec.ValueSpec>
+						<$o>[<$i>] = struct{}{}
+					<else>
+						<$o> = append(<$o>, <$i>)
+					<end>
 					return nil
 				})
 				<$s>.Items.Close()

--- a/gen/testdata/containers/types.go
+++ b/gen/testdata/containers/types.go
@@ -9,6 +9,843 @@ import (
 	"strings"
 )
 
+type ContainersOfContainers struct {
+	ListOfLists   [][]int32             `json:"listOfLists"`
+	ListOfSets    []map[int32]struct{}  `json:"listOfSets"`
+	ListOfMaps    []map[int32]int32     `json:"listOfMaps"`
+	SetOfSets     []map[string]struct{} `json:"setOfSets"`
+	SetOfLists    [][]string            `json:"setOfLists"`
+	SetOfMaps     []map[string]string   `json:"setOfMaps"`
+	MapOfMapToInt []struct {
+		Key   map[string]int32
+		Value int64
+	} `json:"mapOfMapToInt"`
+	MapOfListToSet []struct {
+		Key   []int32
+		Value map[int64]struct{}
+	} `json:"mapOfListToSet"`
+	MapOfSetToListOfDouble []struct {
+		Key   map[int32]struct{}
+		Value []float64
+	} `json:"mapOfSetToListOfDouble"`
+}
+
+type _List_I32_ValueList []int32
+
+func (v _List_I32_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueI32(x))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _List_I32_ValueList) Close() {
+}
+
+type _List_List_I32_ValueList [][]int32
+
+func (v _List_List_I32_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueList(wire.List{ValueType: wire.TI32, Size: len(x), Items: _List_I32_ValueList(x)}))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _List_List_I32_ValueList) Close() {
+}
+
+type _Set_I32_ValueList map[int32]struct{}
+
+func (v _Set_I32_ValueList) ForEach(f func(wire.Value) error) error {
+	for x := range v {
+		err := f(wire.NewValueI32(x))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _Set_I32_ValueList) Close() {
+}
+
+type _List_Set_I32_ValueList []map[int32]struct{}
+
+func (v _List_Set_I32_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueSet(wire.Set{ValueType: wire.TI32, Size: len(x), Items: _Set_I32_ValueList(x)}))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _List_Set_I32_ValueList) Close() {
+}
+
+type _Map_I32_I32_MapItemList map[int32]int32
+
+func (m _Map_I32_I32_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for k, v := range m {
+		err := f(wire.MapItem{Key: wire.NewValueI32(k), Value: wire.NewValueI32(v)})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_I32_I32_MapItemList) Close() {
+}
+
+type _List_Map_I32_I32_ValueList []map[int32]int32
+
+func (v _List_Map_I32_I32_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueMap(wire.Map{KeyType: wire.TI32, ValueType: wire.TI32, Size: len(x), Items: _Map_I32_I32_MapItemList(x)}))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _List_Map_I32_I32_ValueList) Close() {
+}
+
+type _Set_String_ValueList map[string]struct{}
+
+func (v _Set_String_ValueList) ForEach(f func(wire.Value) error) error {
+	for x := range v {
+		err := f(wire.NewValueString(x))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _Set_String_ValueList) Close() {
+}
+
+type _Set_Set_String_ValueList []map[string]struct{}
+
+func (v _Set_Set_String_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueSet(wire.Set{ValueType: wire.TBinary, Size: len(x), Items: _Set_String_ValueList(x)}))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _Set_Set_String_ValueList) Close() {
+}
+
+type _List_String_ValueList []string
+
+func (v _List_String_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueString(x))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _List_String_ValueList) Close() {
+}
+
+type _Set_List_String_ValueList [][]string
+
+func (v _Set_List_String_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueList(wire.List{ValueType: wire.TBinary, Size: len(x), Items: _List_String_ValueList(x)}))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _Set_List_String_ValueList) Close() {
+}
+
+type _Map_String_String_MapItemList map[string]string
+
+func (m _Map_String_String_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for k, v := range m {
+		err := f(wire.MapItem{Key: wire.NewValueString(k), Value: wire.NewValueString(v)})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_String_String_MapItemList) Close() {
+}
+
+type _Set_Map_String_String_ValueList []map[string]string
+
+func (v _Set_Map_String_String_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueMap(wire.Map{KeyType: wire.TBinary, ValueType: wire.TBinary, Size: len(x), Items: _Map_String_String_MapItemList(x)}))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _Set_Map_String_String_ValueList) Close() {
+}
+
+type _Map_String_I32_MapItemList map[string]int32
+
+func (m _Map_String_I32_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for k, v := range m {
+		err := f(wire.MapItem{Key: wire.NewValueString(k), Value: wire.NewValueI32(v)})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_String_I32_MapItemList) Close() {
+}
+
+type _Map_Map_String_I32_I64_MapItemList []struct {
+	Key   map[string]int32
+	Value int64
+}
+
+func (m _Map_Map_String_I32_I64_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for _, i := range m {
+		k := i.Key
+		v := i.Value
+		err := f(wire.MapItem{Key: wire.NewValueMap(wire.Map{KeyType: wire.TBinary, ValueType: wire.TI32, Size: len(k), Items: _Map_String_I32_MapItemList(k)}), Value: wire.NewValueI64(v)})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_Map_String_I32_I64_MapItemList) Close() {
+}
+
+type _Set_I64_ValueList map[int64]struct{}
+
+func (v _Set_I64_ValueList) ForEach(f func(wire.Value) error) error {
+	for x := range v {
+		err := f(wire.NewValueI64(x))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _Set_I64_ValueList) Close() {
+}
+
+type _Map_List_I32_Set_I64_MapItemList []struct {
+	Key   []int32
+	Value map[int64]struct{}
+}
+
+func (m _Map_List_I32_Set_I64_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for _, i := range m {
+		k := i.Key
+		v := i.Value
+		err := f(wire.MapItem{Key: wire.NewValueList(wire.List{ValueType: wire.TI32, Size: len(k), Items: _List_I32_ValueList(k)}), Value: wire.NewValueSet(wire.Set{ValueType: wire.TI64, Size: len(v), Items: _Set_I64_ValueList(v)})})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_List_I32_Set_I64_MapItemList) Close() {
+}
+
+type _List_Double_ValueList []float64
+
+func (v _List_Double_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueDouble(x))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _List_Double_ValueList) Close() {
+}
+
+type _Map_Set_I32_List_Double_MapItemList []struct {
+	Key   map[int32]struct{}
+	Value []float64
+}
+
+func (m _Map_Set_I32_List_Double_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for _, i := range m {
+		k := i.Key
+		v := i.Value
+		err := f(wire.MapItem{Key: wire.NewValueSet(wire.Set{ValueType: wire.TI32, Size: len(k), Items: _Set_I32_ValueList(k)}), Value: wire.NewValueList(wire.List{ValueType: wire.TDouble, Size: len(v), Items: _List_Double_ValueList(v)})})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_Set_I32_List_Double_MapItemList) Close() {
+}
+
+func (v *ContainersOfContainers) ToWire() wire.Value {
+	var fields [9]wire.Field
+	i := 0
+	if v.ListOfLists != nil {
+		fields[i] = wire.Field{ID: 1, Value: wire.NewValueList(wire.List{ValueType: wire.TList, Size: len(v.ListOfLists), Items: _List_List_I32_ValueList(v.ListOfLists)})}
+		i++
+	}
+	if v.ListOfSets != nil {
+		fields[i] = wire.Field{ID: 2, Value: wire.NewValueList(wire.List{ValueType: wire.TSet, Size: len(v.ListOfSets), Items: _List_Set_I32_ValueList(v.ListOfSets)})}
+		i++
+	}
+	if v.ListOfMaps != nil {
+		fields[i] = wire.Field{ID: 3, Value: wire.NewValueList(wire.List{ValueType: wire.TMap, Size: len(v.ListOfMaps), Items: _List_Map_I32_I32_ValueList(v.ListOfMaps)})}
+		i++
+	}
+	if v.SetOfSets != nil {
+		fields[i] = wire.Field{ID: 4, Value: wire.NewValueSet(wire.Set{ValueType: wire.TSet, Size: len(v.SetOfSets), Items: _Set_Set_String_ValueList(v.SetOfSets)})}
+		i++
+	}
+	if v.SetOfLists != nil {
+		fields[i] = wire.Field{ID: 5, Value: wire.NewValueSet(wire.Set{ValueType: wire.TList, Size: len(v.SetOfLists), Items: _Set_List_String_ValueList(v.SetOfLists)})}
+		i++
+	}
+	if v.SetOfMaps != nil {
+		fields[i] = wire.Field{ID: 6, Value: wire.NewValueSet(wire.Set{ValueType: wire.TMap, Size: len(v.SetOfMaps), Items: _Set_Map_String_String_ValueList(v.SetOfMaps)})}
+		i++
+	}
+	if v.MapOfMapToInt != nil {
+		fields[i] = wire.Field{ID: 7, Value: wire.NewValueMap(wire.Map{KeyType: wire.TMap, ValueType: wire.TI64, Size: len(v.MapOfMapToInt), Items: _Map_Map_String_I32_I64_MapItemList(v.MapOfMapToInt)})}
+		i++
+	}
+	if v.MapOfListToSet != nil {
+		fields[i] = wire.Field{ID: 8, Value: wire.NewValueMap(wire.Map{KeyType: wire.TList, ValueType: wire.TSet, Size: len(v.MapOfListToSet), Items: _Map_List_I32_Set_I64_MapItemList(v.MapOfListToSet)})}
+		i++
+	}
+	if v.MapOfSetToListOfDouble != nil {
+		fields[i] = wire.Field{ID: 9, Value: wire.NewValueMap(wire.Map{KeyType: wire.TSet, ValueType: wire.TList, Size: len(v.MapOfSetToListOfDouble), Items: _Map_Set_I32_List_Double_MapItemList(v.MapOfSetToListOfDouble)})}
+		i++
+	}
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
+}
+
+func _List_I32_Read(l wire.List) ([]int32, error) {
+	if l.ValueType != wire.TI32 {
+		return nil, nil
+	}
+	o := make([]int32, 0, l.Size)
+	err := l.Items.ForEach(func(x wire.Value) error {
+		i, err := x.GetI32(), error(nil)
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	l.Items.Close()
+	return o, err
+}
+
+func _List_List_I32_Read(l wire.List) ([][]int32, error) {
+	if l.ValueType != wire.TList {
+		return nil, nil
+	}
+	o := make([][]int32, 0, l.Size)
+	err := l.Items.ForEach(func(x wire.Value) error {
+		i, err := _List_I32_Read(x.GetList())
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	l.Items.Close()
+	return o, err
+}
+
+func _Set_I32_Read(s wire.Set) (map[int32]struct{}, error) {
+	if s.ValueType != wire.TI32 {
+		return nil, nil
+	}
+	o := make(map[int32]struct{}, s.Size)
+	err := s.Items.ForEach(func(x wire.Value) error {
+		i, err := x.GetI32(), error(nil)
+		if err != nil {
+			return err
+		}
+		o[i] = struct{}{}
+		return nil
+	})
+	s.Items.Close()
+	return o, err
+}
+
+func _List_Set_I32_Read(l wire.List) ([]map[int32]struct{}, error) {
+	if l.ValueType != wire.TSet {
+		return nil, nil
+	}
+	o := make([]map[int32]struct{}, 0, l.Size)
+	err := l.Items.ForEach(func(x wire.Value) error {
+		i, err := _Set_I32_Read(x.GetSet())
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	l.Items.Close()
+	return o, err
+}
+
+func _Map_I32_I32_Read(m wire.Map) (map[int32]int32, error) {
+	if m.KeyType != wire.TI32 {
+		return nil, nil
+	}
+	if m.ValueType != wire.TI32 {
+		return nil, nil
+	}
+	o := make(map[int32]int32, m.Size)
+	err := m.Items.ForEach(func(x wire.MapItem) error {
+		k, err := x.Key.GetI32(), error(nil)
+		if err != nil {
+			return err
+		}
+		v, err := x.Value.GetI32(), error(nil)
+		if err != nil {
+			return err
+		}
+		o[k] = v
+		return nil
+	})
+	m.Items.Close()
+	return o, err
+}
+
+func _List_Map_I32_I32_Read(l wire.List) ([]map[int32]int32, error) {
+	if l.ValueType != wire.TMap {
+		return nil, nil
+	}
+	o := make([]map[int32]int32, 0, l.Size)
+	err := l.Items.ForEach(func(x wire.Value) error {
+		i, err := _Map_I32_I32_Read(x.GetMap())
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	l.Items.Close()
+	return o, err
+}
+
+func _Set_String_Read(s wire.Set) (map[string]struct{}, error) {
+	if s.ValueType != wire.TBinary {
+		return nil, nil
+	}
+	o := make(map[string]struct{}, s.Size)
+	err := s.Items.ForEach(func(x wire.Value) error {
+		i, err := x.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+		o[i] = struct{}{}
+		return nil
+	})
+	s.Items.Close()
+	return o, err
+}
+
+func _Set_Set_String_Read(s wire.Set) ([]map[string]struct{}, error) {
+	if s.ValueType != wire.TSet {
+		return nil, nil
+	}
+	o := make([]map[string]struct{}, 0, s.Size)
+	err := s.Items.ForEach(func(x wire.Value) error {
+		i, err := _Set_String_Read(x.GetSet())
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	s.Items.Close()
+	return o, err
+}
+
+func _List_String_Read(l wire.List) ([]string, error) {
+	if l.ValueType != wire.TBinary {
+		return nil, nil
+	}
+	o := make([]string, 0, l.Size)
+	err := l.Items.ForEach(func(x wire.Value) error {
+		i, err := x.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	l.Items.Close()
+	return o, err
+}
+
+func _Set_List_String_Read(s wire.Set) ([][]string, error) {
+	if s.ValueType != wire.TList {
+		return nil, nil
+	}
+	o := make([][]string, 0, s.Size)
+	err := s.Items.ForEach(func(x wire.Value) error {
+		i, err := _List_String_Read(x.GetList())
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	s.Items.Close()
+	return o, err
+}
+
+func _Map_String_String_Read(m wire.Map) (map[string]string, error) {
+	if m.KeyType != wire.TBinary {
+		return nil, nil
+	}
+	if m.ValueType != wire.TBinary {
+		return nil, nil
+	}
+	o := make(map[string]string, m.Size)
+	err := m.Items.ForEach(func(x wire.MapItem) error {
+		k, err := x.Key.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+		v, err := x.Value.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+		o[k] = v
+		return nil
+	})
+	m.Items.Close()
+	return o, err
+}
+
+func _Set_Map_String_String_Read(s wire.Set) ([]map[string]string, error) {
+	if s.ValueType != wire.TMap {
+		return nil, nil
+	}
+	o := make([]map[string]string, 0, s.Size)
+	err := s.Items.ForEach(func(x wire.Value) error {
+		i, err := _Map_String_String_Read(x.GetMap())
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	s.Items.Close()
+	return o, err
+}
+
+func _Map_String_I32_Read(m wire.Map) (map[string]int32, error) {
+	if m.KeyType != wire.TBinary {
+		return nil, nil
+	}
+	if m.ValueType != wire.TI32 {
+		return nil, nil
+	}
+	o := make(map[string]int32, m.Size)
+	err := m.Items.ForEach(func(x wire.MapItem) error {
+		k, err := x.Key.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+		v, err := x.Value.GetI32(), error(nil)
+		if err != nil {
+			return err
+		}
+		o[k] = v
+		return nil
+	})
+	m.Items.Close()
+	return o, err
+}
+
+func _Map_Map_String_I32_I64_Read(m wire.Map) ([]struct {
+	Key   map[string]int32
+	Value int64
+}, error) {
+	if m.KeyType != wire.TMap {
+		return nil, nil
+	}
+	if m.ValueType != wire.TI64 {
+		return nil, nil
+	}
+	o := make([]struct {
+		Key   map[string]int32
+		Value int64
+	}, 0, m.Size)
+	err := m.Items.ForEach(func(x wire.MapItem) error {
+		k, err := _Map_String_I32_Read(x.Key.GetMap())
+		if err != nil {
+			return err
+		}
+		v, err := x.Value.GetI64(), error(nil)
+		if err != nil {
+			return err
+		}
+		o = append(o, struct {
+			Key   map[string]int32
+			Value int64
+		}{k, v})
+		return nil
+	})
+	m.Items.Close()
+	return o, err
+}
+
+func _Set_I64_Read(s wire.Set) (map[int64]struct{}, error) {
+	if s.ValueType != wire.TI64 {
+		return nil, nil
+	}
+	o := make(map[int64]struct{}, s.Size)
+	err := s.Items.ForEach(func(x wire.Value) error {
+		i, err := x.GetI64(), error(nil)
+		if err != nil {
+			return err
+		}
+		o[i] = struct{}{}
+		return nil
+	})
+	s.Items.Close()
+	return o, err
+}
+
+func _Map_List_I32_Set_I64_Read(m wire.Map) ([]struct {
+	Key   []int32
+	Value map[int64]struct{}
+}, error) {
+	if m.KeyType != wire.TList {
+		return nil, nil
+	}
+	if m.ValueType != wire.TSet {
+		return nil, nil
+	}
+	o := make([]struct {
+		Key   []int32
+		Value map[int64]struct{}
+	}, 0, m.Size)
+	err := m.Items.ForEach(func(x wire.MapItem) error {
+		k, err := _List_I32_Read(x.Key.GetList())
+		if err != nil {
+			return err
+		}
+		v, err := _Set_I64_Read(x.Value.GetSet())
+		if err != nil {
+			return err
+		}
+		o = append(o, struct {
+			Key   []int32
+			Value map[int64]struct{}
+		}{k, v})
+		return nil
+	})
+	m.Items.Close()
+	return o, err
+}
+
+func _List_Double_Read(l wire.List) ([]float64, error) {
+	if l.ValueType != wire.TDouble {
+		return nil, nil
+	}
+	o := make([]float64, 0, l.Size)
+	err := l.Items.ForEach(func(x wire.Value) error {
+		i, err := x.GetDouble(), error(nil)
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	l.Items.Close()
+	return o, err
+}
+
+func _Map_Set_I32_List_Double_Read(m wire.Map) ([]struct {
+	Key   map[int32]struct{}
+	Value []float64
+}, error) {
+	if m.KeyType != wire.TSet {
+		return nil, nil
+	}
+	if m.ValueType != wire.TList {
+		return nil, nil
+	}
+	o := make([]struct {
+		Key   map[int32]struct{}
+		Value []float64
+	}, 0, m.Size)
+	err := m.Items.ForEach(func(x wire.MapItem) error {
+		k, err := _Set_I32_Read(x.Key.GetSet())
+		if err != nil {
+			return err
+		}
+		v, err := _List_Double_Read(x.Value.GetList())
+		if err != nil {
+			return err
+		}
+		o = append(o, struct {
+			Key   map[int32]struct{}
+			Value []float64
+		}{k, v})
+		return nil
+	})
+	m.Items.Close()
+	return o, err
+}
+
+func (v *ContainersOfContainers) FromWire(w wire.Value) error {
+	var err error
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 1:
+			if field.Value.Type() == wire.TList {
+				v.ListOfLists, err = _List_List_I32_Read(field.Value.GetList())
+				if err != nil {
+					return err
+				}
+			}
+		case 2:
+			if field.Value.Type() == wire.TList {
+				v.ListOfSets, err = _List_Set_I32_Read(field.Value.GetList())
+				if err != nil {
+					return err
+				}
+			}
+		case 3:
+			if field.Value.Type() == wire.TList {
+				v.ListOfMaps, err = _List_Map_I32_I32_Read(field.Value.GetList())
+				if err != nil {
+					return err
+				}
+			}
+		case 4:
+			if field.Value.Type() == wire.TSet {
+				v.SetOfSets, err = _Set_Set_String_Read(field.Value.GetSet())
+				if err != nil {
+					return err
+				}
+			}
+		case 5:
+			if field.Value.Type() == wire.TSet {
+				v.SetOfLists, err = _Set_List_String_Read(field.Value.GetSet())
+				if err != nil {
+					return err
+				}
+			}
+		case 6:
+			if field.Value.Type() == wire.TSet {
+				v.SetOfMaps, err = _Set_Map_String_String_Read(field.Value.GetSet())
+				if err != nil {
+					return err
+				}
+			}
+		case 7:
+			if field.Value.Type() == wire.TMap {
+				v.MapOfMapToInt, err = _Map_Map_String_I32_I64_Read(field.Value.GetMap())
+				if err != nil {
+					return err
+				}
+			}
+		case 8:
+			if field.Value.Type() == wire.TMap {
+				v.MapOfListToSet, err = _Map_List_I32_Set_I64_Read(field.Value.GetMap())
+				if err != nil {
+					return err
+				}
+			}
+		case 9:
+			if field.Value.Type() == wire.TMap {
+				v.MapOfSetToListOfDouble, err = _Map_Set_I32_List_Double_Read(field.Value.GetMap())
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (v *ContainersOfContainers) String() string {
+	var fields [9]string
+	i := 0
+	if v.ListOfLists != nil {
+		fields[i] = fmt.Sprintf("ListOfLists: %v", v.ListOfLists)
+		i++
+	}
+	if v.ListOfSets != nil {
+		fields[i] = fmt.Sprintf("ListOfSets: %v", v.ListOfSets)
+		i++
+	}
+	if v.ListOfMaps != nil {
+		fields[i] = fmt.Sprintf("ListOfMaps: %v", v.ListOfMaps)
+		i++
+	}
+	if v.SetOfSets != nil {
+		fields[i] = fmt.Sprintf("SetOfSets: %v", v.SetOfSets)
+		i++
+	}
+	if v.SetOfLists != nil {
+		fields[i] = fmt.Sprintf("SetOfLists: %v", v.SetOfLists)
+		i++
+	}
+	if v.SetOfMaps != nil {
+		fields[i] = fmt.Sprintf("SetOfMaps: %v", v.SetOfMaps)
+		i++
+	}
+	if v.MapOfMapToInt != nil {
+		fields[i] = fmt.Sprintf("MapOfMapToInt: %v", v.MapOfMapToInt)
+		i++
+	}
+	if v.MapOfListToSet != nil {
+		fields[i] = fmt.Sprintf("MapOfListToSet: %v", v.MapOfListToSet)
+		i++
+	}
+	if v.MapOfSetToListOfDouble != nil {
+		fields[i] = fmt.Sprintf("MapOfSetToListOfDouble: %v", v.MapOfSetToListOfDouble)
+		i++
+	}
+	return fmt.Sprintf("ContainersOfContainers{%v}", strings.Join(fields[:i], ", "))
+}
+
 type EnumContainers struct {
 	ListOfEnums []enums.EnumDefault                     `json:"listOfEnums"`
 	SetOfEnums  map[enums.EnumWithValues]struct{}       `json:"setOfEnums"`
@@ -241,21 +1078,6 @@ func (v _List_I64_ValueList) ForEach(f func(wire.Value) error) error {
 func (v _List_I64_ValueList) Close() {
 }
 
-type _Set_String_ValueList map[string]struct{}
-
-func (v _Set_String_ValueList) ForEach(f func(wire.Value) error) error {
-	for x := range v {
-		err := f(wire.NewValueString(x))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (v _Set_String_ValueList) Close() {
-}
-
 type _Set_Byte_ValueList map[int8]struct{}
 
 func (v _Set_Byte_ValueList) ForEach(f func(wire.Value) error) error {
@@ -362,23 +1184,6 @@ func _List_I64_Read(l wire.List) ([]int64, error) {
 		return nil
 	})
 	l.Items.Close()
-	return o, err
-}
-
-func _Set_String_Read(s wire.Set) (map[string]struct{}, error) {
-	if s.ValueType != wire.TBinary {
-		return nil, nil
-	}
-	o := make(map[string]struct{}, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
-		i, err := x.GetString(), error(nil)
-		if err != nil {
-			return err
-		}
-		o[i] = struct{}{}
-		return nil
-	})
-	s.Items.Close()
 	return o, err
 }
 
@@ -534,36 +1339,6 @@ type PrimitiveContainersRequired struct {
 	MapOfIntsToDoubles map[int64]float64  `json:"mapOfIntsToDoubles"`
 }
 
-type _List_String_ValueList []string
-
-func (v _List_String_ValueList) ForEach(f func(wire.Value) error) error {
-	for _, x := range v {
-		err := f(wire.NewValueString(x))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (v _List_String_ValueList) Close() {
-}
-
-type _Set_I32_ValueList map[int32]struct{}
-
-func (v _Set_I32_ValueList) ForEach(f func(wire.Value) error) error {
-	for x := range v {
-		err := f(wire.NewValueI32(x))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (v _Set_I32_ValueList) Close() {
-}
-
 type _Map_I64_Double_MapItemList map[int64]float64
 
 func (m _Map_I64_Double_MapItemList) ForEach(f func(wire.MapItem) error) error {
@@ -589,40 +1364,6 @@ func (v *PrimitiveContainersRequired) ToWire() wire.Value {
 	fields[i] = wire.Field{ID: 3, Value: wire.NewValueMap(wire.Map{KeyType: wire.TI64, ValueType: wire.TDouble, Size: len(v.MapOfIntsToDoubles), Items: _Map_I64_Double_MapItemList(v.MapOfIntsToDoubles)})}
 	i++
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]})
-}
-
-func _List_String_Read(l wire.List) ([]string, error) {
-	if l.ValueType != wire.TBinary {
-		return nil, nil
-	}
-	o := make([]string, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
-		i, err := x.GetString(), error(nil)
-		if err != nil {
-			return err
-		}
-		o = append(o, i)
-		return nil
-	})
-	l.Items.Close()
-	return o, err
-}
-
-func _Set_I32_Read(s wire.Set) (map[int32]struct{}, error) {
-	if s.ValueType != wire.TI32 {
-		return nil, nil
-	}
-	o := make(map[int32]struct{}, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
-		i, err := x.GetI32(), error(nil)
-		if err != nil {
-			return err
-		}
-		o[i] = struct{}{}
-		return nil
-	})
-	s.Items.Close()
-	return o, err
 }
 
 func _Map_I64_Double_Read(m wire.Map) (map[int64]float64, error) {

--- a/gen/testdata/thrift/containers.thrift
+++ b/gen/testdata/thrift/containers.thrift
@@ -20,3 +20,17 @@ struct EnumContainers {
     2: optional set<enums.EnumWithValues> setOfEnums
     3: optional map<enums.EnumWithDuplicateValues, i32> mapOfEnums
 }
+
+struct ContainersOfContainers {
+    1: optional list<list<i32>> listOfLists;
+    2: optional list<set<i32>> listOfSets;
+    3: optional list<map<i32, i32>> listOfMaps;
+
+    4: optional set<set<string>> setOfSets;
+    5: optional set<list<string>> setOfLists;
+    6: optional set<map<string, string>> setOfMaps;
+
+    7: optional map<map<string, i32>, i64> mapOfMapToInt;
+    8: optional map<list<i32>, set<i64>> mapOfListToSet;
+    9: optional map<set<i32>, list<double>> mapOfSetToListOfDouble;
+}

--- a/gen/testdata/thrift/typedefs.thrift
+++ b/gen/testdata/thrift/typedefs.thrift
@@ -1,3 +1,5 @@
+include "./structs.thrift"
+
 typedef i64 Timestamp  // alias of primitive
 typedef string State
 
@@ -22,3 +24,7 @@ struct Transition {
 }
 
 typedef binary PDF  // alias of []byte
+
+typedef set<structs.Frame> FrameGroup
+
+typedef map<structs.Point, structs.Point> PointMap

--- a/gen/testdata/thrift/typedefs.thrift
+++ b/gen/testdata/thrift/typedefs.thrift
@@ -28,3 +28,5 @@ typedef binary PDF  // alias of []byte
 typedef set<structs.Frame> FrameGroup
 
 typedef map<structs.Point, structs.Point> PointMap
+
+typedef set<binary> BinarySet

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -9,6 +9,56 @@ import (
 	"strings"
 )
 
+type _Set_Binary_ValueList [][]byte
+
+func (v _Set_Binary_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(wire.NewValueBinary(x))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _Set_Binary_ValueList) Close() {
+}
+
+func _Set_Binary_Read(s wire.Set) ([][]byte, error) {
+	if s.ValueType != wire.TBinary {
+		return nil, nil
+	}
+	o := make([][]byte, 0, s.Size)
+	err := s.Items.ForEach(func(x wire.Value) error {
+		i, err := x.GetBinary(), error(nil)
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	s.Items.Close()
+	return o, err
+}
+
+type BinarySet [][]byte
+
+func (v BinarySet) ToWire() wire.Value {
+	x := ([][]byte)(v)
+	return wire.NewValueSet(wire.Set{ValueType: wire.TBinary, Size: len(x), Items: _Set_Binary_ValueList(x)})
+}
+
+func (v BinarySet) String() string {
+	x := ([][]byte)(v)
+	return fmt.Sprint(x)
+}
+
+func (v *BinarySet) FromWire(w wire.Value) error {
+	x, err := _Set_Binary_Read(w.GetSet())
+	*v = (BinarySet)(x)
+	return err
+}
+
 type Event struct {
 	UUID *UUID      `json:"uuid"`
 	Time *Timestamp `json:"time,omitempty"`

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -4,6 +4,7 @@ package typedefs
 
 import (
 	"fmt"
+	"github.com/thriftrw/thriftrw-go/gen/testdata/structs"
 	"github.com/thriftrw/thriftrw-go/wire"
 	"strings"
 )
@@ -130,6 +131,62 @@ func (v *EventGroup) FromWire(w wire.Value) error {
 	return err
 }
 
+type _Set_Frame_ValueList []*structs.Frame
+
+func (v _Set_Frame_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		err := f(x.ToWire())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _Set_Frame_ValueList) Close() {
+}
+
+func _Frame_Read(w wire.Value) (*structs.Frame, error) {
+	var v structs.Frame
+	err := v.FromWire(w)
+	return &v, err
+}
+
+func _Set_Frame_Read(s wire.Set) ([]*structs.Frame, error) {
+	if s.ValueType != wire.TStruct {
+		return nil, nil
+	}
+	o := make([]*structs.Frame, 0, s.Size)
+	err := s.Items.ForEach(func(x wire.Value) error {
+		i, err := _Frame_Read(x)
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	s.Items.Close()
+	return o, err
+}
+
+type FrameGroup []*structs.Frame
+
+func (v FrameGroup) ToWire() wire.Value {
+	x := ([]*structs.Frame)(v)
+	return wire.NewValueSet(wire.Set{ValueType: wire.TStruct, Size: len(x), Items: _Set_Frame_ValueList(x)})
+}
+
+func (v FrameGroup) String() string {
+	x := ([]*structs.Frame)(v)
+	return fmt.Sprint(x)
+}
+
+func (v *FrameGroup) FromWire(w wire.Value) error {
+	x, err := _Set_Frame_Read(w.GetSet())
+	*v = (FrameGroup)(x)
+	return err
+}
+
 type Pdf []byte
 
 func (v Pdf) ToWire() wire.Value {
@@ -145,6 +202,92 @@ func (v Pdf) String() string {
 func (v *Pdf) FromWire(w wire.Value) error {
 	x, err := w.GetBinary(), error(nil)
 	*v = (Pdf)(x)
+	return err
+}
+
+type _Map_Point_Point_MapItemList []struct {
+	Key   *structs.Point
+	Value *structs.Point
+}
+
+func (m _Map_Point_Point_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for _, i := range m {
+		k := i.Key
+		v := i.Value
+		err := f(wire.MapItem{Key: k.ToWire(), Value: v.ToWire()})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_Point_Point_MapItemList) Close() {
+}
+
+func _Point_Read(w wire.Value) (*structs.Point, error) {
+	var v structs.Point
+	err := v.FromWire(w)
+	return &v, err
+}
+
+func _Map_Point_Point_Read(m wire.Map) ([]struct {
+	Key   *structs.Point
+	Value *structs.Point
+}, error) {
+	if m.KeyType != wire.TStruct {
+		return nil, nil
+	}
+	if m.ValueType != wire.TStruct {
+		return nil, nil
+	}
+	o := make([]struct {
+		Key   *structs.Point
+		Value *structs.Point
+	}, 0, m.Size)
+	err := m.Items.ForEach(func(x wire.MapItem) error {
+		k, err := _Point_Read(x.Key)
+		if err != nil {
+			return err
+		}
+		v, err := _Point_Read(x.Value)
+		if err != nil {
+			return err
+		}
+		o = append(o, struct {
+			Key   *structs.Point
+			Value *structs.Point
+		}{k, v})
+		return nil
+	})
+	m.Items.Close()
+	return o, err
+}
+
+type PointMap []struct {
+	Key   *structs.Point
+	Value *structs.Point
+}
+
+func (v PointMap) ToWire() wire.Value {
+	x := ([]struct {
+		Key   *structs.Point
+		Value *structs.Point
+	})(v)
+	return wire.NewValueMap(wire.Map{KeyType: wire.TStruct, ValueType: wire.TStruct, Size: len(x), Items: _Map_Point_Point_MapItemList(x)})
+}
+
+func (v PointMap) String() string {
+	x := ([]struct {
+		Key   *structs.Point
+		Value *structs.Point
+	})(v)
+	return fmt.Sprint(x)
+}
+
+func (v *PointMap) FromWire(w wire.Value) error {
+	x, err := _Map_Point_Point_Read(w.GetMap())
+	*v = (PointMap)(x)
 	return err
 }
 

--- a/gen/type.go
+++ b/gen/type.go
@@ -40,6 +40,13 @@ func TypeDefinition(g Generator, spec compile.TypeSpec) error {
 	}
 }
 
+// isHashable returns true if the given type is considered hashable by
+// thriftrw-go.
+func isHashable(t compile.TypeSpec) bool {
+	// Only primitive types are hashable
+	return isPrimitiveType(t)
+}
+
 // isPrimitiveType returns true if the given type is a primitive type. Only
 // primitive types are considered hashable.
 //
@@ -157,7 +164,7 @@ func typeName(g Generator, spec compile.TypeSpec) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if !isPrimitiveType(s.KeySpec) {
+		if !isHashable(s.KeySpec) {
 			// unhashable type
 			return fmt.Sprintf("[]struct{Key %s; Value %s}", k, v), nil
 		}
@@ -173,7 +180,7 @@ func typeName(g Generator, spec compile.TypeSpec) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if !isPrimitiveType(s.ValueSpec) {
+		if !isHashable(s.ValueSpec) {
 			// unhashable type
 			return fmt.Sprintf("[]%s", v), nil
 		}

--- a/gen/type.go
+++ b/gen/type.go
@@ -40,7 +40,8 @@ func TypeDefinition(g Generator, spec compile.TypeSpec) error {
 	}
 }
 
-// isPrimitiveType returns true if the given type is a primitive type.
+// isPrimitiveType returns true if the given type is a primitive type. Only
+// primitive types are considered hashable.
 //
 // Note that binary is not considered a primitive type because it is
 // represented as []byte in Go.
@@ -148,7 +149,6 @@ func typeName(g Generator, spec compile.TypeSpec) (string, error) {
 
 	switch s := spec.(type) {
 	case *compile.MapSpec:
-		// TODO unhashable types
 		k, err := typeReference(g, s.KeySpec)
 		if err != nil {
 			return "", err
@@ -156,6 +156,10 @@ func typeName(g Generator, spec compile.TypeSpec) (string, error) {
 		v, err := typeReference(g, s.ValueSpec)
 		if err != nil {
 			return "", err
+		}
+		if !isPrimitiveType(s.KeySpec) {
+			// unhashable type
+			return fmt.Sprintf("[]struct{Key %s; Value %s}", k, v), nil
 		}
 		return fmt.Sprintf("map[%s]%s", k, v), nil
 	case *compile.ListSpec:
@@ -165,10 +169,13 @@ func typeName(g Generator, spec compile.TypeSpec) (string, error) {
 		}
 		return "[]" + v, nil
 	case *compile.SetSpec:
-		// TODO unhashable types
 		v, err := typeReference(g, s.ValueSpec)
 		if err != nil {
 			return "", err
+		}
+		if !isPrimitiveType(s.ValueSpec) {
+			// unhashable type
+			return fmt.Sprintf("[]%s", v), nil
 		}
 		return fmt.Sprintf("map[%s]struct{}", v), nil
 	case *compile.EnumSpec, *compile.StructSpec, *compile.TypedefSpec:

--- a/gen/typedef_test.go
+++ b/gen/typedef_test.go
@@ -272,3 +272,37 @@ func TestUnhashableMapKeyAlias(t *testing.T) {
 		assertRoundTrip(t, &tt.x, tt.v, "PointMap")
 	}
 }
+
+func TestBinarySet(t *testing.T) {
+	tests := []struct {
+		x td.BinarySet
+		v wire.Value
+	}{
+		{
+			td.BinarySet{},
+			wire.NewValueSet(wire.Set{
+				ValueType: wire.TBinary,
+				Size:      0,
+				Items:     wire.ValueListFromSlice([]wire.Value{}),
+			}),
+		},
+		{
+			td.BinarySet{
+				{1, 2, 3},
+				{4, 5, 6},
+			},
+			wire.NewValueSet(wire.Set{
+				ValueType: wire.TBinary,
+				Size:      2,
+				Items: wire.ValueListFromSlice([]wire.Value{
+					wire.NewValueBinary([]byte{1, 2, 3}),
+					wire.NewValueBinary([]byte{4, 5, 6}),
+				}),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		assertRoundTrip(t, &tt.x, tt.v, "BinarySet")
+	}
+}

--- a/gen/typedef_test.go
+++ b/gen/typedef_test.go
@@ -23,6 +23,7 @@ package gen
 import (
 	"testing"
 
+	ts "github.com/thriftrw/thriftrw-go/gen/testdata/structs"
 	td "github.com/thriftrw/thriftrw-go/gen/testdata/typedefs"
 	"github.com/thriftrw/thriftrw-go/wire"
 )
@@ -143,5 +144,131 @@ func TestTypedefContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "EventGroup")
+	}
+}
+
+func TestUnhashableSetAlias(t *testing.T) {
+	tests := []struct {
+		x td.FrameGroup
+		v wire.Value
+	}{
+		{
+			td.FrameGroup{},
+			wire.NewValueSet(wire.Set{
+				ValueType: wire.TStruct,
+				Size:      0,
+				Items:     wire.ValueListFromSlice([]wire.Value{}),
+			}),
+		},
+		{
+			td.FrameGroup{
+				&ts.Frame{TopLeft: &ts.Point{X: 1, Y: 2}, Size: &ts.Size{Width: 3, Height: 4}},
+				&ts.Frame{TopLeft: &ts.Point{X: 5, Y: 6}, Size: &ts.Size{Width: 7, Height: 8}},
+			},
+			wire.NewValueSet(wire.Set{
+				ValueType: wire.TStruct,
+				Size:      2,
+				Items: wire.ValueListFromSlice([]wire.Value{
+					wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+						{ID: 1, Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(1)},
+							{ID: 2, Value: wire.NewValueDouble(2)},
+						}})},
+						{ID: 2, Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(3)},
+							{ID: 2, Value: wire.NewValueDouble(4)},
+						}})},
+					}}),
+					wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+						{ID: 1, Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(5)},
+							{ID: 2, Value: wire.NewValueDouble(6)},
+						}})},
+						{ID: 2, Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(7)},
+							{ID: 2, Value: wire.NewValueDouble(8)},
+						}})},
+					}}),
+				}),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		assertRoundTrip(t, &tt.x, tt.v, "FrameGroup")
+	}
+}
+
+func TestUnhashableMapKeyAlias(t *testing.T) {
+	tests := []struct {
+		x td.PointMap
+		v wire.Value
+	}{
+		{
+			td.PointMap{},
+			wire.NewValueMap(wire.Map{
+				KeyType:   wire.TStruct,
+				ValueType: wire.TStruct,
+				Size:      0,
+				Items:     wire.MapItemListFromSlice([]wire.MapItem{}),
+			}),
+		},
+		{
+			td.PointMap{
+				{
+					Key:   &ts.Point{X: 1, Y: 2},
+					Value: &ts.Point{X: 3, Y: 4},
+				},
+				{
+					Key:   &ts.Point{X: 5, Y: 6},
+					Value: &ts.Point{X: 7, Y: 8},
+				},
+				{
+					Key:   &ts.Point{X: 9, Y: 10},
+					Value: &ts.Point{X: 11, Y: 12},
+				},
+			},
+			wire.NewValueMap(wire.Map{
+				KeyType:   wire.TStruct,
+				ValueType: wire.TStruct,
+				Size:      3,
+				Items: wire.MapItemListFromSlice([]wire.MapItem{
+					{
+						Key: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(1)},
+							{ID: 2, Value: wire.NewValueDouble(2)},
+						}}),
+						Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(3)},
+							{ID: 2, Value: wire.NewValueDouble(4)},
+						}}),
+					},
+					{
+						Key: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(5)},
+							{ID: 2, Value: wire.NewValueDouble(6)},
+						}}),
+						Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(7)},
+							{ID: 2, Value: wire.NewValueDouble(8)},
+						}}),
+					},
+					{
+						Key: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(9)},
+							{ID: 2, Value: wire.NewValueDouble(10)},
+						}}),
+						Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+							{ID: 1, Value: wire.NewValueDouble(11)},
+							{ID: 2, Value: wire.NewValueDouble(12)},
+						}}),
+					},
+				}),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		assertRoundTrip(t, &tt.x, tt.v, "PointMap")
 	}
 }

--- a/gen/wire.go
+++ b/gen/wire.go
@@ -65,7 +65,6 @@ func (w *WireGenerator) ToWire(g Generator, spec compile.TypeSpec, varName strin
 
 	switch s := spec.(type) {
 	case *compile.MapSpec:
-		// TODO unhashable types
 		mapItemList, err := w.mapG.ItemList(g, s)
 		if err != nil {
 			return "", err
@@ -110,7 +109,6 @@ func (w *WireGenerator) ToWire(g Generator, spec compile.TypeSpec, varName strin
 			return "", err
 		}
 
-		// TODO unhashable types
 		return g.TextTemplate(
 			`<.Wire>.NewValueSet(<.Wire>.Set{
 				ValueType: <typeCode .Spec.ValueSpec>,


### PR DESCRIPTION
This adds support for using unhashable types as map keys and set items. A type
is considered hashable only if it is a non-`binary` primitive type. All other
types are considered unhashable.

Sets of unhashable objects are downgraded to lists, and maps with unhashable
keys are downgraded to lists of key-value pairs. De-duplication is left up to
the user.

Resolves #75.

----

Don't let the line count scare you. Most of it is generated code and tests.