### PR TITLE
constant values: Support casting

### DIFF
--- a/compile/constant.go
+++ b/compile/constant.go
@@ -20,7 +20,11 @@
 
 package compile
 
-import "github.com/thriftrw/thriftrw-go/ast"
+import (
+	"fmt"
+
+	"github.com/thriftrw/thriftrw-go/ast"
+)
 
 // Constant represents a single named constant value from the Thrift file.
 type Constant struct {
@@ -52,10 +56,13 @@ func (c *Constant) Link(scope Scope) (err error) {
 		return compileError{Target: c.Name, Reason: err}
 	}
 
-	if c.Value, err = c.Value.Link(scope); err != nil {
+	if c.Value, err = c.Value.Link(scope, c.Type); err != nil {
 		return compileError{Target: c.Name, Reason: err}
 	}
 
-	// TODO(abg): validate that the constant matches the TypeSpec
 	return nil
+}
+
+func (c *Constant) String() string {
+	return fmt.Sprintf("Constant(%s %s)", c.Type.ThriftName(), c.Name)
 }

--- a/compile/constant_test.go
+++ b/compile/constant_test.go
@@ -83,10 +83,10 @@ func TestCompileConstant(t *testing.T) {
 				Name: "foo",
 				File: "test.thrift",
 				Type: &ListSpec{ValueSpec: StringSpec},
-				Value: ConstantList([]ConstantValue{
+				Value: ConstantList{
 					ConstantString("hello"),
 					ConstantString("world"),
-				}),
+				},
 			},
 		},
 		{
@@ -96,10 +96,10 @@ func TestCompileConstant(t *testing.T) {
 				Name: "foo",
 				File: "test.thrift",
 				Type: &ListSpec{ValueSpec: StringSpec},
-				Value: ConstantList([]ConstantValue{
+				Value: ConstantList{
 					ConstantString("x"),
 					ConstReference{Target: y},
-				}),
+				},
 			},
 		},
 	}

--- a/compile/constant_value.go
+++ b/compile/constant_value.go
@@ -96,8 +96,7 @@ func (c ConstantInt) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
 	case DoubleSpec:
 		return ConstantDouble(float64(c)).Link(scope, t)
 	case BoolSpec:
