### PR TITLE
compile: Add RootTypeSpec function

### DIFF
--- a/compile/type.go
+++ b/compile/type.go
@@ -53,6 +53,17 @@ type TypeSpec interface {
 	ForEachTypeReference(func(TypeSpec) error) error
 }
 
+// RootTypeSpec returns the TypeSpec that the given linked TypeSpec points to.
+//
+// For most types, this is the type itself. For Typedefs, it is the root
+// TypeSpec of the Typedef's target.
+func RootTypeSpec(s TypeSpec) TypeSpec {
+	if t, ok := s.(*TypedefSpec); ok {
+		return t.root
+	}
+	return s
+}
+
 // nativeThriftType is the common parent for all TypeSpecs that are native
 // Thrift types.
 type nativeThriftType struct{}

--- a/compile/typedef.go
+++ b/compile/typedef.go
@@ -32,6 +32,8 @@ type TypedefSpec struct {
 	Name   string
 	File   string
 	Target TypeSpec
+
+	root TypeSpec
 }
 
 // compileTypedef compiles the given Typedef AST into a TypedefSpec.
@@ -56,6 +58,9 @@ func (t *TypedefSpec) Link(scope Scope) (TypeSpec, error) {
 
 	var err error
 	t.Target, err = t.Target.Link(scope)
+	if err == nil {
+		t.root = RootTypeSpec(t.Target)
+	}
 	return t, err
 }
 

--- a/gen/wire.go
+++ b/gen/wire.go
@@ -241,6 +241,7 @@ func (w *WireGenerator) FromWirePtr(g Generator, spec compile.TypeSpec, lhs stri
 // over-the-wire type code for the given TypeSpec.
 func TypeCode(g Generator, spec compile.TypeSpec) string {
 	wire := g.Import("github.com/thriftrw/thriftrw-go/wire")
+	spec = compile.RootTypeSpec(spec)
 
 	switch spec {
 	case compile.BoolSpec:
@@ -261,15 +262,13 @@ func TypeCode(g Generator, spec compile.TypeSpec) string {
 		// Not a primitive type
 	}
 
-	switch s := spec.(type) {
+	switch spec.(type) {
 	case *compile.MapSpec:
 		return fmt.Sprintf("%s.TMap", wire)
 	case *compile.ListSpec:
 		return fmt.Sprintf("%s.TList", wire)
 	case *compile.SetSpec:
 		return fmt.Sprintf("%s.TSet", wire)
-	case *compile.TypedefSpec:
-		return TypeCode(g, s.Target)
 	case *compile.EnumSpec:
 		return fmt.Sprintf("%s.TI32", wire)
 	case *compile.StructSpec:


### PR DESCRIPTION
This retrieves the root TypeSpec a typedef chain points to.

Resolves #138