### PR TITLE
compile: Add a non-strict mode for compilation

### DIFF
--- a/compile/options.go
+++ b/compile/options.go
@@ -54,3 +54,11 @@ func Filesystem(fs FS) Option {
 		c.fs = fs
 	}
 }
+
+// NonStrict disables strict validation of the Thrift file. This allows
+// struct fields which are not marked as optional or required.
+func NonStrict() Option {
+	return func(c *compiler) {
+		c.nonStrict = true
+	}
+}

--- a/compile/struct.go
+++ b/compile/struct.go
@@ -36,8 +36,8 @@ type StructSpec struct {
 }
 
 // compileStruct compiles a struct AST into a StructSpec.
-func compileStruct(file string, src *ast.Struct) (*StructSpec, error) {
-	opts := fieldOptions{requiredness: explicitRequiredness}
+func compileStruct(file string, src *ast.Struct, requiredness fieldRequiredness) (*StructSpec, error) {
+	opts := fieldOptions{requiredness: requiredness}
 
 	if src.Type == ast.UnionType {
 		opts.requiredness = noRequiredFields


### PR DESCRIPTION
In tools like yab, we want to be able to opt-out of strict mode.