-		v := int64(c)
-		switch v {
+		switch v := int64(c); v {
 		case 0, 1:
 			return ConstantBool(v == 1).Link(scope, t)
 		default:

--- a/compile/constant_value.go
+++ b/compile/constant_value.go
@@ -21,6 +21,7 @@
 package compile
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/thriftrw/thriftrw-go/ast"
@@ -28,12 +29,9 @@ import (
 
 // ConstantValue represents a compiled constant value or a reference to one.
 type ConstantValue interface {
-	Link(scope Scope) (ConstantValue, error)
-
-	// TODO link probably needs a reference to the type the constant is expected
-	// to be.
-
-	// TODO all constants must have a type associated with them.
+	// Link the constant value with the given scope, casting it to the given
+	// type if necessary.
+	Link(scope Scope, t TypeSpec) (ConstantValue, error)
 }
 
 // compileConstantValue compiles a constant value AST into a ConstantValue.
@@ -41,6 +39,7 @@ func compileConstantValue(v ast.ConstantValue) ConstantValue {
 	if v == nil {
 		return nil
 	}
+
 	switch src := v.(type) {
 	case ast.ConstantReference:
 		return constantReference(src)
@@ -61,6 +60,14 @@ func compileConstantValue(v ast.ConstantValue) ConstantValue {
 	}
 }
 
+// Helper for ConstantValues whose link method expects a specific TypeSpec.
+func typeEqualsOrCastError(c ConstantValue, want, got TypeSpec) (ConstantValue, error) {
+	if want != got {
+		return nil, constantValueCastError{Value: c, Type: got}
+	}
+	return c, nil
+}
+
 type (
 	// ConstantBool represents a boolean constant from the Thrift file.
 	ConstantBool bool
@@ -76,24 +83,110 @@ type (
 )
 
 // Link for ConstantBool
-func (c ConstantBool) Link(scope Scope) (ConstantValue, error) {
-	return c, nil
+func (c ConstantBool) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	return typeEqualsOrCastError(c, BoolSpec, t)
 }
 
 // Link for ConstantInt.
-func (c ConstantInt) Link(scope Scope) (ConstantValue, error) {
-	// TODO ConstantInt can resolve to a ConstantBool if it's being treated as
-	// a bool.
-	return c, nil
+func (c ConstantInt) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	switch t {
+	case I8Spec, I16Spec, I32Spec, I64Spec:
+		// TODO bounds checks?
+		return c, nil
+	case DoubleSpec:
+		return ConstantDouble(float64(c)).Link(scope, t)
+	case BoolSpec:
+		v := int64(c)
+		switch v {
+		case 0, 1:
+			return ConstantBool(v == 1).Link(scope, t)
+		default:
+			return nil, constantValueCastError{
+				Value:  c,
+				Type:   t,
+				Reason: errors.New("the value must be 0 or 1"),
+			}
+		}
+	default:
+		// fall through
+	}
+
+	// Used for an enum
+	if e, ok := t.(*EnumSpec); ok {
+		for _, item := range e.Items {
+			if item.Value == int32(c) {
+				return EnumItemReference{Enum: e, Item: item}, nil
+			}
+		}
+
+		return nil, constantValueCastError{
+			Value: c,
+			Type:  t,
+			Reason: fmt.Errorf(
+				"%v is not a valid value for enum %q", int32(c), e.ThriftName()),
+		}
+	}
+
+	return nil, constantValueCastError{Value: c, Type: t}
+	// TODO: AST for constants will need to track positions for us to
+	// include them in the error messages.
 }
 
 // Link for ConstantString.
-func (c ConstantString) Link(scope Scope) (ConstantValue, error) {
-	return c, nil
+func (c ConstantString) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	return typeEqualsOrCastError(c, StringSpec, t)
+	// TODO(abg): Are binary literals a thing?
 }
 
 // Link for ConstantDouble.
-func (c ConstantDouble) Link(scope Scope) (ConstantValue, error) {
+func (c ConstantDouble) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	return typeEqualsOrCastError(c, DoubleSpec, t)
+}
+
+// ConstantStruct represents a struct literal from the Thrift file.
+type ConstantStruct struct {
+	Fields map[string]ConstantValue
+}
+
+// Link for ConstantStruct
+func (c *ConstantStruct) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	s, ok := t.(*StructSpec)
+	if !ok {
+		return nil, constantValueCastError{Value: c, Type: t}
+	}
+
+	for _, field := range s.Fields {
+		f, ok := c.Fields[field.Name]
+		if !ok {
+			if field.Default == nil {
+				if field.Required {
+					return nil, constantValueCastError{
+						Value:  c,
+						Type:   t,
+						Reason: fmt.Errorf("%q is a required field", field.Name),
+					}
+				}
+				continue
+			}
+			f = field.Default
+			c.Fields[field.Name] = f
+		}
+
+		f, err := f.Link(scope, field.Type)
+		if err != nil {
+			return nil, constantValueCastError{
+				Value: c,
+				Type:  t,
+				Reason: constantStructFieldCastError{
+					FieldName: field.Name,
+					Reason:    err,
+				},
+			}
+		}
+
+		c.Fields[field.Name] = f
+	}
+
 	return c, nil
 }
 
@@ -118,20 +211,39 @@ type ConstantValuePair struct {
 }
 
 // Link for ConstantMap.
-func (c ConstantMap) Link(scope Scope) (ConstantValue, error) {
+func (c ConstantMap) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	if _, isStruct := t.(*StructSpec); isStruct {
+		fields := make(map[string]ConstantValue, len(c))
+		for _, pair := range c {
+			s, isString := pair.Key.(ConstantString)
+			if !isString {
+				return nil, constantValueCastError{
+					Value: c,
+					Type:  t,
+					Reason: fmt.Errorf(
+						"%v is not a string: all keys must be strings", pair.Key),
+				}
+			}
+
+			fields[string(s)] = pair.Value
+		}
+		s := ConstantStruct{Fields: fields}
+		return s.Link(scope, t)
+	}
+
+	m, ok := t.(*MapSpec)
+	if !ok {
+		return nil, constantValueCastError{Value: c, Type: t}
+	}
+
 	items := make([]ConstantValuePair, len(c))
-
-	// TODO ConstantMap can resolve into a constant struct if the type it is
-	// being cast to is a struct. Otherwise, all keys and values must be the
-	// same type.
-
 	for i, item := range c {
-		key, err := item.Key.Link(scope)
+		key, err := item.Key.Link(scope, m.KeySpec)
 		if err != nil {
 			return nil, err
 		}
 
-		value, err := item.Value.Link(scope)
+		value, err := item.Value.Link(scope, m.ValueSpec)
 		if err != nil {
 			return nil, err
 		}
@@ -141,6 +253,29 @@ func (c ConstantMap) Link(scope Scope) (ConstantValue, error) {
 	}
 
 	return ConstantMap(items), nil
+}
+
+// ConstantSet represents a set of constant values from the Thrift file.
+type ConstantSet []ConstantValue
+
+// Link for ConstantSet.
+func (c ConstantSet) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	s, ok := t.(*SetSpec)
+	if !ok {
+		return nil, constantValueCastError{Value: c, Type: t}
+	}
+
+	// TODO(abg): Track whether things are linked so that we don't re-link here
+	values := make([]ConstantValue, len(c))
+	for i, v := range c {
+		value, err := v.Link(scope, s.ValueSpec)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = value
+	}
+
+	return ConstantSet(values), nil
 }
 
 // ConstantList represents a list of constant values from the Thrift file.
@@ -155,14 +290,19 @@ func compileConstantList(src ast.ConstantList) ConstantList {
 }
 
 // Link for ConstantList.
-func (c ConstantList) Link(scope Scope) (ConstantValue, error) {
+func (c ConstantList) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	if _, isSet := t.(*SetSpec); isSet {
+		return ConstantSet(c).Link(scope, t)
+	}
+
+	l, ok := t.(*ListSpec)
+	if !ok {
+		return nil, constantValueCastError{Value: c, Type: t}
+	}
+
 	values := make([]ConstantValue, len(c))
-
-	// TODO ConstantList can resolve to a constant set if it's being treated as
-	// such.
-
 	for i, v := range c {
-		value, err := v.Link(scope)
+		value, err := v.Link(scope, l.ValueSpec)
 		if err != nil {
 			return nil, err
 		}
@@ -179,9 +319,12 @@ type ConstReference struct {
 }
 
 // Link for ConstReference.
-func (c ConstReference) Link(scope Scope) (ConstantValue, error) {
-	// The reference has already been verified. Nothing to do.
-	return c, nil
+func (c ConstReference) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	cv, err := typeEqualsOrCastError(c, c.Target.Type, t)
+	if err != nil {
+		err = constantCastError{Name: c.Target.Name, Reason: err}
+	}
+	return cv, err
 }
 
 // EnumItemReference represents a reference to an item of an enum defined in the
@@ -192,9 +335,8 @@ type EnumItemReference struct {
 }
 
 // Link for EnumItemReference.
-func (e EnumItemReference) Link(scope Scope) (ConstantValue, error) {
-	// The reference has already been verified. Nothing to do.
-	return e, nil
+func (e EnumItemReference) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
+	return typeEqualsOrCastError(e, e.Enum, t)
 }
 
 // constantReference represents a reference to another constant.
@@ -206,7 +348,7 @@ type constantReference ast.ConstantReference
 // Link a constantReference.
 //
 // This resolves the reference to a ConstReference or an EnumItemReference.
-func (r constantReference) Link(scope Scope) (ConstantValue, error) {
+func (r constantReference) Link(scope Scope, t TypeSpec) (ConstantValue, error) {
 	src := ast.ConstantReference(r)
 
 	c, err := scope.LookupConstant(src.Name)
@@ -254,7 +396,7 @@ func (r constantReference) Link(scope Scope) (ConstantValue, error) {
 		}
 	}
 
-	value, err := constantReference{Name: iname}.Link(includedScope)
+	value, err := constantReference{Name: iname}.Link(includedScope, t)
 	if err != nil {
 		return nil, referenceError{
 			Target:    src.Name,

--- a/compile/constant_value_test.go
+++ b/compile/constant_value_test.go
@@ -362,13 +362,13 @@ func TestCastConstants(t *testing.T) {
 		},
 		{
 			desc: "ConstantReference: mismatch",
-			typ:  I64Spec,
+			typ:  DoubleSpec,
 			give: ConstReference{Target: &Constant{
 				Name:  "Version",
 				Type:  I32Spec,
 				Value: ConstantInt(42),
 			}},
-			wantError: `failed to cast constant "Version"`,
+			want: ConstantDouble(42.0),
 		},
 	}
 

--- a/compile/constant_value_test.go
+++ b/compile/constant_value_test.go
@@ -51,22 +51,26 @@ func TestLinkConstantReference(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc     string
-		scope    Scope
-		name     string
+		desc  string
+		scope Scope
+		name  string
+
 		expected ConstantValue
+		typ      TypeSpec
 	}{
 		{
 			"simple constant lookup",
 			scope("Version", version),
 			"Version",
 			ConstReference{Target: version},
+			I32Spec,
 		},
 		{
 			"included constant lookup",
 			scope("shared", scope("DefaultUser", defaultUser)),
 			"shared.DefaultUser",
 			ConstReference{Target: defaultUser},
+			StringSpec,
 		},
 		{
 			"enum constant lookup",
@@ -76,6 +80,7 @@ func TestLinkConstantReference(t *testing.T) {
 				Enum: role,
 				Item: EnumItem{Name: "Moderator", Value: 2},
 			},
+			role,
 		},
 		{
 			"included enum constant lookup",
@@ -85,33 +90,333 @@ func TestLinkConstantReference(t *testing.T) {
 				Enum: role,
 				Item: EnumItem{Name: "Disabled", Value: -1},
 			},
+			role,
 		},
 	}
 
 	for _, tt := range tests {
-		expected, err := tt.expected.Link(scope())
+		expected, err := tt.expected.Link(scope(), tt.typ)
 		require.NoError(t, err, "Test constant value must link without errors")
 
 		scope := scopeOrDefault(tt.scope)
-		got, err := constantReference(ast.ConstantReference{Name: tt.name}).Link(scope)
+		got, err := constantReference(ast.ConstantReference{Name: tt.name}).Link(scope, tt.typ)
 		if assert.NoError(t, err, tt.desc) {
 			assert.Equal(t, expected, got)
 		}
 	}
 }
 
+func TestCastConstants(t *testing.T) {
+	role := &EnumSpec{
+		Name: "Role",
+		Items: []EnumItem{
+			{Name: "Disabled", Value: -1},
+			{Name: "Enabled", Value: 1},
+			{Name: "Moderator", Value: 2},
+		},
+	}
+
+	someStruct := &StructSpec{
+		Name: "SomeStruct",
+		Type: ast.StructType,
+		Fields: FieldGroup{
+			{
+				ID:       1,
+				Name:     "someRequiredField",
+				Required: true,
+				Type:     I32Spec,
+			},
+			{
+				ID:   2,
+				Name: "someOptionalField",
+				Type: StringSpec,
+			},
+			{
+				ID:       3,
+				Name:     "someFieldWithADefault",
+				Required: true,
+				Type:     I64Spec,
+				Default:  ConstantInt(42),
+			},
+		},
+	}
+
+	tests := []struct {
+		desc  string
+		scope Scope
+		typ   TypeSpec
+		give  ConstantValue
+
+		want      ConstantValue
+		wantError string
+	}{
+		{
+			desc: "ConstantBool",
+			typ:  BoolSpec,
+			give: ConstantBool(true),
+			want: ConstantBool(true),
+		},
+		{
+			desc: "ConstantInt: bool (false)",
+			typ:  BoolSpec,
+			give: ConstantInt(0),
+			want: ConstantBool(false),
+		},
+		{
+			desc: "ConstantInt: bool (true)",
+			typ:  BoolSpec,
+			give: ConstantInt(1),
+			want: ConstantBool(true),
+		},
+		{
+			desc:      "ConstantInt: bool (failure)",
+			typ:       BoolSpec,
+			give:      ConstantInt(2),
+			wantError: "the value must be 0 or 1",
+		},
+		{
+			desc: "ConstantInt: i8",
+			typ:  I8Spec,
+			give: ConstantInt(42),
+			want: ConstantInt(42),
+		},
+		{
+			desc: "ConstantInt: i16",
+			typ:  I16Spec,
+			give: ConstantInt(42),
+			want: ConstantInt(42),
+		},
+		{
+			desc: "ConstantInt: i32",
+			typ:  I32Spec,
+			give: ConstantInt(42),
+			want: ConstantInt(42),
+		},
+		{
+			desc: "ConstantInt: i64",
+			typ:  I64Spec,
+			give: ConstantInt(42),
+			want: ConstantInt(42),
+		},
+		{
+			desc: "ConstantInt: double",
+			typ:  DoubleSpec,
+			give: ConstantInt(42),
+			want: ConstantDouble(42.0),
+		},
+		{
+			desc: "ConstantInt: enum (negative)",
+			typ:  role,
+			give: ConstantInt(-1),
+			want: EnumItemReference{
+				Enum: role,
+				Item: role.Items[0], // Disabled
+			},
+		},
+		{
+			desc: "ConstantInt: enum (positive)",
+			typ:  role,
+			give: ConstantInt(2),
+			want: EnumItemReference{
+				Enum: role,
+				Item: role.Items[2], // Moderator
+			},
+		},
+		{
+			desc:      "ConstantInt: enum (failure)",
+			typ:       role,
+			give:      ConstantInt(3),
+			wantError: `3 is not a valid value for enum "Role"`,
+		},
+		{
+			desc:      "ConstantInt: failure",
+			typ:       StringSpec,
+			give:      ConstantInt(1),
+			wantError: `cannot cast 1 to "string"`,
+		},
+		{
+			desc: "ConstantString",
+			typ:  StringSpec,
+			give: ConstantString("foo"),
+			want: ConstantString("foo"),
+		},
+		{
+			desc: "ConstantDouble",
+			typ:  DoubleSpec,
+			give: ConstantDouble(42.0),
+			want: ConstantDouble(42.0),
+		},
+		{
+			desc: "ConstantStruct: all fields",
+			typ:  someStruct,
+			give: &ConstantStruct{
+				Fields: map[string]ConstantValue{
+					"someRequiredField":     ConstantInt(100),
+					"someOptionalField":     ConstantString("hello"),
+					"someFieldWithADefault": ConstantInt(1),
+				},
+			},
+			want: &ConstantStruct{
+				Fields: map[string]ConstantValue{
+					"someRequiredField":     ConstantInt(100),
+					"someOptionalField":     ConstantString("hello"),
+					"someFieldWithADefault": ConstantInt(1),
+				},
+			},
+		},
+		{
+			desc: "ConstantStruct: with default",
+			typ:  someStruct,
+			give: &ConstantStruct{
+				Fields: map[string]ConstantValue{
+					"someRequiredField": ConstantInt(100),
+				},
+			},
+			want: &ConstantStruct{
+				Fields: map[string]ConstantValue{
+					"someRequiredField":     ConstantInt(100),
+					"someFieldWithADefault": ConstantInt(42),
+				},
+			},
+		},
+		{
+			desc:      "ConstantStruct: failure",
+			typ:       someStruct,
+			give:      &ConstantStruct{Fields: map[string]ConstantValue{}},
+			wantError: `"someRequiredField" is a required field`,
+		},
+		{
+			desc: "ConstantStruct: field casting failure",
+			typ:  someStruct,
+			give: &ConstantStruct{
+				Fields: map[string]ConstantValue{
+					"someRequiredField": ConstantString("foo"),
+				},
+			},
+			wantError: `failed to cast field "someRequiredField": cannot cast foo to "i32"`,
+		},
+		{
+			desc: "ConstantMap",
+			typ:  &MapSpec{KeySpec: StringSpec, ValueSpec: I32Spec},
+			give: ConstantMap{
+				{Key: ConstantString("hello"), Value: ConstantInt(100)},
+				{Key: ConstantString("world"), Value: ConstantInt(200)},
+			},
+			want: ConstantMap{
+				{Key: ConstantString("hello"), Value: ConstantInt(100)},
+				{Key: ConstantString("world"), Value: ConstantInt(200)},
+			},
+		},
+		{
+			desc: "ConstantMap: struct",
+			typ:  someStruct,
+			give: ConstantMap{
+				{
+					Key:   ConstantString("someRequiredField"),
+					Value: ConstantInt(100),
+				},
+			},
+			want: &ConstantStruct{
+				Fields: map[string]ConstantValue{
+					"someRequiredField":     ConstantInt(100),
+					"someFieldWithADefault": ConstantInt(42),
+				},
+			},
+		},
+		{
+			desc: "ConstantMap: struct (invalid key)",
+			typ:  someStruct,
+			give: ConstantMap{
+				{
+					Key:   ConstantInt(100),
+					Value: ConstantInt(200),
+				},
+			},
+			wantError: "100 is not a string: all keys must be strings",
+		},
+		{
+			desc: "ConstantSet",
+			typ:  &SetSpec{ValueSpec: I32Spec},
+			give: ConstantSet{ConstantInt(1), ConstantInt(2), ConstantInt(3)},
+			want: ConstantSet{ConstantInt(1), ConstantInt(2), ConstantInt(3)},
+		},
+		{
+			desc: "ConstantList",
+			typ:  &ListSpec{ValueSpec: I32Spec},
+			give: ConstantList{ConstantInt(1), ConstantInt(2), ConstantInt(3)},
+			want: ConstantList{ConstantInt(1), ConstantInt(2), ConstantInt(3)},
+		},
+		{
+			desc: "ConstantReference",
+			typ:  I32Spec,
+			give: ConstReference{Target: &Constant{
+				Name:  "Version",
+				Type:  I32Spec,
+				Value: ConstantInt(42),
+			}},
+			want: ConstReference{Target: &Constant{
+				Name:  "Version",
+				Type:  I32Spec,
+				Value: ConstantInt(42),
+			}},
+		},
+		{
+			desc: "ConstantReference: mismatch",
+			typ:  I64Spec,
+			give: ConstReference{Target: &Constant{
+				Name:  "Version",
+				Type:  I32Spec,
+				Value: ConstantInt(42),
+			}},
+			wantError: `failed to cast constant "Version"`,
+		},
+	}
+
+	for _, tt := range tests {
+		var err error
+		tt.typ, err = tt.typ.Link(scope())
+		require.NoError(t, err, "'typ' must link without errors")
+
+		if tt.want != nil {
+			tt.want, err = tt.want.Link(scope(), tt.typ)
+			require.NoError(t, err, "'want' must link without errors")
+		}
+
+		scope := scopeOrDefault(tt.scope)
+		got, err := tt.give.Link(scope, tt.typ)
+		if tt.wantError != "" {
+			if assert.Error(t, err, tt.desc) {
+				assert.Contains(t, err.Error(), tt.wantError, tt.desc)
+			}
+		} else {
+			if assert.NoError(t, err, tt.desc) {
+				assert.Equal(t, tt.want, got, tt.desc)
+			}
+		}
+	}
+}
+
 func TestLinkConstantReferenceFailure(t *testing.T) {
+	foo := &EnumSpec{
+		Name: "Foo",
+		Items: []EnumItem{
+			{Name: "A", Value: 1},
+			{Name: "B", Value: 2},
+		},
+	}
 	tests := []struct {
 		desc     string
 		scope    Scope
 		name     string
 		messages []string
+		typ      TypeSpec
 	}{
 		{
 			"unknown identifier",
 			scope("bar"),
 			"foo",
 			[]string{`could not resolve reference "foo" in "bar"`},
+			StringSpec,
 		},
 		{
 			"unknown module",
@@ -121,6 +426,7 @@ func TestLinkConstantReferenceFailure(t *testing.T) {
 				`could not resolve reference "shared.DEFAULT_UUID" in "bar"`,
 				`unknown module "shared"`,
 			},
+			StringSpec,
 		},
 		{
 			"unknown identifier in included module",
@@ -130,29 +436,25 @@ func TestLinkConstantReferenceFailure(t *testing.T) {
 				`could not resolve reference "shared.DEFAULT_UUID" in "foo"`,
 				`could not resolve reference "DEFAULT_UUID" in "shared"`,
 			},
+			StringSpec,
 		},
 		{
 			"unknown item in enum",
 			scope("foo",
-				"Foo", &EnumSpec{
-					Name: "Foo",
-					Items: []EnumItem{
-						{Name: "A", Value: 1},
-						{Name: "B", Value: 2},
-					},
-				},
+				"Foo", foo,
 			),
 			"Foo.C",
 			[]string{
 				`could not resolve reference "Foo.C" in "foo"`,
 				`enum "Foo" does not have an item named "C"`,
 			},
+			foo,
 		},
 	}
 
 	for _, tt := range tests {
 		scope := scopeOrDefault(tt.scope)
-		_, err := constantReference(ast.ConstantReference{Name: tt.name}).Link(scope)
+		_, err := constantReference(ast.ConstantReference{Name: tt.name}).Link(scope, tt.typ)
 		if assert.Error(t, err, tt.desc) {
 			for _, msg := range tt.messages {
 				assert.Contains(t, err.Error(), msg, tt.desc)

--- a/compile/error.go
+++ b/compile/error.go
@@ -276,3 +276,38 @@ func (e typeReferenceCycleError) Error() string {
 	}
 	return strings.Join(lines, "\n")
 }
+
+// Failure to cast a Constantvalue to a specific type.
+type constantValueCastError struct {
+	Value  ConstantValue
+	Type   TypeSpec
+	Reason error // optional
+}
+
+func (e constantValueCastError) Error() string {
+	s := fmt.Sprintf("cannot cast %v to %q", e.Value, e.Type.ThriftName())
+	if e.Reason != nil {
+		s += fmt.Sprintf(": %v", e.Reason)
+	}
+	return s
+}
+
+// Failure to cast a specific field of a struct literal.
+type constantStructFieldCastError struct {
+	FieldName string
+	Reason    error
+}
+
+func (e constantStructFieldCastError) Error() string {
+	return fmt.Sprintf("failed to cast field %q: %v", e.FieldName, e.Reason)
+}
+
+// Failure to cast a value referenced by a named constant.
+type constantCastError struct {
+	Name   string
+	Reason error
+}
+
+func (e constantCastError) Error() string {
+	return fmt.Sprintf("failed to cast constant %q: %v", e.Name, e.Reason)
+}

--- a/compile/field.go
+++ b/compile/field.go
@@ -127,7 +127,7 @@ func (f *FieldSpec) Link(scope Scope) (err error) {
 		return err
 	}
 	if f.Default != nil {
-		f.Default, err = f.Default.Link(scope)
+		f.Default, err = f.Default.Link(scope, f.Type)
 	}
 	return err
 }


### PR DESCRIPTION
This adds support for constant values to be casted to types based on context.
The following casts are supported:

-   `int` to `double`
-   `int` to `bool`
-   `int` to `enum`
-   `map[string]*` to `struct`
-   `list` to `set`

This is the same behavior supported by Apache Thrift, but with an extra level
of safety and type checking.

We need this before we can implement code generation for constant values.