### PR TITLE
lazy lists: Embed type information in interfaces

### DIFF
--- a/gen/container_test.go
+++ b/gen/container_test.go
@@ -40,12 +40,8 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 			"empty list",
 			tc.PrimitiveContainers{ListOfInts: []int64{}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{{
-				ID: 2,
-				Value: wire.NewValueList(wire.List{
-					ValueType: wire.TI64,
-					Size:      0,
-					Items:     wire.ValueListFromSlice([]wire.Value{}),
-				}),
+				ID:    2,
+				Value: wire.NewValueList(wire.ValueListFromSlice(wire.TI64, []wire.Value{})),
 			}}}),
 		},
 		{
@@ -53,15 +49,13 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 			tc.PrimitiveContainers{ListOfInts: []int64{1, 2, 3}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{{
 				ID: 2,
-				Value: wire.NewValueList(wire.List{
-					ValueType: wire.TI64,
-					Size:      3,
-					Items: wire.ValueListFromSlice([]wire.Value{
+				Value: wire.NewValueList(
+					wire.ValueListFromSlice(wire.TI64, []wire.Value{
 						wire.NewValueI64(1),
 						wire.NewValueI64(2),
 						wire.NewValueI64(3),
 					}),
-				}),
+				),
 			}}}),
 		},
 		{
@@ -73,15 +67,13 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{{
 				ID: 1,
-				Value: wire.NewValueList(wire.List{
-					ValueType: wire.TBinary,
-					Size:      3,
-					Items: wire.ValueListFromSlice([]wire.Value{
+				Value: wire.NewValueList(
+					wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 						wire.NewValueBinary([]byte("foo")),
 						wire.NewValueBinary([]byte("bar")),
 						wire.NewValueBinary([]byte("baz")),
 					}),
-				}),
+				),
 			}}}),
 		},
 		// Sets //////////////////////////////////////////////////////////////
@@ -90,11 +82,9 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 			tc.PrimitiveContainers{SetOfStrings: map[string]struct{}{}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{{
 				ID: 3,
-				Value: wire.NewValueSet(wire.Set{
-					ValueType: wire.TBinary,
-					Size:      0,
-					Items:     wire.ValueListFromSlice([]wire.Value{}),
-				}),
+				Value: wire.NewValueSet(
+					wire.ValueListFromSlice(wire.TBinary, []wire.Value{}),
+				),
 			}}}),
 		},
 		{
@@ -106,15 +96,13 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 			}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{{
 				ID: 3,
-				Value: wire.NewValueSet(wire.Set{
-					ValueType: wire.TBinary,
-					Size:      3,
-					Items: wire.ValueListFromSlice([]wire.Value{
+				Value: wire.NewValueSet(
+					wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 						wire.NewValueString("foo"),
 						wire.NewValueString("bar"),
 						wire.NewValueString("baz"),
 					}),
-				}),
+				),
 			}}}),
 		},
 		{
@@ -126,15 +114,13 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 			}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{{
 				ID: 4,
-				Value: wire.NewValueSet(wire.Set{
-					ValueType: wire.TI8,
-					Size:      3,
-					Items: wire.ValueListFromSlice([]wire.Value{
+				Value: wire.NewValueSet(
+					wire.ValueListFromSlice(wire.TI8, []wire.Value{
 						wire.NewValueI8(-1),
 						wire.NewValueI8(1),
 						wire.NewValueI8(125),
 					}),
-				}),
+				),
 			}}}),
 		},
 		// Maps //////////////////////////////////////////////////////////////
@@ -143,12 +129,9 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 			tc.PrimitiveContainers{MapOfStringToBool: map[string]bool{}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{{
 				ID: 6,
-				Value: wire.NewValueMap(wire.Map{
-					KeyType:   wire.TBinary,
-					ValueType: wire.TBool,
-					Size:      0,
-					Items:     wire.MapItemListFromSlice([]wire.MapItem{}),
-				}),
+				Value: wire.NewValueMap(
+					wire.MapItemListFromSlice(wire.TBinary, wire.TBool, []wire.MapItem{}),
+				),
 			}}}),
 		},
 		{
@@ -160,16 +143,13 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 			}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{{
 				ID: 5,
-				Value: wire.NewValueMap(wire.Map{
-					KeyType:   wire.TI32,
-					ValueType: wire.TBinary,
-					Size:      3,
-					Items: wire.MapItemListFromSlice([]wire.MapItem{
+				Value: wire.NewValueMap(
+					wire.MapItemListFromSlice(wire.TI32, wire.TBinary, []wire.MapItem{
 						{Key: wire.NewValueI32(-1), Value: wire.NewValueString("foo")},
 						{Key: wire.NewValueI32(1234), Value: wire.NewValueString("bar")},
 						{Key: wire.NewValueI32(-9876), Value: wire.NewValueString("baz")},
 					}),
-				}),
+				),
 			}}}),
 		},
 		{
@@ -181,16 +161,13 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 			}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{{
 				ID: 6,
-				Value: wire.NewValueMap(wire.Map{
-					KeyType:   wire.TBinary,
-					ValueType: wire.TBool,
-					Size:      3,
-					Items: wire.MapItemListFromSlice([]wire.MapItem{
+				Value: wire.NewValueMap(
+					wire.MapItemListFromSlice(wire.TBinary, wire.TBool, []wire.MapItem{
 						{Key: wire.NewValueString("foo"), Value: wire.NewValueBool(true)},
 						{Key: wire.NewValueString("bar"), Value: wire.NewValueBool(false)},
 						{Key: wire.NewValueString("baz"), Value: wire.NewValueBool(true)},
 					}),
-				}),
+				),
 			}}}),
 		},
 	}
@@ -212,14 +189,12 @@ func TestEnumContainers(t *testing.T) {
 					te.EnumDefaultBar,
 				},
 			},
-			singleFieldStruct(1, wire.NewValueList(wire.List{
-				ValueType: wire.TI32,
-				Size:      2,
-				Items: wire.ValueListFromSlice([]wire.Value{
+			singleFieldStruct(1, wire.NewValueList(
+				wire.ValueListFromSlice(wire.TI32, []wire.Value{
 					wire.NewValueI32(0),
 					wire.NewValueI32(1),
 				}),
-			})),
+			)),
 		},
 		{
 			tc.EnumContainers{
@@ -228,14 +203,12 @@ func TestEnumContainers(t *testing.T) {
 					te.EnumWithValuesZ: struct{}{},
 				},
 			},
-			singleFieldStruct(2, wire.NewValueSet(wire.Set{
-				ValueType: wire.TI32,
-				Size:      2,
-				Items: wire.ValueListFromSlice([]wire.Value{
+			singleFieldStruct(2, wire.NewValueSet(
+				wire.ValueListFromSlice(wire.TI32, []wire.Value{
 					wire.NewValueI32(123),
 					wire.NewValueI32(789),
 				}),
-			})),
+			)),
 		},
 		{
 			tc.EnumContainers{
@@ -244,15 +217,12 @@ func TestEnumContainers(t *testing.T) {
 					te.EnumWithDuplicateValuesQ: 456,
 				},
 			},
-			singleFieldStruct(3, wire.NewValueMap(wire.Map{
-				KeyType:   wire.TI32,
-				ValueType: wire.TI32,
-				Size:      2,
-				Items: wire.MapItemListFromSlice([]wire.MapItem{
+			singleFieldStruct(3, wire.NewValueMap(
+				wire.MapItemListFromSlice(wire.TI32, wire.TI32, []wire.MapItem{
 					wire.MapItem{Key: wire.NewValueI32(0), Value: wire.NewValueI32(123)},
 					wire.MapItem{Key: wire.NewValueI32(-1), Value: wire.NewValueI32(456)},
 				}),
-			})),
+			)),
 		},
 		{
 			// this is the same as the one above except we're using "R" intsead
@@ -263,15 +233,13 @@ func TestEnumContainers(t *testing.T) {
 					te.EnumWithDuplicateValuesQ: 456,
 				},
 			},
-			singleFieldStruct(3, wire.NewValueMap(wire.Map{
-				KeyType:   wire.TI32,
-				ValueType: wire.TI32,
-				Size:      2,
-				Items: wire.MapItemListFromSlice([]wire.MapItem{
+			singleFieldStruct(3, wire.NewValueMap(
+
+				wire.MapItemListFromSlice(wire.TI32, wire.TI32, []wire.MapItem{
 					wire.MapItem{Key: wire.NewValueI32(0), Value: wire.NewValueI32(123)},
 					wire.MapItem{Key: wire.NewValueI32(-1), Value: wire.NewValueI32(456)},
 				}),
-			})),
+			)),
 		},
 	}
 
@@ -287,11 +255,9 @@ func TestListOfStructs(t *testing.T) {
 	}{
 		{
 			ts.Graph{Edges: []*ts.Edge{}},
-			singleFieldStruct(1, wire.NewValueList(wire.List{
-				ValueType: wire.TStruct,
-				Size:      0,
-				Items:     wire.ValueListFromSlice(nil),
-			})),
+			singleFieldStruct(1, wire.NewValueList(
+				wire.ValueListFromSlice(wire.TStruct, nil),
+			)),
 		},
 		{
 			ts.Graph{Edges: []*ts.Edge{
@@ -308,10 +274,8 @@ func TestListOfStructs(t *testing.T) {
 					End:   &ts.Point{X: 11.0, Y: 12.0},
 				},
 			}},
-			singleFieldStruct(1, wire.NewValueList(wire.List{
-				ValueType: wire.TStruct,
-				Size:      3,
-				Items: wire.ValueListFromSlice([]wire.Value{
+			singleFieldStruct(1, wire.NewValueList(
+				wire.ValueListFromSlice(wire.TStruct, []wire.Value{
 					wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 						{
 							ID: 1,
@@ -361,7 +325,7 @@ func TestListOfStructs(t *testing.T) {
 						},
 					}}),
 				}),
-			})),
+			)),
 		},
 	}
 
@@ -385,30 +349,24 @@ func TestCrazyTown(t *testing.T) {
 				},
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 1, Value: wire.NewValueList(wire.List{
-					ValueType: wire.TList,
-					Size:      2,
-					Items: wire.ValueListFromSlice([]wire.Value{
-						wire.NewValueList(wire.List{
-							ValueType: wire.TI32,
-							Size:      3,
-							Items: wire.ValueListFromSlice([]wire.Value{
+				{ID: 1, Value: wire.NewValueList(
+					wire.ValueListFromSlice(wire.TList, []wire.Value{
+						wire.NewValueList(
+							wire.ValueListFromSlice(wire.TI32, []wire.Value{
 								wire.NewValueI32(1),
 								wire.NewValueI32(2),
 								wire.NewValueI32(3),
 							}),
-						}),
-						wire.NewValueList(wire.List{
-							ValueType: wire.TI32,
-							Size:      3,
-							Items: wire.ValueListFromSlice([]wire.Value{
+						),
+						wire.NewValueList(
+							wire.ValueListFromSlice(wire.TI32, []wire.Value{
 								wire.NewValueI32(4),
 								wire.NewValueI32(5),
 								wire.NewValueI32(6),
 							}),
-						}),
+						),
 					}),
-				})},
+				)},
 			}}),
 		},
 		{
@@ -428,30 +386,24 @@ func TestCrazyTown(t *testing.T) {
 				},
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 2, Value: wire.NewValueList(wire.List{
-					ValueType: wire.TSet,
-					Size:      2,
-					Items: wire.ValueListFromSlice([]wire.Value{
-						wire.NewValueSet(wire.Set{
-							ValueType: wire.TI32,
-							Size:      3,
-							Items: wire.ValueListFromSlice([]wire.Value{
+				{ID: 2, Value: wire.NewValueList(
+					wire.ValueListFromSlice(wire.TSet, []wire.Value{
+						wire.NewValueSet(
+							wire.ValueListFromSlice(wire.TI32, []wire.Value{
 								wire.NewValueI32(1),
 								wire.NewValueI32(2),
 								wire.NewValueI32(3),
 							}),
-						}),
-						wire.NewValueSet(wire.Set{
-							ValueType: wire.TI32,
-							Size:      3,
-							Items: wire.ValueListFromSlice([]wire.Value{
+						),
+						wire.NewValueSet(
+							wire.ValueListFromSlice(wire.TI32, []wire.Value{
 								wire.NewValueI32(4),
 								wire.NewValueI32(5),
 								wire.NewValueI32(6),
 							}),
-						}),
+						),
 					}),
-				})},
+				)},
 			}}),
 		},
 		{
@@ -471,32 +423,24 @@ func TestCrazyTown(t *testing.T) {
 				},
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 3, Value: wire.NewValueList(wire.List{
-					ValueType: wire.TMap,
-					Size:      2,
-					Items: wire.ValueListFromSlice([]wire.Value{
-						wire.NewValueMap(wire.Map{
-							KeyType:   wire.TI32,
-							ValueType: wire.TI32,
-							Size:      3,
-							Items: wire.MapItemListFromSlice([]wire.MapItem{
+				{ID: 3, Value: wire.NewValueList(
+					wire.ValueListFromSlice(wire.TMap, []wire.Value{
+						wire.NewValueMap(
+							wire.MapItemListFromSlice(wire.TI32, wire.TI32, []wire.MapItem{
 								{Key: wire.NewValueI32(1), Value: wire.NewValueI32(100)},
 								{Key: wire.NewValueI32(2), Value: wire.NewValueI32(200)},
 								{Key: wire.NewValueI32(3), Value: wire.NewValueI32(300)},
 							}),
-						}),
-						wire.NewValueMap(wire.Map{
-							KeyType:   wire.TI32,
-							ValueType: wire.TI32,
-							Size:      3,
-							Items: wire.MapItemListFromSlice([]wire.MapItem{
+						),
+						wire.NewValueMap(
+							wire.MapItemListFromSlice(wire.TI32, wire.TI32, []wire.MapItem{
 								{Key: wire.NewValueI32(4), Value: wire.NewValueI32(400)},
 								{Key: wire.NewValueI32(5), Value: wire.NewValueI32(500)},
 								{Key: wire.NewValueI32(6), Value: wire.NewValueI32(600)},
 							}),
-						}),
+						),
 					}),
-				})},
+				)},
 			}}),
 		},
 		{
@@ -516,30 +460,24 @@ func TestCrazyTown(t *testing.T) {
 				},
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 4, Value: wire.NewValueSet(wire.Set{
-					ValueType: wire.TSet,
-					Size:      2,
-					Items: wire.ValueListFromSlice([]wire.Value{
-						wire.NewValueSet(wire.Set{
-							ValueType: wire.TBinary,
-							Size:      3,
-							Items: wire.ValueListFromSlice([]wire.Value{
+				{ID: 4, Value: wire.NewValueSet(
+					wire.ValueListFromSlice(wire.TSet, []wire.Value{
+						wire.NewValueSet(
+							wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 								wire.NewValueString("1"),
 								wire.NewValueString("2"),
 								wire.NewValueString("3"),
 							}),
-						}),
-						wire.NewValueSet(wire.Set{
-							ValueType: wire.TBinary,
-							Size:      3,
-							Items: wire.ValueListFromSlice([]wire.Value{
+						),
+						wire.NewValueSet(
+							wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 								wire.NewValueString("4"),
 								wire.NewValueString("5"),
 								wire.NewValueString("6"),
 							}),
-						}),
+						),
 					}),
-				})},
+				)},
 			}}),
 		},
 		{
@@ -551,30 +489,24 @@ func TestCrazyTown(t *testing.T) {
 				},
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 5, Value: wire.NewValueSet(wire.Set{
-					ValueType: wire.TList,
-					Size:      2,
-					Items: wire.ValueListFromSlice([]wire.Value{
-						wire.NewValueList(wire.List{
-							ValueType: wire.TBinary,
-							Size:      3,
-							Items: wire.ValueListFromSlice([]wire.Value{
+				{ID: 5, Value: wire.NewValueSet(
+					wire.ValueListFromSlice(wire.TList, []wire.Value{
+						wire.NewValueList(
+							wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 								wire.NewValueString("1"),
 								wire.NewValueString("2"),
 								wire.NewValueString("3"),
 							}),
-						}),
-						wire.NewValueList(wire.List{
-							ValueType: wire.TBinary,
-							Size:      3,
-							Items: wire.ValueListFromSlice([]wire.Value{
+						),
+						wire.NewValueList(
+							wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 								wire.NewValueString("4"),
 								wire.NewValueString("5"),
 								wire.NewValueString("6"),
 							}),
-						}),
+						),
 					}),
-				})},
+				)},
 			}}),
 		},
 		{
@@ -594,32 +526,24 @@ func TestCrazyTown(t *testing.T) {
 				},
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 6, Value: wire.NewValueSet(wire.Set{
-					ValueType: wire.TMap,
-					Size:      2,
-					Items: wire.ValueListFromSlice([]wire.Value{
-						wire.NewValueMap(wire.Map{
-							KeyType:   wire.TBinary,
-							ValueType: wire.TBinary,
-							Size:      3,
-							Items: wire.MapItemListFromSlice([]wire.MapItem{
+				{ID: 6, Value: wire.NewValueSet(
+					wire.ValueListFromSlice(wire.TMap, []wire.Value{
+						wire.NewValueMap(
+							wire.MapItemListFromSlice(wire.TBinary, wire.TBinary, []wire.MapItem{
 								{Key: wire.NewValueString("1"), Value: wire.NewValueString("one")},
 								{Key: wire.NewValueString("2"), Value: wire.NewValueString("two")},
 								{Key: wire.NewValueString("3"), Value: wire.NewValueString("three")},
 							}),
-						}),
-						wire.NewValueMap(wire.Map{
-							KeyType:   wire.TBinary,
-							ValueType: wire.TBinary,
-							Size:      3,
-							Items: wire.MapItemListFromSlice([]wire.MapItem{
+						),
+						wire.NewValueMap(
+							wire.MapItemListFromSlice(wire.TBinary, wire.TBinary, []wire.MapItem{
 								{Key: wire.NewValueString("4"), Value: wire.NewValueString("four")},
 								{Key: wire.NewValueString("5"), Value: wire.NewValueString("five")},
 								{Key: wire.NewValueString("6"), Value: wire.NewValueString("six")},
 							}),
-						}),
+						),
 					}),
-				})},
+				)},
 			}}),
 		},
 		{
@@ -640,39 +564,30 @@ func TestCrazyTown(t *testing.T) {
 				},
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 7, Value: wire.NewValueMap(wire.Map{
-					KeyType:   wire.TMap,
-					ValueType: wire.TI64,
-					Size:      2,
-					Items: wire.MapItemListFromSlice([]wire.MapItem{
+				{ID: 7, Value: wire.NewValueMap(
+					wire.MapItemListFromSlice(wire.TMap, wire.TI64, []wire.MapItem{
 						{
-							Key: wire.NewValueMap(wire.Map{
-								KeyType:   wire.TBinary,
-								ValueType: wire.TI32,
-								Size:      3,
-								Items: wire.MapItemListFromSlice([]wire.MapItem{
+							Key: wire.NewValueMap(
+								wire.MapItemListFromSlice(wire.TBinary, wire.TI32, []wire.MapItem{
 									{Key: wire.NewValueString("1"), Value: wire.NewValueI32(1)},
 									{Key: wire.NewValueString("2"), Value: wire.NewValueI32(2)},
 									{Key: wire.NewValueString("3"), Value: wire.NewValueI32(3)},
 								}),
-							}),
+							),
 							Value: wire.NewValueI64(123),
 						},
 						{
-							Key: wire.NewValueMap(wire.Map{
-								KeyType:   wire.TBinary,
-								ValueType: wire.TI32,
-								Size:      3,
-								Items: wire.MapItemListFromSlice([]wire.MapItem{
+							Key: wire.NewValueMap(
+								wire.MapItemListFromSlice(wire.TBinary, wire.TI32, []wire.MapItem{
 									{Key: wire.NewValueString("4"), Value: wire.NewValueI32(4)},
 									{Key: wire.NewValueString("5"), Value: wire.NewValueI32(5)},
 									{Key: wire.NewValueString("6"), Value: wire.NewValueI32(6)},
 								}),
-							}),
+							),
 							Value: wire.NewValueI64(456),
 						},
 					}),
-				})},
+				)},
 			}}),
 		},
 		{
@@ -701,53 +616,42 @@ func TestCrazyTown(t *testing.T) {
 				},
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 8, Value: wire.NewValueMap(wire.Map{
-					KeyType:   wire.TList,
-					ValueType: wire.TSet,
-					Size:      2,
-					Items: wire.MapItemListFromSlice([]wire.MapItem{
+				{ID: 8, Value: wire.NewValueMap(
+					wire.MapItemListFromSlice(wire.TList, wire.TSet, []wire.MapItem{
 						{
-							Key: wire.NewValueList(wire.List{
-								ValueType: wire.TI32,
-								Size:      3,
-								Items: wire.ValueListFromSlice([]wire.Value{
+							Key: wire.NewValueList(
+								wire.ValueListFromSlice(wire.TI32, []wire.Value{
 									wire.NewValueI32(1),
 									wire.NewValueI32(2),
 									wire.NewValueI32(3),
 								}),
-							}),
-							Value: wire.NewValueSet(wire.Set{
-								ValueType: wire.TI64,
-								Size:      3,
-								Items: wire.ValueListFromSlice([]wire.Value{
+							),
+							Value: wire.NewValueSet(
+								wire.ValueListFromSlice(wire.TI64, []wire.Value{
 									wire.NewValueI64(1),
 									wire.NewValueI64(2),
 									wire.NewValueI64(3),
 								}),
-							}),
+							),
 						},
 						{
-							Key: wire.NewValueList(wire.List{
-								ValueType: wire.TI32,
-								Size:      3,
-								Items: wire.ValueListFromSlice([]wire.Value{
+							Key: wire.NewValueList(
+								wire.ValueListFromSlice(wire.TI32, []wire.Value{
 									wire.NewValueI32(4),
 									wire.NewValueI32(5),
 									wire.NewValueI32(6),
 								}),
-							}),
-							Value: wire.NewValueSet(wire.Set{
-								ValueType: wire.TI64,
-								Size:      3,
-								Items: wire.ValueListFromSlice([]wire.Value{
+							),
+							Value: wire.NewValueSet(
+								wire.ValueListFromSlice(wire.TI64, []wire.Value{
 									wire.NewValueI64(4),
 									wire.NewValueI64(5),
 									wire.NewValueI64(6),
 								}),
-							}),
+							),
 						},
 					}),
-				})},
+				)},
 			}}),
 		},
 		{
@@ -776,53 +680,42 @@ func TestCrazyTown(t *testing.T) {
 				},
 			},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 9, Value: wire.NewValueMap(wire.Map{
-					KeyType:   wire.TSet,
-					ValueType: wire.TList,
-					Size:      2,
-					Items: wire.MapItemListFromSlice([]wire.MapItem{
+				{ID: 9, Value: wire.NewValueMap(
+					wire.MapItemListFromSlice(wire.TSet, wire.TList, []wire.MapItem{
 						{
-							Key: wire.NewValueSet(wire.Set{
-								ValueType: wire.TI32,
-								Size:      3,
-								Items: wire.ValueListFromSlice([]wire.Value{
+							Key: wire.NewValueSet(
+								wire.ValueListFromSlice(wire.TI32, []wire.Value{
 									wire.NewValueI32(1),
 									wire.NewValueI32(2),
 									wire.NewValueI32(3),
 								}),
-							}),
-							Value: wire.NewValueList(wire.List{
-								ValueType: wire.TDouble,
-								Size:      3,
-								Items: wire.ValueListFromSlice([]wire.Value{
+							),
+							Value: wire.NewValueList(
+								wire.ValueListFromSlice(wire.TDouble, []wire.Value{
 									wire.NewValueDouble(1.0),
 									wire.NewValueDouble(2.0),
 									wire.NewValueDouble(3.0),
 								}),
-							}),
+							),
 						},
 						{
-							Key: wire.NewValueSet(wire.Set{
-								ValueType: wire.TI32,
-								Size:      3,
-								Items: wire.ValueListFromSlice([]wire.Value{
+							Key: wire.NewValueSet(
+								wire.ValueListFromSlice(wire.TI32, []wire.Value{
 									wire.NewValueI32(4),
 									wire.NewValueI32(5),
 									wire.NewValueI32(6),
 								}),
-							}),
-							Value: wire.NewValueList(wire.List{
-								ValueType: wire.TDouble,
-								Size:      3,
-								Items: wire.ValueListFromSlice([]wire.Value{
+							),
+							Value: wire.NewValueList(
+								wire.ValueListFromSlice(wire.TDouble, []wire.Value{
 									wire.NewValueDouble(4.0),
 									wire.NewValueDouble(5.0),
 									wire.NewValueDouble(6.0),
 								}),
-							}),
+							),
 						},
 					}),
-				})},
+				)},
 			}}),
 		},
 	}

--- a/gen/list.go
+++ b/gen/list.go
@@ -70,7 +70,15 @@ func (l *listGenerator) ValueList(g Generator, spec *compile.ListSpec) (string, 
 				return nil
 			}
 
-			func (<$v> <.Name>) Close() {}
+			func (<$v> <.Name>) Size() int {
+				return len(<$v>)
+			}
+
+			func (<.Name>) ValueType() <$wire>.Type {
+				return <typeCode .Spec.ValueSpec>
+			}
+
+			func (<.Name>) Close() {}
 		`,
 		struct {
 			Name string
@@ -104,13 +112,13 @@ func (l *listGenerator) Reader(g Generator, spec *compile.ListSpec) (string, err
 			<$i := newVar "i">
 			<$o := newVar "o">
 			<$x := newVar "x">
-			func <.Name>(<$l> <$wire>.List) (<$listType>, error) {
-				if <$l>.ValueType != <typeCode .Spec.ValueSpec> {
+			func <.Name>(<$l> <$wire>.ValueList) (<$listType>, error) {
+				if <$l>.ValueType() != <typeCode .Spec.ValueSpec> {
 					return nil, nil
 				}
 
-				<$o> := make(<$listType>, 0, <$l>.Size)
-				err := <$l>.Items.ForEach(func(<$x> <$wire>.Value) error {
+				<$o> := make(<$listType>, 0, <$l>.Size())
+				err := <$l>.ForEach(func(<$x> <$wire>.Value) error {
 					<$i>, err := <fromWire .Spec.ValueSpec $x>
 					if err != nil {
 						return err
@@ -118,7 +126,7 @@ func (l *listGenerator) Reader(g Generator, spec *compile.ListSpec) (string, err
 					<$o> = append(<$o>, <$i>)
 					return nil
 				})
-				<$l>.Items.Close()
+				<$l>.Close()
 				return <$o>, err
 			}
 		`,

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -153,34 +153,27 @@ func TestStructRoundTripAndString(t *testing.T) {
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{
 					ID: 1,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TBinary,
-						Size:      3,
-						Items: wire.ValueListFromSlice([]wire.Value{
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TBinary, []wire.Value([]wire.Value{
 							wire.NewValueString("foo"),
 							wire.NewValueString("bar"),
 							wire.NewValueString("baz"),
-						}),
-					}),
+						})),
+					),
 				},
 				{
 					ID: 2,
-					Value: wire.NewValueSet(wire.Set{
-						ValueType: wire.TI32,
-						Size:      2,
-						Items: wire.ValueListFromSlice([]wire.Value{
+					Value: wire.NewValueSet(
+						wire.ValueListFromSlice(wire.TI32, []wire.Value{
 							wire.NewValueI32(1),
 							wire.NewValueI32(2),
 						}),
-					}),
+					),
 				},
 				{
 					ID: 3,
-					Value: wire.NewValueMap(wire.Map{
-						KeyType:   wire.TI64,
-						ValueType: wire.TDouble,
-						Size:      2,
-						Items: wire.MapItemListFromSlice([]wire.MapItem{
+					Value: wire.NewValueMap(
+						wire.MapItemListFromSlice(wire.TI64, wire.TDouble, []wire.MapItem{
 							wire.MapItem{
 								Key:   wire.NewValueI64(1),
 								Value: wire.NewValueDouble(2.0),
@@ -190,7 +183,7 @@ func TestStructRoundTripAndString(t *testing.T) {
 								Value: wire.NewValueDouble(4.0),
 							},
 						}),
-					}),
+					),
 				},
 			}}),
 			"",
@@ -303,10 +296,8 @@ func TestStructRoundTripAndString(t *testing.T) {
 				{StringValue: stringp("hello")},
 			}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 4, Value: wire.NewValueList(wire.List{
-					ValueType: wire.TStruct,
-					Size:      3,
-					Items: wire.ValueListFromSlice([]wire.Value{
+				{ID: 4, Value: wire.NewValueList(
+					wire.ValueListFromSlice(wire.TStruct, []wire.Value{
 						wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 							{ID: 1, Value: wire.NewValueBool(true)},
 						}}),
@@ -317,7 +308,7 @@ func TestStructRoundTripAndString(t *testing.T) {
 							{ID: 3, Value: wire.NewValueString("hello")},
 						}}),
 					}),
-				})},
+				)},
 			}}),
 			"ArbitraryValue{ListValue: [ArbitraryValue{BoolValue: true} ArbitraryValue{Int64Value: 42} ArbitraryValue{StringValue: hello}]}",
 		},
@@ -329,11 +320,8 @@ func TestStructRoundTripAndString(t *testing.T) {
 				"string": {StringValue: stringp("hello")},
 			}},
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
-				{ID: 5, Value: wire.NewValueMap(wire.Map{
-					KeyType:   wire.TBinary,
-					ValueType: wire.TStruct,
-					Size:      3,
-					Items: wire.MapItemListFromSlice([]wire.MapItem{
+				{ID: 5, Value: wire.NewValueMap(
+					wire.MapItemListFromSlice(wire.TBinary, wire.TStruct, []wire.MapItem{
 						{
 							Key: wire.NewValueString("bool"),
 							Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
@@ -353,7 +341,7 @@ func TestStructRoundTripAndString(t *testing.T) {
 							}}),
 						},
 					}),
-				})},
+				)},
 			}}),
 			"",
 		},
@@ -697,26 +685,22 @@ func TestStructWithDefaults(t *testing.T) {
 				{ID: 4, Value: wire.NewValueI32(2)},
 				{
 					ID: 5,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TBinary,
-						Size:      2,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 							wire.NewValueString("hello"),
 							wire.NewValueString("world"),
-						},
-					}),
+						}),
+					),
 				},
 				{
 					ID: 6,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TDouble,
-						Size:      3,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TDouble, []wire.Value{
 							wire.NewValueDouble(1.0),
 							wire.NewValueDouble(2.0),
 							wire.NewValueDouble(3.0),
-						},
-					}),
+						}),
+					),
 				},
 				{
 					ID: 7,
@@ -785,11 +769,9 @@ func TestStructWithDefaults(t *testing.T) {
 				{ID: 4, Value: wire.NewValueI32(0)},
 				{
 					ID: 5,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TBinary,
-						Size:      0,
-						Items:     wire.ValueListFromSlice{},
-					}),
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TBinary, []wire.Value{}),
+					),
 				},
 			}}),
 
@@ -800,23 +782,19 @@ func TestStructWithDefaults(t *testing.T) {
 				{ID: 4, Value: wire.NewValueI32(0)},
 				{
 					ID: 5,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TBinary,
-						Size:      0,
-						Items:     wire.ValueListFromSlice{},
-					}),
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TBinary, []wire.Value{}),
+					),
 				},
 				{
 					ID: 6,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TDouble,
-						Size:      3,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TDouble, []wire.Value{
 							wire.NewValueDouble(1.0),
 							wire.NewValueDouble(2.0),
 							wire.NewValueDouble(3.0),
-						},
-					}),
+						}),
+					),
 				},
 				{
 					ID: 7,
@@ -1105,10 +1083,8 @@ func TestStructValidation(t *testing.T) {
 			deserialize: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{
 					ID: 1,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TStruct,
-						Size:      2,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TStruct, []wire.Value{
 							wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 								{
 									ID: 1,
@@ -1134,8 +1110,8 @@ func TestStructValidation(t *testing.T) {
 									}}),
 								},
 							}}),
-						},
-					}),
+						}),
+					),
 				},
 			}}),
 			wantError: "field End of Edge is required",
@@ -1165,23 +1141,18 @@ func TestStructValidation(t *testing.T) {
 			deserialize: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{
 					ID: 2,
-					Value: wire.NewValueSet(wire.Set{
-						ValueType: wire.TI32,
-						Size:      3,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueSet(
+						wire.ValueListFromSlice(wire.TI32, []wire.Value{
 							wire.NewValueI32(1),
 							wire.NewValueI32(2),
 							wire.NewValueI32(3),
-						},
-					}),
+						}),
+					),
 				},
 				{
 					ID: 3,
-					Value: wire.NewValueMap(wire.Map{
-						KeyType:   wire.TI64,
-						ValueType: wire.TDouble,
-						Size:      2,
-						Items: wire.MapItemListFromSlice{
+					Value: wire.NewValueMap(
+						wire.MapItemListFromSlice(wire.TI64, wire.TDouble, []wire.MapItem{
 							{
 								Key:   wire.NewValueI64(1),
 								Value: wire.NewValueDouble(2.3),
@@ -1190,8 +1161,8 @@ func TestStructValidation(t *testing.T) {
 								Key:   wire.NewValueI64(4),
 								Value: wire.NewValueDouble(5.6),
 							},
-						},
-					}),
+						}),
+					),
 				},
 			}}),
 			wantError: "field ListOfStrings of PrimitiveContainersRequired is required",
@@ -1205,22 +1176,17 @@ func TestStructValidation(t *testing.T) {
 			deserialize: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{
 					ID: 1,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TBinary,
-						Size:      2,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 							wire.NewValueString("hello"),
 							wire.NewValueString("world"),
-						},
-					}),
+						}),
+					),
 				},
 				{
 					ID: 3,
-					Value: wire.NewValueMap(wire.Map{
-						KeyType:   wire.TI64,
-						ValueType: wire.TDouble,
-						Size:      2,
-						Items: wire.MapItemListFromSlice{
+					Value: wire.NewValueMap(
+						wire.MapItemListFromSlice(wire.TI64, wire.TDouble, []wire.MapItem{
 							{
 								Key:   wire.NewValueI64(1),
 								Value: wire.NewValueDouble(2.3),
@@ -1229,8 +1195,8 @@ func TestStructValidation(t *testing.T) {
 								Key:   wire.NewValueI64(4),
 								Value: wire.NewValueDouble(5.6),
 							},
-						},
-					}),
+						}),
+					),
 				},
 			}}),
 			wantError: "field SetOfInts of PrimitiveContainersRequired is required",
@@ -1248,26 +1214,22 @@ func TestStructValidation(t *testing.T) {
 			deserialize: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{
 					ID: 1,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TBinary,
-						Size:      2,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 							wire.NewValueString("hello"),
 							wire.NewValueString("world"),
-						},
-					}),
+						}),
+					),
 				},
 				{
 					ID: 2,
-					Value: wire.NewValueSet(wire.Set{
-						ValueType: wire.TI32,
-						Size:      3,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueSet(
+						wire.ValueListFromSlice(wire.TI32, []wire.Value{
 							wire.NewValueI32(1),
 							wire.NewValueI32(2),
 							wire.NewValueI32(3),
-						},
-					}),
+						}),
+					),
 				},
 			}}),
 			wantError: "field MapOfIntsToDoubles of PrimitiveContainersRequired is required",
@@ -1339,10 +1301,8 @@ func TestStructValidation(t *testing.T) {
 				{ID: 3, Value: wire.NewValueString("")},
 				{
 					ID: 4,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TStruct,
-						Size:      3,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TStruct, []wire.Value{
 							wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 								{ID: 1, Value: wire.NewValueBool(true)},
 							}}),
@@ -1352,16 +1312,13 @@ func TestStructValidation(t *testing.T) {
 							wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 								{ID: 3, Value: wire.NewValueString("")},
 							}}),
-						},
-					}),
+						}),
+					),
 				},
 				{
 					ID: 5,
-					Value: wire.NewValueMap(wire.Map{
-						KeyType:   wire.TBinary,
-						ValueType: wire.TStruct,
-						Size:      3,
-						Items: wire.MapItemListFromSlice{
+					Value: wire.NewValueMap(
+						wire.MapItemListFromSlice(wire.TBinary, wire.TStruct, []wire.MapItem{
 							{
 								Key: wire.NewValueString("bool"),
 								Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
@@ -1380,8 +1337,8 @@ func TestStructValidation(t *testing.T) {
 									{ID: 3, Value: wire.NewValueString("")},
 								}}),
 							},
-						},
-					}),
+						}),
+					),
 				},
 			}}),
 			wantError: "ArbitraryValue should have exactly one field: got 5 fields",
@@ -1397,16 +1354,13 @@ func TestStructValidation(t *testing.T) {
 			deserialize: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{
 					ID: 4,
-					Value: wire.NewValueList(wire.List{
-						ValueType: wire.TStruct,
-						Size:      2,
-						Items: wire.ValueListFromSlice{
+					Value: wire.NewValueList(
+						wire.ValueListFromSlice(wire.TStruct, []wire.Value{
 							wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 								{ID: 1, Value: wire.NewValueBool(true)},
 							}}),
 							wire.NewValueStruct(wire.Struct{Fields: []wire.Field{}}),
-						},
-					}),
+						})),
 				},
 			}}),
 			wantError: "ArbitraryValue should have exactly one field: got 0 fields",
@@ -1422,11 +1376,8 @@ func TestStructValidation(t *testing.T) {
 			deserialize: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{
 					ID: 5,
-					Value: wire.NewValueMap(wire.Map{
-						KeyType:   wire.TBinary,
-						ValueType: wire.TStruct,
-						Size:      2,
-						Items: wire.MapItemListFromSlice{
+					Value: wire.NewValueMap(
+						wire.MapItemListFromSlice(wire.TBinary, wire.TStruct, []wire.MapItem{
 							{
 								Key: wire.NewValueString("bool"),
 								Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
@@ -1437,8 +1388,8 @@ func TestStructValidation(t *testing.T) {
 								Key:   wire.NewValueString("empty"),
 								Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{}}),
 							},
-						},
-					}),
+						}),
+					),
 				},
 			}}),
 			wantError: "ArbitraryValue should have exactly one field: got 0 fields",
@@ -1452,10 +1403,8 @@ func TestStructValidation(t *testing.T) {
 				},
 				&ts.Frame{TopLeft: &ts.Point{X: 5, Y: 6}},
 			},
-			deserialize: wire.NewValueSet(wire.Set{
-				ValueType: wire.TStruct,
-				Size:      2,
-				Items: wire.ValueListFromSlice{
+			deserialize: wire.NewValueSet(
+				wire.ValueListFromSlice(wire.TStruct, []wire.Value{
 					wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 						{
 							ID: 1,
@@ -1499,8 +1448,8 @@ func TestStructValidation(t *testing.T) {
 							}}),
 						},
 					}}),
-				},
-			}),
+				}),
+			),
 			wantError: "field Size of Frame is required",
 		},
 		{
@@ -1511,11 +1460,8 @@ func TestStructValidation(t *testing.T) {
 					Value: &ts.Edge{Start: &ts.Point{X: 3, Y: 4}, End: &ts.Point{X: 5, Y: 6}},
 				},
 			},
-			deserialize: wire.NewValueMap(wire.Map{
-				KeyType:   wire.TStruct,
-				ValueType: wire.TStruct,
-				Size:      1,
-				Items: wire.MapItemListFromSlice{
+			deserialize: wire.NewValueMap(
+				wire.MapItemListFromSlice(wire.TStruct, wire.TStruct, []wire.MapItem{
 					{
 						Key: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 							{
@@ -1543,8 +1489,8 @@ func TestStructValidation(t *testing.T) {
 							},
 						}}),
 					},
-				},
-			}),
+				}),
+			),
 			wantError: "field End of Edge is required",
 		},
 	}

--- a/gen/testdata/containers/types.go
+++ b/gen/testdata/containers/types.go
@@ -47,14 +47,22 @@ func (v _List_I32_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_I32_ValueList) Close() {
+func (v _List_I32_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_I32_ValueList) ValueType() wire.Type {
+	return wire.TI32
+}
+
+func (_List_I32_ValueList) Close() {
 }
 
 type _List_List_I32_ValueList [][]int32
 
 func (v _List_List_I32_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
-		w, err := wire.NewValueList(wire.List{ValueType: wire.TI32, Size: len(x), Items: _List_I32_ValueList(x)}), error(nil)
+		w, err := wire.NewValueList(_List_I32_ValueList(x)), error(nil)
 		if err != nil {
 			return err
 		}
@@ -66,7 +74,15 @@ func (v _List_List_I32_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_List_I32_ValueList) Close() {
+func (v _List_List_I32_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_List_I32_ValueList) ValueType() wire.Type {
+	return wire.TList
+}
+
+func (_List_List_I32_ValueList) Close() {
 }
 
 type _Set_I32_ValueList map[int32]struct{}
@@ -85,14 +101,22 @@ func (v _Set_I32_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _Set_I32_ValueList) Close() {
+func (v _Set_I32_ValueList) Size() int {
+	return len(v)
+}
+
+func (_Set_I32_ValueList) ValueType() wire.Type {
+	return wire.TI32
+}
+
+func (_Set_I32_ValueList) Close() {
 }
 
 type _List_Set_I32_ValueList []map[int32]struct{}
 
 func (v _List_Set_I32_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
-		w, err := wire.NewValueSet(wire.Set{ValueType: wire.TI32, Size: len(x), Items: _Set_I32_ValueList(x)}), error(nil)
+		w, err := wire.NewValueSet(_Set_I32_ValueList(x)), error(nil)
 		if err != nil {
 			return err
 		}
@@ -104,7 +128,15 @@ func (v _List_Set_I32_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_Set_I32_ValueList) Close() {
+func (v _List_Set_I32_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_Set_I32_ValueList) ValueType() wire.Type {
+	return wire.TSet
+}
+
+func (_List_Set_I32_ValueList) Close() {
 }
 
 type _Map_I32_I32_MapItemList map[int32]int32
@@ -127,14 +159,26 @@ func (m _Map_I32_I32_MapItemList) ForEach(f func(wire.MapItem) error) error {
 	return nil
 }
 
-func (m _Map_I32_I32_MapItemList) Close() {
+func (m _Map_I32_I32_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_I32_I32_MapItemList) KeyType() wire.Type {
+	return wire.TI32
+}
+
+func (_Map_I32_I32_MapItemList) ValueType() wire.Type {
+	return wire.TI32
+}
+
+func (_Map_I32_I32_MapItemList) Close() {
 }
 
 type _List_Map_I32_I32_ValueList []map[int32]int32
 
 func (v _List_Map_I32_I32_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
-		w, err := wire.NewValueMap(wire.Map{KeyType: wire.TI32, ValueType: wire.TI32, Size: len(x), Items: _Map_I32_I32_MapItemList(x)}), error(nil)
+		w, err := wire.NewValueMap(_Map_I32_I32_MapItemList(x)), error(nil)
 		if err != nil {
 			return err
 		}
@@ -146,7 +190,15 @@ func (v _List_Map_I32_I32_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_Map_I32_I32_ValueList) Close() {
+func (v _List_Map_I32_I32_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_Map_I32_I32_ValueList) ValueType() wire.Type {
+	return wire.TMap
+}
+
+func (_List_Map_I32_I32_ValueList) Close() {
 }
 
 type _Set_String_ValueList map[string]struct{}
@@ -165,14 +217,22 @@ func (v _Set_String_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _Set_String_ValueList) Close() {
+func (v _Set_String_ValueList) Size() int {
+	return len(v)
+}
+
+func (_Set_String_ValueList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Set_String_ValueList) Close() {
 }
 
 type _Set_Set_String_ValueList []map[string]struct{}
 
 func (v _Set_Set_String_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
-		w, err := wire.NewValueSet(wire.Set{ValueType: wire.TBinary, Size: len(x), Items: _Set_String_ValueList(x)}), error(nil)
+		w, err := wire.NewValueSet(_Set_String_ValueList(x)), error(nil)
 		if err != nil {
 			return err
 		}
@@ -184,7 +244,15 @@ func (v _Set_Set_String_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _Set_Set_String_ValueList) Close() {
+func (v _Set_Set_String_ValueList) Size() int {
+	return len(v)
+}
+
+func (_Set_Set_String_ValueList) ValueType() wire.Type {
+	return wire.TSet
+}
+
+func (_Set_Set_String_ValueList) Close() {
 }
 
 type _List_String_ValueList []string
@@ -203,14 +271,22 @@ func (v _List_String_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_String_ValueList) Close() {
+func (v _List_String_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_String_ValueList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_List_String_ValueList) Close() {
 }
 
 type _Set_List_String_ValueList [][]string
 
 func (v _Set_List_String_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
-		w, err := wire.NewValueList(wire.List{ValueType: wire.TBinary, Size: len(x), Items: _List_String_ValueList(x)}), error(nil)
+		w, err := wire.NewValueList(_List_String_ValueList(x)), error(nil)
 		if err != nil {
 			return err
 		}
@@ -222,7 +298,15 @@ func (v _Set_List_String_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _Set_List_String_ValueList) Close() {
+func (v _Set_List_String_ValueList) Size() int {
+	return len(v)
+}
+
+func (_Set_List_String_ValueList) ValueType() wire.Type {
+	return wire.TList
+}
+
+func (_Set_List_String_ValueList) Close() {
 }
 
 type _Map_String_String_MapItemList map[string]string
@@ -245,14 +329,26 @@ func (m _Map_String_String_MapItemList) ForEach(f func(wire.MapItem) error) erro
 	return nil
 }
 
-func (m _Map_String_String_MapItemList) Close() {
+func (m _Map_String_String_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_String_String_MapItemList) KeyType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_String_MapItemList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_String_MapItemList) Close() {
 }
 
 type _Set_Map_String_String_ValueList []map[string]string
 
 func (v _Set_Map_String_String_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
-		w, err := wire.NewValueMap(wire.Map{KeyType: wire.TBinary, ValueType: wire.TBinary, Size: len(x), Items: _Map_String_String_MapItemList(x)}), error(nil)
+		w, err := wire.NewValueMap(_Map_String_String_MapItemList(x)), error(nil)
 		if err != nil {
 			return err
 		}
@@ -264,7 +360,15 @@ func (v _Set_Map_String_String_ValueList) ForEach(f func(wire.Value) error) erro
 	return nil
 }
 
-func (v _Set_Map_String_String_ValueList) Close() {
+func (v _Set_Map_String_String_ValueList) Size() int {
+	return len(v)
+}
+
+func (_Set_Map_String_String_ValueList) ValueType() wire.Type {
+	return wire.TMap
+}
+
+func (_Set_Map_String_String_ValueList) Close() {
 }
 
 type _Map_String_I32_MapItemList map[string]int32
@@ -287,7 +391,19 @@ func (m _Map_String_I32_MapItemList) ForEach(f func(wire.MapItem) error) error {
 	return nil
 }
 
-func (m _Map_String_I32_MapItemList) Close() {
+func (m _Map_String_I32_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_String_I32_MapItemList) KeyType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_I32_MapItemList) ValueType() wire.Type {
+	return wire.TI32
+}
+
+func (_Map_String_I32_MapItemList) Close() {
 }
 
 type _Map_Map_String_I32_I64_MapItemList []struct {
@@ -299,7 +415,7 @@ func (m _Map_Map_String_I32_I64_MapItemList) ForEach(f func(wire.MapItem) error)
 	for _, i := range m {
 		k := i.Key
 		v := i.Value
-		kw, err := wire.NewValueMap(wire.Map{KeyType: wire.TBinary, ValueType: wire.TI32, Size: len(k), Items: _Map_String_I32_MapItemList(k)}), error(nil)
+		kw, err := wire.NewValueMap(_Map_String_I32_MapItemList(k)), error(nil)
 		if err != nil {
 			return err
 		}
@@ -315,7 +431,19 @@ func (m _Map_Map_String_I32_I64_MapItemList) ForEach(f func(wire.MapItem) error)
 	return nil
 }
 
-func (m _Map_Map_String_I32_I64_MapItemList) Close() {
+func (m _Map_Map_String_I32_I64_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_Map_String_I32_I64_MapItemList) KeyType() wire.Type {
+	return wire.TMap
+}
+
+func (_Map_Map_String_I32_I64_MapItemList) ValueType() wire.Type {
+	return wire.TI64
+}
+
+func (_Map_Map_String_I32_I64_MapItemList) Close() {
 }
 
 type _Set_I64_ValueList map[int64]struct{}
@@ -334,7 +462,15 @@ func (v _Set_I64_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _Set_I64_ValueList) Close() {
+func (v _Set_I64_ValueList) Size() int {
+	return len(v)
+}
+
+func (_Set_I64_ValueList) ValueType() wire.Type {
+	return wire.TI64
+}
+
+func (_Set_I64_ValueList) Close() {
 }
 
 type _Map_List_I32_Set_I64_MapItemList []struct {
@@ -346,11 +482,11 @@ func (m _Map_List_I32_Set_I64_MapItemList) ForEach(f func(wire.MapItem) error) e
 	for _, i := range m {
 		k := i.Key
 		v := i.Value
-		kw, err := wire.NewValueList(wire.List{ValueType: wire.TI32, Size: len(k), Items: _List_I32_ValueList(k)}), error(nil)
+		kw, err := wire.NewValueList(_List_I32_ValueList(k)), error(nil)
 		if err != nil {
 			return err
 		}
-		vw, err := wire.NewValueSet(wire.Set{ValueType: wire.TI64, Size: len(v), Items: _Set_I64_ValueList(v)}), error(nil)
+		vw, err := wire.NewValueSet(_Set_I64_ValueList(v)), error(nil)
 		if err != nil {
 			return err
 		}
@@ -362,7 +498,19 @@ func (m _Map_List_I32_Set_I64_MapItemList) ForEach(f func(wire.MapItem) error) e
 	return nil
 }
 
-func (m _Map_List_I32_Set_I64_MapItemList) Close() {
+func (m _Map_List_I32_Set_I64_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_List_I32_Set_I64_MapItemList) KeyType() wire.Type {
+	return wire.TList
+}
+
+func (_Map_List_I32_Set_I64_MapItemList) ValueType() wire.Type {
+	return wire.TSet
+}
+
+func (_Map_List_I32_Set_I64_MapItemList) Close() {
 }
 
 type _List_Double_ValueList []float64
@@ -381,7 +529,15 @@ func (v _List_Double_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_Double_ValueList) Close() {
+func (v _List_Double_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_Double_ValueList) ValueType() wire.Type {
+	return wire.TDouble
+}
+
+func (_List_Double_ValueList) Close() {
 }
 
 type _Map_Set_I32_List_Double_MapItemList []struct {
@@ -393,11 +549,11 @@ func (m _Map_Set_I32_List_Double_MapItemList) ForEach(f func(wire.MapItem) error
 	for _, i := range m {
 		k := i.Key
 		v := i.Value
-		kw, err := wire.NewValueSet(wire.Set{ValueType: wire.TI32, Size: len(k), Items: _Set_I32_ValueList(k)}), error(nil)
+		kw, err := wire.NewValueSet(_Set_I32_ValueList(k)), error(nil)
 		if err != nil {
 			return err
 		}
-		vw, err := wire.NewValueList(wire.List{ValueType: wire.TDouble, Size: len(v), Items: _List_Double_ValueList(v)}), error(nil)
+		vw, err := wire.NewValueList(_List_Double_ValueList(v)), error(nil)
 		if err != nil {
 			return err
 		}
@@ -409,7 +565,19 @@ func (m _Map_Set_I32_List_Double_MapItemList) ForEach(f func(wire.MapItem) error
 	return nil
 }
 
-func (m _Map_Set_I32_List_Double_MapItemList) Close() {
+func (m _Map_Set_I32_List_Double_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_Set_I32_List_Double_MapItemList) KeyType() wire.Type {
+	return wire.TSet
+}
+
+func (_Map_Set_I32_List_Double_MapItemList) ValueType() wire.Type {
+	return wire.TList
+}
+
+func (_Map_Set_I32_List_Double_MapItemList) Close() {
 }
 
 func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
@@ -420,7 +588,7 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 		err    error
 	)
 	if v.ListOfLists != nil {
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TList, Size: len(v.ListOfLists), Items: _List_List_I32_ValueList(v.ListOfLists)}), error(nil)
+		w, err = wire.NewValueList(_List_List_I32_ValueList(v.ListOfLists)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -428,7 +596,7 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.ListOfSets != nil {
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TSet, Size: len(v.ListOfSets), Items: _List_Set_I32_ValueList(v.ListOfSets)}), error(nil)
+		w, err = wire.NewValueList(_List_Set_I32_ValueList(v.ListOfSets)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -436,7 +604,7 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.ListOfMaps != nil {
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TMap, Size: len(v.ListOfMaps), Items: _List_Map_I32_I32_ValueList(v.ListOfMaps)}), error(nil)
+		w, err = wire.NewValueList(_List_Map_I32_I32_ValueList(v.ListOfMaps)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -444,7 +612,7 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.SetOfSets != nil {
-		w, err = wire.NewValueSet(wire.Set{ValueType: wire.TSet, Size: len(v.SetOfSets), Items: _Set_Set_String_ValueList(v.SetOfSets)}), error(nil)
+		w, err = wire.NewValueSet(_Set_Set_String_ValueList(v.SetOfSets)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -452,7 +620,7 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.SetOfLists != nil {
-		w, err = wire.NewValueSet(wire.Set{ValueType: wire.TList, Size: len(v.SetOfLists), Items: _Set_List_String_ValueList(v.SetOfLists)}), error(nil)
+		w, err = wire.NewValueSet(_Set_List_String_ValueList(v.SetOfLists)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -460,7 +628,7 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.SetOfMaps != nil {
-		w, err = wire.NewValueSet(wire.Set{ValueType: wire.TMap, Size: len(v.SetOfMaps), Items: _Set_Map_String_String_ValueList(v.SetOfMaps)}), error(nil)
+		w, err = wire.NewValueSet(_Set_Map_String_String_ValueList(v.SetOfMaps)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -468,7 +636,7 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.MapOfMapToInt != nil {
-		w, err = wire.NewValueMap(wire.Map{KeyType: wire.TMap, ValueType: wire.TI64, Size: len(v.MapOfMapToInt), Items: _Map_Map_String_I32_I64_MapItemList(v.MapOfMapToInt)}), error(nil)
+		w, err = wire.NewValueMap(_Map_Map_String_I32_I64_MapItemList(v.MapOfMapToInt)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -476,7 +644,7 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.MapOfListToSet != nil {
-		w, err = wire.NewValueMap(wire.Map{KeyType: wire.TList, ValueType: wire.TSet, Size: len(v.MapOfListToSet), Items: _Map_List_I32_Set_I64_MapItemList(v.MapOfListToSet)}), error(nil)
+		w, err = wire.NewValueMap(_Map_List_I32_Set_I64_MapItemList(v.MapOfListToSet)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -484,7 +652,7 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.MapOfSetToListOfDouble != nil {
-		w, err = wire.NewValueMap(wire.Map{KeyType: wire.TSet, ValueType: wire.TList, Size: len(v.MapOfSetToListOfDouble), Items: _Map_Set_I32_List_Double_MapItemList(v.MapOfSetToListOfDouble)}), error(nil)
+		w, err = wire.NewValueMap(_Map_Set_I32_List_Double_MapItemList(v.MapOfSetToListOfDouble)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -494,12 +662,12 @@ func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _List_I32_Read(l wire.List) ([]int32, error) {
-	if l.ValueType != wire.TI32 {
+func _List_I32_Read(l wire.ValueList) ([]int32, error) {
+	if l.ValueType() != wire.TI32 {
 		return nil, nil
 	}
-	o := make([]int32, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]int32, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := x.GetI32(), error(nil)
 		if err != nil {
 			return err
@@ -507,16 +675,16 @@ func _List_I32_Read(l wire.List) ([]int32, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _List_List_I32_Read(l wire.List) ([][]int32, error) {
-	if l.ValueType != wire.TList {
+func _List_List_I32_Read(l wire.ValueList) ([][]int32, error) {
+	if l.ValueType() != wire.TList {
 		return nil, nil
 	}
-	o := make([][]int32, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([][]int32, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := _List_I32_Read(x.GetList())
 		if err != nil {
 			return err
@@ -524,16 +692,16 @@ func _List_List_I32_Read(l wire.List) ([][]int32, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _Set_I32_Read(s wire.Set) (map[int32]struct{}, error) {
-	if s.ValueType != wire.TI32 {
+func _Set_I32_Read(s wire.ValueList) (map[int32]struct{}, error) {
+	if s.ValueType() != wire.TI32 {
 		return nil, nil
 	}
-	o := make(map[int32]struct{}, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make(map[int32]struct{}, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := x.GetI32(), error(nil)
 		if err != nil {
 			return err
@@ -541,16 +709,16 @@ func _Set_I32_Read(s wire.Set) (map[int32]struct{}, error) {
 		o[i] = struct{}{}
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
-func _List_Set_I32_Read(l wire.List) ([]map[int32]struct{}, error) {
-	if l.ValueType != wire.TSet {
+func _List_Set_I32_Read(l wire.ValueList) ([]map[int32]struct{}, error) {
+	if l.ValueType() != wire.TSet {
 		return nil, nil
 	}
-	o := make([]map[int32]struct{}, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]map[int32]struct{}, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := _Set_I32_Read(x.GetSet())
 		if err != nil {
 			return err
@@ -558,19 +726,19 @@ func _List_Set_I32_Read(l wire.List) ([]map[int32]struct{}, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _Map_I32_I32_Read(m wire.Map) (map[int32]int32, error) {
-	if m.KeyType != wire.TI32 {
+func _Map_I32_I32_Read(m wire.MapItemList) (map[int32]int32, error) {
+	if m.KeyType() != wire.TI32 {
 		return nil, nil
 	}
-	if m.ValueType != wire.TI32 {
+	if m.ValueType() != wire.TI32 {
 		return nil, nil
 	}
-	o := make(map[int32]int32, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	o := make(map[int32]int32, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := x.Key.GetI32(), error(nil)
 		if err != nil {
 			return err
@@ -582,16 +750,16 @@ func _Map_I32_I32_Read(m wire.Map) (map[int32]int32, error) {
 		o[k] = v
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
-func _List_Map_I32_I32_Read(l wire.List) ([]map[int32]int32, error) {
-	if l.ValueType != wire.TMap {
+func _List_Map_I32_I32_Read(l wire.ValueList) ([]map[int32]int32, error) {
+	if l.ValueType() != wire.TMap {
 		return nil, nil
 	}
-	o := make([]map[int32]int32, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]map[int32]int32, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := _Map_I32_I32_Read(x.GetMap())
 		if err != nil {
 			return err
@@ -599,16 +767,16 @@ func _List_Map_I32_I32_Read(l wire.List) ([]map[int32]int32, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _Set_String_Read(s wire.Set) (map[string]struct{}, error) {
-	if s.ValueType != wire.TBinary {
+func _Set_String_Read(s wire.ValueList) (map[string]struct{}, error) {
+	if s.ValueType() != wire.TBinary {
 		return nil, nil
 	}
-	o := make(map[string]struct{}, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make(map[string]struct{}, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := x.GetString(), error(nil)
 		if err != nil {
 			return err
@@ -616,16 +784,16 @@ func _Set_String_Read(s wire.Set) (map[string]struct{}, error) {
 		o[i] = struct{}{}
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
-func _Set_Set_String_Read(s wire.Set) ([]map[string]struct{}, error) {
-	if s.ValueType != wire.TSet {
+func _Set_Set_String_Read(s wire.ValueList) ([]map[string]struct{}, error) {
+	if s.ValueType() != wire.TSet {
 		return nil, nil
 	}
-	o := make([]map[string]struct{}, 0, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make([]map[string]struct{}, 0, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := _Set_String_Read(x.GetSet())
 		if err != nil {
 			return err
@@ -633,16 +801,16 @@ func _Set_Set_String_Read(s wire.Set) ([]map[string]struct{}, error) {
 		o = append(o, i)
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
-func _List_String_Read(l wire.List) ([]string, error) {
-	if l.ValueType != wire.TBinary {
+func _List_String_Read(l wire.ValueList) ([]string, error) {
+	if l.ValueType() != wire.TBinary {
 		return nil, nil
 	}
-	o := make([]string, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]string, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := x.GetString(), error(nil)
 		if err != nil {
 			return err
@@ -650,16 +818,16 @@ func _List_String_Read(l wire.List) ([]string, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _Set_List_String_Read(s wire.Set) ([][]string, error) {
-	if s.ValueType != wire.TList {
+func _Set_List_String_Read(s wire.ValueList) ([][]string, error) {
+	if s.ValueType() != wire.TList {
 		return nil, nil
 	}
-	o := make([][]string, 0, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make([][]string, 0, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := _List_String_Read(x.GetList())
 		if err != nil {
 			return err
@@ -667,19 +835,19 @@ func _Set_List_String_Read(s wire.Set) ([][]string, error) {
 		o = append(o, i)
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
-func _Map_String_String_Read(m wire.Map) (map[string]string, error) {
-	if m.KeyType != wire.TBinary {
+func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
+	if m.KeyType() != wire.TBinary {
 		return nil, nil
 	}
-	if m.ValueType != wire.TBinary {
+	if m.ValueType() != wire.TBinary {
 		return nil, nil
 	}
-	o := make(map[string]string, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	o := make(map[string]string, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := x.Key.GetString(), error(nil)
 		if err != nil {
 			return err
@@ -691,16 +859,16 @@ func _Map_String_String_Read(m wire.Map) (map[string]string, error) {
 		o[k] = v
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
-func _Set_Map_String_String_Read(s wire.Set) ([]map[string]string, error) {
-	if s.ValueType != wire.TMap {
+func _Set_Map_String_String_Read(s wire.ValueList) ([]map[string]string, error) {
+	if s.ValueType() != wire.TMap {
 		return nil, nil
 	}
-	o := make([]map[string]string, 0, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make([]map[string]string, 0, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := _Map_String_String_Read(x.GetMap())
 		if err != nil {
 			return err
@@ -708,19 +876,19 @@ func _Set_Map_String_String_Read(s wire.Set) ([]map[string]string, error) {
 		o = append(o, i)
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
-func _Map_String_I32_Read(m wire.Map) (map[string]int32, error) {
-	if m.KeyType != wire.TBinary {
+func _Map_String_I32_Read(m wire.MapItemList) (map[string]int32, error) {
+	if m.KeyType() != wire.TBinary {
 		return nil, nil
 	}
-	if m.ValueType != wire.TI32 {
+	if m.ValueType() != wire.TI32 {
 		return nil, nil
 	}
-	o := make(map[string]int32, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	o := make(map[string]int32, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := x.Key.GetString(), error(nil)
 		if err != nil {
 			return err
@@ -732,25 +900,25 @@ func _Map_String_I32_Read(m wire.Map) (map[string]int32, error) {
 		o[k] = v
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
-func _Map_Map_String_I32_I64_Read(m wire.Map) ([]struct {
+func _Map_Map_String_I32_I64_Read(m wire.MapItemList) ([]struct {
 	Key   map[string]int32
 	Value int64
 }, error) {
-	if m.KeyType != wire.TMap {
+	if m.KeyType() != wire.TMap {
 		return nil, nil
 	}
-	if m.ValueType != wire.TI64 {
+	if m.ValueType() != wire.TI64 {
 		return nil, nil
 	}
 	o := make([]struct {
 		Key   map[string]int32
 		Value int64
-	}, 0, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	}, 0, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := _Map_String_I32_Read(x.Key.GetMap())
 		if err != nil {
 			return err
@@ -765,16 +933,16 @@ func _Map_Map_String_I32_I64_Read(m wire.Map) ([]struct {
 		}{k, v})
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
-func _Set_I64_Read(s wire.Set) (map[int64]struct{}, error) {
-	if s.ValueType != wire.TI64 {
+func _Set_I64_Read(s wire.ValueList) (map[int64]struct{}, error) {
+	if s.ValueType() != wire.TI64 {
 		return nil, nil
 	}
-	o := make(map[int64]struct{}, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make(map[int64]struct{}, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := x.GetI64(), error(nil)
 		if err != nil {
 			return err
@@ -782,25 +950,25 @@ func _Set_I64_Read(s wire.Set) (map[int64]struct{}, error) {
 		o[i] = struct{}{}
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
-func _Map_List_I32_Set_I64_Read(m wire.Map) ([]struct {
+func _Map_List_I32_Set_I64_Read(m wire.MapItemList) ([]struct {
 	Key   []int32
 	Value map[int64]struct{}
 }, error) {
-	if m.KeyType != wire.TList {
+	if m.KeyType() != wire.TList {
 		return nil, nil
 	}
-	if m.ValueType != wire.TSet {
+	if m.ValueType() != wire.TSet {
 		return nil, nil
 	}
 	o := make([]struct {
 		Key   []int32
 		Value map[int64]struct{}
-	}, 0, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	}, 0, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := _List_I32_Read(x.Key.GetList())
 		if err != nil {
 			return err
@@ -815,16 +983,16 @@ func _Map_List_I32_Set_I64_Read(m wire.Map) ([]struct {
 		}{k, v})
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
-func _List_Double_Read(l wire.List) ([]float64, error) {
-	if l.ValueType != wire.TDouble {
+func _List_Double_Read(l wire.ValueList) ([]float64, error) {
+	if l.ValueType() != wire.TDouble {
 		return nil, nil
 	}
-	o := make([]float64, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]float64, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := x.GetDouble(), error(nil)
 		if err != nil {
 			return err
@@ -832,25 +1000,25 @@ func _List_Double_Read(l wire.List) ([]float64, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _Map_Set_I32_List_Double_Read(m wire.Map) ([]struct {
+func _Map_Set_I32_List_Double_Read(m wire.MapItemList) ([]struct {
 	Key   map[int32]struct{}
 	Value []float64
 }, error) {
-	if m.KeyType != wire.TSet {
+	if m.KeyType() != wire.TSet {
 		return nil, nil
 	}
-	if m.ValueType != wire.TList {
+	if m.ValueType() != wire.TList {
 		return nil, nil
 	}
 	o := make([]struct {
 		Key   map[int32]struct{}
 		Value []float64
-	}, 0, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	}, 0, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := _Set_I32_Read(x.Key.GetSet())
 		if err != nil {
 			return err
@@ -865,7 +1033,7 @@ func _Map_Set_I32_List_Double_Read(m wire.Map) ([]struct {
 		}{k, v})
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
@@ -1005,7 +1173,15 @@ func (v _List_EnumDefault_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_EnumDefault_ValueList) Close() {
+func (v _List_EnumDefault_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_EnumDefault_ValueList) ValueType() wire.Type {
+	return wire.TI32
+}
+
+func (_List_EnumDefault_ValueList) Close() {
 }
 
 type _Set_EnumWithValues_ValueList map[enums.EnumWithValues]struct{}
@@ -1024,7 +1200,15 @@ func (v _Set_EnumWithValues_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _Set_EnumWithValues_ValueList) Close() {
+func (v _Set_EnumWithValues_ValueList) Size() int {
+	return len(v)
+}
+
+func (_Set_EnumWithValues_ValueList) ValueType() wire.Type {
+	return wire.TI32
+}
+
+func (_Set_EnumWithValues_ValueList) Close() {
 }
 
 type _Map_EnumWithDuplicateValues_I32_MapItemList map[enums.EnumWithDuplicateValues]int32
@@ -1047,7 +1231,19 @@ func (m _Map_EnumWithDuplicateValues_I32_MapItemList) ForEach(f func(wire.MapIte
 	return nil
 }
 
-func (m _Map_EnumWithDuplicateValues_I32_MapItemList) Close() {
+func (m _Map_EnumWithDuplicateValues_I32_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_EnumWithDuplicateValues_I32_MapItemList) KeyType() wire.Type {
+	return wire.TI32
+}
+
+func (_Map_EnumWithDuplicateValues_I32_MapItemList) ValueType() wire.Type {
+	return wire.TI32
+}
+
+func (_Map_EnumWithDuplicateValues_I32_MapItemList) Close() {
 }
 
 func (v *EnumContainers) ToWire() (wire.Value, error) {
@@ -1058,7 +1254,7 @@ func (v *EnumContainers) ToWire() (wire.Value, error) {
 		err    error
 	)
 	if v.ListOfEnums != nil {
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TI32, Size: len(v.ListOfEnums), Items: _List_EnumDefault_ValueList(v.ListOfEnums)}), error(nil)
+		w, err = wire.NewValueList(_List_EnumDefault_ValueList(v.ListOfEnums)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -1066,7 +1262,7 @@ func (v *EnumContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.SetOfEnums != nil {
-		w, err = wire.NewValueSet(wire.Set{ValueType: wire.TI32, Size: len(v.SetOfEnums), Items: _Set_EnumWithValues_ValueList(v.SetOfEnums)}), error(nil)
+		w, err = wire.NewValueSet(_Set_EnumWithValues_ValueList(v.SetOfEnums)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -1074,7 +1270,7 @@ func (v *EnumContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.MapOfEnums != nil {
-		w, err = wire.NewValueMap(wire.Map{KeyType: wire.TI32, ValueType: wire.TI32, Size: len(v.MapOfEnums), Items: _Map_EnumWithDuplicateValues_I32_MapItemList(v.MapOfEnums)}), error(nil)
+		w, err = wire.NewValueMap(_Map_EnumWithDuplicateValues_I32_MapItemList(v.MapOfEnums)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -1090,12 +1286,12 @@ func _EnumDefault_Read(w wire.Value) (enums.EnumDefault, error) {
 	return v, err
 }
 
-func _List_EnumDefault_Read(l wire.List) ([]enums.EnumDefault, error) {
-	if l.ValueType != wire.TI32 {
+func _List_EnumDefault_Read(l wire.ValueList) ([]enums.EnumDefault, error) {
+	if l.ValueType() != wire.TI32 {
 		return nil, nil
 	}
-	o := make([]enums.EnumDefault, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]enums.EnumDefault, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := _EnumDefault_Read(x)
 		if err != nil {
 			return err
@@ -1103,7 +1299,7 @@ func _List_EnumDefault_Read(l wire.List) ([]enums.EnumDefault, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
@@ -1113,12 +1309,12 @@ func _EnumWithValues_Read(w wire.Value) (enums.EnumWithValues, error) {
 	return v, err
 }
 
-func _Set_EnumWithValues_Read(s wire.Set) (map[enums.EnumWithValues]struct{}, error) {
-	if s.ValueType != wire.TI32 {
+func _Set_EnumWithValues_Read(s wire.ValueList) (map[enums.EnumWithValues]struct{}, error) {
+	if s.ValueType() != wire.TI32 {
 		return nil, nil
 	}
-	o := make(map[enums.EnumWithValues]struct{}, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make(map[enums.EnumWithValues]struct{}, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := _EnumWithValues_Read(x)
 		if err != nil {
 			return err
@@ -1126,7 +1322,7 @@ func _Set_EnumWithValues_Read(s wire.Set) (map[enums.EnumWithValues]struct{}, er
 		o[i] = struct{}{}
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
@@ -1136,15 +1332,15 @@ func _EnumWithDuplicateValues_Read(w wire.Value) (enums.EnumWithDuplicateValues,
 	return v, err
 }
 
-func _Map_EnumWithDuplicateValues_I32_Read(m wire.Map) (map[enums.EnumWithDuplicateValues]int32, error) {
-	if m.KeyType != wire.TI32 {
+func _Map_EnumWithDuplicateValues_I32_Read(m wire.MapItemList) (map[enums.EnumWithDuplicateValues]int32, error) {
+	if m.KeyType() != wire.TI32 {
 		return nil, nil
 	}
-	if m.ValueType != wire.TI32 {
+	if m.ValueType() != wire.TI32 {
 		return nil, nil
 	}
-	o := make(map[enums.EnumWithDuplicateValues]int32, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	o := make(map[enums.EnumWithDuplicateValues]int32, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := _EnumWithDuplicateValues_Read(x.Key)
 		if err != nil {
 			return err
@@ -1156,7 +1352,7 @@ func _Map_EnumWithDuplicateValues_I32_Read(m wire.Map) (map[enums.EnumWithDuplic
 		o[k] = v
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
@@ -1233,7 +1429,15 @@ func (v _List_Binary_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_Binary_ValueList) Close() {
+func (v _List_Binary_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_Binary_ValueList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_List_Binary_ValueList) Close() {
 }
 
 type _List_I64_ValueList []int64
@@ -1252,7 +1456,15 @@ func (v _List_I64_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_I64_ValueList) Close() {
+func (v _List_I64_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_I64_ValueList) ValueType() wire.Type {
+	return wire.TI64
+}
+
+func (_List_I64_ValueList) Close() {
 }
 
 type _Set_Byte_ValueList map[int8]struct{}
@@ -1271,7 +1483,15 @@ func (v _Set_Byte_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _Set_Byte_ValueList) Close() {
+func (v _Set_Byte_ValueList) Size() int {
+	return len(v)
+}
+
+func (_Set_Byte_ValueList) ValueType() wire.Type {
+	return wire.TI8
+}
+
+func (_Set_Byte_ValueList) Close() {
 }
 
 type _Map_I32_String_MapItemList map[int32]string
@@ -1294,7 +1514,19 @@ func (m _Map_I32_String_MapItemList) ForEach(f func(wire.MapItem) error) error {
 	return nil
 }
 
-func (m _Map_I32_String_MapItemList) Close() {
+func (m _Map_I32_String_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_I32_String_MapItemList) KeyType() wire.Type {
+	return wire.TI32
+}
+
+func (_Map_I32_String_MapItemList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_I32_String_MapItemList) Close() {
 }
 
 type _Map_String_Bool_MapItemList map[string]bool
@@ -1317,7 +1549,19 @@ func (m _Map_String_Bool_MapItemList) ForEach(f func(wire.MapItem) error) error 
 	return nil
 }
 
-func (m _Map_String_Bool_MapItemList) Close() {
+func (m _Map_String_Bool_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_String_Bool_MapItemList) KeyType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_Bool_MapItemList) ValueType() wire.Type {
+	return wire.TBool
+}
+
+func (_Map_String_Bool_MapItemList) Close() {
 }
 
 func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
@@ -1328,7 +1572,7 @@ func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 		err    error
 	)
 	if v.ListOfBinary != nil {
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TBinary, Size: len(v.ListOfBinary), Items: _List_Binary_ValueList(v.ListOfBinary)}), error(nil)
+		w, err = wire.NewValueList(_List_Binary_ValueList(v.ListOfBinary)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -1336,7 +1580,7 @@ func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.ListOfInts != nil {
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TI64, Size: len(v.ListOfInts), Items: _List_I64_ValueList(v.ListOfInts)}), error(nil)
+		w, err = wire.NewValueList(_List_I64_ValueList(v.ListOfInts)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -1344,7 +1588,7 @@ func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.SetOfStrings != nil {
-		w, err = wire.NewValueSet(wire.Set{ValueType: wire.TBinary, Size: len(v.SetOfStrings), Items: _Set_String_ValueList(v.SetOfStrings)}), error(nil)
+		w, err = wire.NewValueSet(_Set_String_ValueList(v.SetOfStrings)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -1352,7 +1596,7 @@ func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.SetOfBytes != nil {
-		w, err = wire.NewValueSet(wire.Set{ValueType: wire.TI8, Size: len(v.SetOfBytes), Items: _Set_Byte_ValueList(v.SetOfBytes)}), error(nil)
+		w, err = wire.NewValueSet(_Set_Byte_ValueList(v.SetOfBytes)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -1360,7 +1604,7 @@ func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.MapOfIntToString != nil {
-		w, err = wire.NewValueMap(wire.Map{KeyType: wire.TI32, ValueType: wire.TBinary, Size: len(v.MapOfIntToString), Items: _Map_I32_String_MapItemList(v.MapOfIntToString)}), error(nil)
+		w, err = wire.NewValueMap(_Map_I32_String_MapItemList(v.MapOfIntToString)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -1368,7 +1612,7 @@ func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.MapOfStringToBool != nil {
-		w, err = wire.NewValueMap(wire.Map{KeyType: wire.TBinary, ValueType: wire.TBool, Size: len(v.MapOfStringToBool), Items: _Map_String_Bool_MapItemList(v.MapOfStringToBool)}), error(nil)
+		w, err = wire.NewValueMap(_Map_String_Bool_MapItemList(v.MapOfStringToBool)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -1378,12 +1622,12 @@ func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _List_Binary_Read(l wire.List) ([][]byte, error) {
-	if l.ValueType != wire.TBinary {
+func _List_Binary_Read(l wire.ValueList) ([][]byte, error) {
+	if l.ValueType() != wire.TBinary {
 		return nil, nil
 	}
-	o := make([][]byte, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([][]byte, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := x.GetBinary(), error(nil)
 		if err != nil {
 			return err
@@ -1391,16 +1635,16 @@ func _List_Binary_Read(l wire.List) ([][]byte, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _List_I64_Read(l wire.List) ([]int64, error) {
-	if l.ValueType != wire.TI64 {
+func _List_I64_Read(l wire.ValueList) ([]int64, error) {
+	if l.ValueType() != wire.TI64 {
 		return nil, nil
 	}
-	o := make([]int64, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]int64, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := x.GetI64(), error(nil)
 		if err != nil {
 			return err
@@ -1408,16 +1652,16 @@ func _List_I64_Read(l wire.List) ([]int64, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _Set_Byte_Read(s wire.Set) (map[int8]struct{}, error) {
-	if s.ValueType != wire.TI8 {
+func _Set_Byte_Read(s wire.ValueList) (map[int8]struct{}, error) {
+	if s.ValueType() != wire.TI8 {
 		return nil, nil
 	}
-	o := make(map[int8]struct{}, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make(map[int8]struct{}, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := x.GetI8(), error(nil)
 		if err != nil {
 			return err
@@ -1425,19 +1669,19 @@ func _Set_Byte_Read(s wire.Set) (map[int8]struct{}, error) {
 		o[i] = struct{}{}
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
-func _Map_I32_String_Read(m wire.Map) (map[int32]string, error) {
-	if m.KeyType != wire.TI32 {
+func _Map_I32_String_Read(m wire.MapItemList) (map[int32]string, error) {
+	if m.KeyType() != wire.TI32 {
 		return nil, nil
 	}
-	if m.ValueType != wire.TBinary {
+	if m.ValueType() != wire.TBinary {
 		return nil, nil
 	}
-	o := make(map[int32]string, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	o := make(map[int32]string, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := x.Key.GetI32(), error(nil)
 		if err != nil {
 			return err
@@ -1449,19 +1693,19 @@ func _Map_I32_String_Read(m wire.Map) (map[int32]string, error) {
 		o[k] = v
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
-func _Map_String_Bool_Read(m wire.Map) (map[string]bool, error) {
-	if m.KeyType != wire.TBinary {
+func _Map_String_Bool_Read(m wire.MapItemList) (map[string]bool, error) {
+	if m.KeyType() != wire.TBinary {
 		return nil, nil
 	}
-	if m.ValueType != wire.TBool {
+	if m.ValueType() != wire.TBool {
 		return nil, nil
 	}
-	o := make(map[string]bool, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	o := make(map[string]bool, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := x.Key.GetString(), error(nil)
 		if err != nil {
 			return err
@@ -1473,7 +1717,7 @@ func _Map_String_Bool_Read(m wire.Map) (map[string]bool, error) {
 		o[k] = v
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
@@ -1584,7 +1828,19 @@ func (m _Map_I64_Double_MapItemList) ForEach(f func(wire.MapItem) error) error {
 	return nil
 }
 
-func (m _Map_I64_Double_MapItemList) Close() {
+func (m _Map_I64_Double_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_I64_Double_MapItemList) KeyType() wire.Type {
+	return wire.TI64
+}
+
+func (_Map_I64_Double_MapItemList) ValueType() wire.Type {
+	return wire.TDouble
+}
+
+func (_Map_I64_Double_MapItemList) Close() {
 }
 
 func (v *PrimitiveContainersRequired) ToWire() (wire.Value, error) {
@@ -1597,7 +1853,7 @@ func (v *PrimitiveContainersRequired) ToWire() (wire.Value, error) {
 	if v.ListOfStrings == nil {
 		return w, errors.New("field ListOfStrings of PrimitiveContainersRequired is required")
 	}
-	w, err = wire.NewValueList(wire.List{ValueType: wire.TBinary, Size: len(v.ListOfStrings), Items: _List_String_ValueList(v.ListOfStrings)}), error(nil)
+	w, err = wire.NewValueList(_List_String_ValueList(v.ListOfStrings)), error(nil)
 	if err != nil {
 		return w, err
 	}
@@ -1606,7 +1862,7 @@ func (v *PrimitiveContainersRequired) ToWire() (wire.Value, error) {
 	if v.SetOfInts == nil {
 		return w, errors.New("field SetOfInts of PrimitiveContainersRequired is required")
 	}
-	w, err = wire.NewValueSet(wire.Set{ValueType: wire.TI32, Size: len(v.SetOfInts), Items: _Set_I32_ValueList(v.SetOfInts)}), error(nil)
+	w, err = wire.NewValueSet(_Set_I32_ValueList(v.SetOfInts)), error(nil)
 	if err != nil {
 		return w, err
 	}
@@ -1615,7 +1871,7 @@ func (v *PrimitiveContainersRequired) ToWire() (wire.Value, error) {
 	if v.MapOfIntsToDoubles == nil {
 		return w, errors.New("field MapOfIntsToDoubles of PrimitiveContainersRequired is required")
 	}
-	w, err = wire.NewValueMap(wire.Map{KeyType: wire.TI64, ValueType: wire.TDouble, Size: len(v.MapOfIntsToDoubles), Items: _Map_I64_Double_MapItemList(v.MapOfIntsToDoubles)}), error(nil)
+	w, err = wire.NewValueMap(_Map_I64_Double_MapItemList(v.MapOfIntsToDoubles)), error(nil)
 	if err != nil {
 		return w, err
 	}
@@ -1624,15 +1880,15 @@ func (v *PrimitiveContainersRequired) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _Map_I64_Double_Read(m wire.Map) (map[int64]float64, error) {
-	if m.KeyType != wire.TI64 {
+func _Map_I64_Double_Read(m wire.MapItemList) (map[int64]float64, error) {
+	if m.KeyType() != wire.TI64 {
 		return nil, nil
 	}
-	if m.ValueType != wire.TDouble {
+	if m.ValueType() != wire.TDouble {
 		return nil, nil
 	}
-	o := make(map[int64]float64, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	o := make(map[int64]float64, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := x.Key.GetI64(), error(nil)
 		if err != nil {
 			return err
@@ -1644,7 +1900,7 @@ func _Map_I64_Double_Read(m wire.Map) (map[int64]float64, error) {
 		o[k] = v
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 

--- a/gen/testdata/services/service/keyvalue/getmanyvalues.go
+++ b/gen/testdata/services/service/keyvalue/getmanyvalues.go
@@ -32,7 +32,15 @@ func (v _List_Key_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_Key_ValueList) Close() {
+func (v _List_Key_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_Key_ValueList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_List_Key_ValueList) Close() {
 }
 
 func (v *GetManyValuesArgs) ToWire() (wire.Value, error) {
@@ -43,7 +51,7 @@ func (v *GetManyValuesArgs) ToWire() (wire.Value, error) {
 		err    error
 	)
 	if v.Range != nil {
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TBinary, Size: len(v.Range), Items: _List_Key_ValueList(v.Range)}), error(nil)
+		w, err = wire.NewValueList(_List_Key_ValueList(v.Range)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -53,12 +61,12 @@ func (v *GetManyValuesArgs) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _List_Key_Read(l wire.List) ([]services.Key, error) {
-	if l.ValueType != wire.TBinary {
+func _List_Key_Read(l wire.ValueList) ([]services.Key, error) {
+	if l.ValueType() != wire.TBinary {
 		return nil, nil
 	}
-	o := make([]services.Key, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]services.Key, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := _Key_Read(x)
 		if err != nil {
 			return err
@@ -66,7 +74,7 @@ func _List_Key_Read(l wire.List) ([]services.Key, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
@@ -125,7 +133,15 @@ func (v _List_ArbitraryValue_ValueList) ForEach(f func(wire.Value) error) error 
 	return nil
 }
 
-func (v _List_ArbitraryValue_ValueList) Close() {
+func (v _List_ArbitraryValue_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_ArbitraryValue_ValueList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_List_ArbitraryValue_ValueList) Close() {
 }
 
 func (v *GetManyValuesResult) ToWire() (wire.Value, error) {
@@ -136,7 +152,7 @@ func (v *GetManyValuesResult) ToWire() (wire.Value, error) {
 		err    error
 	)
 	if v.Success != nil {
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TStruct, Size: len(v.Success), Items: _List_ArbitraryValue_ValueList(v.Success)}), error(nil)
+		w, err = wire.NewValueList(_List_ArbitraryValue_ValueList(v.Success)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -163,12 +179,12 @@ func _ArbitraryValue_Read(w wire.Value) (*unions.ArbitraryValue, error) {
 	return &v, err
 }
 
-func _List_ArbitraryValue_Read(l wire.List) ([]*unions.ArbitraryValue, error) {
-	if l.ValueType != wire.TStruct {
+func _List_ArbitraryValue_Read(l wire.ValueList) ([]*unions.ArbitraryValue, error) {
+	if l.ValueType() != wire.TStruct {
 		return nil, nil
 	}
-	o := make([]*unions.ArbitraryValue, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]*unions.ArbitraryValue, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := _ArbitraryValue_Read(x)
 		if err != nil {
 			return err
@@ -176,7 +192,7 @@ func _List_ArbitraryValue_Read(l wire.List) ([]*unions.ArbitraryValue, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -94,7 +94,15 @@ func (v _List_String_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_String_ValueList) Close() {
+func (v _List_String_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_String_ValueList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_List_String_ValueList) Close() {
 }
 
 type _List_Double_ValueList []float64
@@ -113,7 +121,15 @@ func (v _List_Double_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_Double_ValueList) Close() {
+func (v _List_Double_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_Double_ValueList) ValueType() wire.Type {
+	return wire.TDouble
+}
+
+func (_List_Double_ValueList) Close() {
 }
 
 func (v *DefaultsStruct) ToWire() (wire.Value, error) {
@@ -171,7 +187,7 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 		v.RequiredList = []string{"hello", "world"}
 	}
 	{
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TBinary, Size: len(v.RequiredList), Items: _List_String_ValueList(v.RequiredList)}), error(nil)
+		w, err = wire.NewValueList(_List_String_ValueList(v.RequiredList)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -182,7 +198,7 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 		v.OptionalList = []float64{1, 2, 3}
 	}
 	{
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TDouble, Size: len(v.OptionalList), Items: _List_Double_ValueList(v.OptionalList)}), error(nil)
+		w, err = wire.NewValueList(_List_Double_ValueList(v.OptionalList)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -220,12 +236,12 @@ func _EnumDefault_Read(w wire.Value) (enums.EnumDefault, error) {
 	return v, err
 }
 
-func _List_String_Read(l wire.List) ([]string, error) {
-	if l.ValueType != wire.TBinary {
+func _List_String_Read(l wire.ValueList) ([]string, error) {
+	if l.ValueType() != wire.TBinary {
 		return nil, nil
 	}
-	o := make([]string, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]string, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := x.GetString(), error(nil)
 		if err != nil {
 			return err
@@ -233,16 +249,16 @@ func _List_String_Read(l wire.List) ([]string, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _List_Double_Read(l wire.List) ([]float64, error) {
-	if l.ValueType != wire.TDouble {
+func _List_Double_Read(l wire.ValueList) ([]float64, error) {
+	if l.ValueType() != wire.TDouble {
 		return nil, nil
 	}
-	o := make([]float64, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]float64, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := x.GetDouble(), error(nil)
 		if err != nil {
 			return err
@@ -250,7 +266,7 @@ func _List_Double_Read(l wire.List) ([]float64, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
@@ -609,7 +625,15 @@ func (v _List_Edge_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_Edge_ValueList) Close() {
+func (v _List_Edge_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_Edge_ValueList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_List_Edge_ValueList) Close() {
 }
 
 func (v *Graph) ToWire() (wire.Value, error) {
@@ -622,7 +646,7 @@ func (v *Graph) ToWire() (wire.Value, error) {
 	if v.Edges == nil {
 		return w, errors.New("field Edges of Graph is required")
 	}
-	w, err = wire.NewValueList(wire.List{ValueType: wire.TStruct, Size: len(v.Edges), Items: _List_Edge_ValueList(v.Edges)}), error(nil)
+	w, err = wire.NewValueList(_List_Edge_ValueList(v.Edges)), error(nil)
 	if err != nil {
 		return w, err
 	}
@@ -631,12 +655,12 @@ func (v *Graph) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _List_Edge_Read(l wire.List) ([]*Edge, error) {
-	if l.ValueType != wire.TStruct {
+func _List_Edge_Read(l wire.ValueList) ([]*Edge, error) {
+	if l.ValueType() != wire.TStruct {
 		return nil, nil
 	}
-	o := make([]*Edge, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]*Edge, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := _Edge_Read(x)
 		if err != nil {
 			return err
@@ -644,7 +668,7 @@ func _List_Edge_Read(l wire.List) ([]*Edge, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -27,15 +27,23 @@ func (v _Set_Binary_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _Set_Binary_ValueList) Close() {
+func (v _Set_Binary_ValueList) Size() int {
+	return len(v)
 }
 
-func _Set_Binary_Read(s wire.Set) ([][]byte, error) {
-	if s.ValueType != wire.TBinary {
+func (_Set_Binary_ValueList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Set_Binary_ValueList) Close() {
+}
+
+func _Set_Binary_Read(s wire.ValueList) ([][]byte, error) {
+	if s.ValueType() != wire.TBinary {
 		return nil, nil
 	}
-	o := make([][]byte, 0, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make([][]byte, 0, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := x.GetBinary(), error(nil)
 		if err != nil {
 			return err
@@ -43,7 +51,7 @@ func _Set_Binary_Read(s wire.Set) ([][]byte, error) {
 		o = append(o, i)
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
@@ -51,7 +59,7 @@ type BinarySet [][]byte
 
 func (v BinarySet) ToWire() (wire.Value, error) {
 	x := ([][]byte)(v)
-	return wire.NewValueSet(wire.Set{ValueType: wire.TBinary, Size: len(x), Items: _Set_Binary_ValueList(x)}), error(nil)
+	return wire.NewValueSet(_Set_Binary_ValueList(x)), error(nil)
 }
 
 func (v BinarySet) String() string {
@@ -90,7 +98,19 @@ func (m _Map_Edge_Edge_MapItemList) ForEach(f func(wire.MapItem) error) error {
 	return nil
 }
 
-func (m _Map_Edge_Edge_MapItemList) Close() {
+func (m _Map_Edge_Edge_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_Edge_Edge_MapItemList) KeyType() wire.Type {
+	return wire.TStruct
+}
+
+func (_Map_Edge_Edge_MapItemList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_Map_Edge_Edge_MapItemList) Close() {
 }
 
 func _Edge_Read(w wire.Value) (*structs.Edge, error) {
@@ -99,21 +119,21 @@ func _Edge_Read(w wire.Value) (*structs.Edge, error) {
 	return &v, err
 }
 
-func _Map_Edge_Edge_Read(m wire.Map) ([]struct {
+func _Map_Edge_Edge_Read(m wire.MapItemList) ([]struct {
 	Key   *structs.Edge
 	Value *structs.Edge
 }, error) {
-	if m.KeyType != wire.TStruct {
+	if m.KeyType() != wire.TStruct {
 		return nil, nil
 	}
-	if m.ValueType != wire.TStruct {
+	if m.ValueType() != wire.TStruct {
 		return nil, nil
 	}
 	o := make([]struct {
 		Key   *structs.Edge
 		Value *structs.Edge
-	}, 0, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	}, 0, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := _Edge_Read(x.Key)
 		if err != nil {
 			return err
@@ -128,7 +148,7 @@ func _Map_Edge_Edge_Read(m wire.Map) ([]struct {
 		}{k, v})
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
@@ -142,7 +162,7 @@ func (v EdgeMap) ToWire() (wire.Value, error) {
 		Key   *structs.Edge
 		Value *structs.Edge
 	})(v)
-	return wire.NewValueMap(wire.Map{KeyType: wire.TStruct, ValueType: wire.TStruct, Size: len(x), Items: _Map_Edge_Edge_MapItemList(x)}), error(nil)
+	return wire.NewValueMap(_Map_Edge_Edge_MapItemList(x)), error(nil)
 }
 
 func (v EdgeMap) String() string {
@@ -261,7 +281,15 @@ func (v _List_Event_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _List_Event_ValueList) Close() {
+func (v _List_Event_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_Event_ValueList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_List_Event_ValueList) Close() {
 }
 
 func _Event_Read(w wire.Value) (*Event, error) {
@@ -270,12 +298,12 @@ func _Event_Read(w wire.Value) (*Event, error) {
 	return &v, err
 }
 
-func _List_Event_Read(l wire.List) ([]*Event, error) {
-	if l.ValueType != wire.TStruct {
+func _List_Event_Read(l wire.ValueList) ([]*Event, error) {
+	if l.ValueType() != wire.TStruct {
 		return nil, nil
 	}
-	o := make([]*Event, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]*Event, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := _Event_Read(x)
 		if err != nil {
 			return err
@@ -283,7 +311,7 @@ func _List_Event_Read(l wire.List) ([]*Event, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
@@ -291,7 +319,7 @@ type EventGroup []*Event
 
 func (v EventGroup) ToWire() (wire.Value, error) {
 	x := ([]*Event)(v)
-	return wire.NewValueList(wire.List{ValueType: wire.TStruct, Size: len(x), Items: _List_Event_ValueList(x)}), error(nil)
+	return wire.NewValueList(_List_Event_ValueList(x)), error(nil)
 }
 
 func (v EventGroup) String() string {
@@ -321,7 +349,15 @@ func (v _Set_Frame_ValueList) ForEach(f func(wire.Value) error) error {
 	return nil
 }
 
-func (v _Set_Frame_ValueList) Close() {
+func (v _Set_Frame_ValueList) Size() int {
+	return len(v)
+}
+
+func (_Set_Frame_ValueList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_Set_Frame_ValueList) Close() {
 }
 
 func _Frame_Read(w wire.Value) (*structs.Frame, error) {
@@ -330,12 +366,12 @@ func _Frame_Read(w wire.Value) (*structs.Frame, error) {
 	return &v, err
 }
 
-func _Set_Frame_Read(s wire.Set) ([]*structs.Frame, error) {
-	if s.ValueType != wire.TStruct {
+func _Set_Frame_Read(s wire.ValueList) ([]*structs.Frame, error) {
+	if s.ValueType() != wire.TStruct {
 		return nil, nil
 	}
-	o := make([]*structs.Frame, 0, s.Size)
-	err := s.Items.ForEach(func(x wire.Value) error {
+	o := make([]*structs.Frame, 0, s.Size())
+	err := s.ForEach(func(x wire.Value) error {
 		i, err := _Frame_Read(x)
 		if err != nil {
 			return err
@@ -343,7 +379,7 @@ func _Set_Frame_Read(s wire.Set) ([]*structs.Frame, error) {
 		o = append(o, i)
 		return nil
 	})
-	s.Items.Close()
+	s.Close()
 	return o, err
 }
 
@@ -351,7 +387,7 @@ type FrameGroup []*structs.Frame
 
 func (v FrameGroup) ToWire() (wire.Value, error) {
 	x := ([]*structs.Frame)(v)
-	return wire.NewValueSet(wire.Set{ValueType: wire.TStruct, Size: len(x), Items: _Set_Frame_ValueList(x)}), error(nil)
+	return wire.NewValueSet(_Set_Frame_ValueList(x)), error(nil)
 }
 
 func (v FrameGroup) String() string {
@@ -432,7 +468,19 @@ func (m _Map_Point_Point_MapItemList) ForEach(f func(wire.MapItem) error) error 
 	return nil
 }
 
-func (m _Map_Point_Point_MapItemList) Close() {
+func (m _Map_Point_Point_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_Point_Point_MapItemList) KeyType() wire.Type {
+	return wire.TStruct
+}
+
+func (_Map_Point_Point_MapItemList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_Map_Point_Point_MapItemList) Close() {
 }
 
 func _Point_Read(w wire.Value) (*structs.Point, error) {
@@ -441,21 +489,21 @@ func _Point_Read(w wire.Value) (*structs.Point, error) {
 	return &v, err
 }
 
-func _Map_Point_Point_Read(m wire.Map) ([]struct {
+func _Map_Point_Point_Read(m wire.MapItemList) ([]struct {
 	Key   *structs.Point
 	Value *structs.Point
 }, error) {
-	if m.KeyType != wire.TStruct {
+	if m.KeyType() != wire.TStruct {
 		return nil, nil
 	}
-	if m.ValueType != wire.TStruct {
+	if m.ValueType() != wire.TStruct {
 		return nil, nil
 	}
 	o := make([]struct {
 		Key   *structs.Point
 		Value *structs.Point
-	}, 0, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	}, 0, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := _Point_Read(x.Key)
 		if err != nil {
 			return err
@@ -470,7 +518,7 @@ func _Map_Point_Point_Read(m wire.Map) ([]struct {
 		}{k, v})
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 
@@ -484,7 +532,7 @@ func (v PointMap) ToWire() (wire.Value, error) {
 		Key   *structs.Point
 		Value *structs.Point
 	})(v)
-	return wire.NewValueMap(wire.Map{KeyType: wire.TStruct, ValueType: wire.TStruct, Size: len(x), Items: _Map_Point_Point_MapItemList(x)}), error(nil)
+	return wire.NewValueMap(_Map_Point_Point_MapItemList(x)), error(nil)
 }
 
 func (v PointMap) String() string {

--- a/gen/testdata/unions/types.go
+++ b/gen/testdata/unions/types.go
@@ -33,7 +33,15 @@ func (v _List_ArbitraryValue_ValueList) ForEach(f func(wire.Value) error) error 
 	return nil
 }
 
-func (v _List_ArbitraryValue_ValueList) Close() {
+func (v _List_ArbitraryValue_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_ArbitraryValue_ValueList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_List_ArbitraryValue_ValueList) Close() {
 }
 
 type _Map_String_ArbitraryValue_MapItemList map[string]*ArbitraryValue
@@ -56,7 +64,19 @@ func (m _Map_String_ArbitraryValue_MapItemList) ForEach(f func(wire.MapItem) err
 	return nil
 }
 
-func (m _Map_String_ArbitraryValue_MapItemList) Close() {
+func (m _Map_String_ArbitraryValue_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_String_ArbitraryValue_MapItemList) KeyType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_ArbitraryValue_MapItemList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_Map_String_ArbitraryValue_MapItemList) Close() {
 }
 
 func (v *ArbitraryValue) ToWire() (wire.Value, error) {
@@ -91,7 +111,7 @@ func (v *ArbitraryValue) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.ListValue != nil {
-		w, err = wire.NewValueList(wire.List{ValueType: wire.TStruct, Size: len(v.ListValue), Items: _List_ArbitraryValue_ValueList(v.ListValue)}), error(nil)
+		w, err = wire.NewValueList(_List_ArbitraryValue_ValueList(v.ListValue)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -99,7 +119,7 @@ func (v *ArbitraryValue) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.MapValue != nil {
-		w, err = wire.NewValueMap(wire.Map{KeyType: wire.TBinary, ValueType: wire.TStruct, Size: len(v.MapValue), Items: _Map_String_ArbitraryValue_MapItemList(v.MapValue)}), error(nil)
+		w, err = wire.NewValueMap(_Map_String_ArbitraryValue_MapItemList(v.MapValue)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -118,12 +138,12 @@ func _ArbitraryValue_Read(w wire.Value) (*ArbitraryValue, error) {
 	return &v, err
 }
 
-func _List_ArbitraryValue_Read(l wire.List) ([]*ArbitraryValue, error) {
-	if l.ValueType != wire.TStruct {
+func _List_ArbitraryValue_Read(l wire.ValueList) ([]*ArbitraryValue, error) {
+	if l.ValueType() != wire.TStruct {
 		return nil, nil
 	}
-	o := make([]*ArbitraryValue, 0, l.Size)
-	err := l.Items.ForEach(func(x wire.Value) error {
+	o := make([]*ArbitraryValue, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
 		i, err := _ArbitraryValue_Read(x)
 		if err != nil {
 			return err
@@ -131,19 +151,19 @@ func _List_ArbitraryValue_Read(l wire.List) ([]*ArbitraryValue, error) {
 		o = append(o, i)
 		return nil
 	})
-	l.Items.Close()
+	l.Close()
 	return o, err
 }
 
-func _Map_String_ArbitraryValue_Read(m wire.Map) (map[string]*ArbitraryValue, error) {
-	if m.KeyType != wire.TBinary {
+func _Map_String_ArbitraryValue_Read(m wire.MapItemList) (map[string]*ArbitraryValue, error) {
+	if m.KeyType() != wire.TBinary {
 		return nil, nil
 	}
-	if m.ValueType != wire.TStruct {
+	if m.ValueType() != wire.TStruct {
 		return nil, nil
 	}
-	o := make(map[string]*ArbitraryValue, m.Size)
-	err := m.Items.ForEach(func(x wire.MapItem) error {
+	o := make(map[string]*ArbitraryValue, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
 		k, err := x.Key.GetString(), error(nil)
 		if err != nil {
 			return err
@@ -155,7 +175,7 @@ func _Map_String_ArbitraryValue_Read(m wire.Map) (map[string]*ArbitraryValue, er
 		o[k] = v
 		return nil
 	})
-	m.Items.Close()
+	m.Close()
 	return o, err
 }
 

--- a/gen/typedef_test.go
+++ b/gen/typedef_test.go
@@ -119,10 +119,8 @@ func TestTypedefContainer(t *testing.T) {
 					Time: (*td.Timestamp)(int64p(100)),
 				},
 			},
-			wire.NewValueList(wire.List{
-				ValueType: wire.TStruct,
-				Size:      2,
-				Items: wire.ValueListFromSlice([]wire.Value{
+			wire.NewValueList(
+				wire.ValueListFromSlice(wire.TStruct, []wire.Value{
 					wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 						{ID: 1, Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 							{ID: 1, Value: wire.NewValueI64(100)},
@@ -138,7 +136,7 @@ func TestTypedefContainer(t *testing.T) {
 						{ID: 2, Value: wire.NewValueI64(100)},
 					}}),
 				}),
-			}),
+			),
 		},
 	}
 
@@ -154,21 +152,17 @@ func TestUnhashableSetAlias(t *testing.T) {
 	}{
 		{
 			td.FrameGroup{},
-			wire.NewValueSet(wire.Set{
-				ValueType: wire.TStruct,
-				Size:      0,
-				Items:     wire.ValueListFromSlice([]wire.Value{}),
-			}),
+			wire.NewValueSet(
+				wire.ValueListFromSlice(wire.TStruct, []wire.Value{}),
+			),
 		},
 		{
 			td.FrameGroup{
 				&ts.Frame{TopLeft: &ts.Point{X: 1, Y: 2}, Size: &ts.Size{Width: 3, Height: 4}},
 				&ts.Frame{TopLeft: &ts.Point{X: 5, Y: 6}, Size: &ts.Size{Width: 7, Height: 8}},
 			},
-			wire.NewValueSet(wire.Set{
-				ValueType: wire.TStruct,
-				Size:      2,
-				Items: wire.ValueListFromSlice([]wire.Value{
+			wire.NewValueSet(
+				wire.ValueListFromSlice(wire.TStruct, []wire.Value{
 					wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 						{ID: 1, Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 							{ID: 1, Value: wire.NewValueDouble(1)},
@@ -190,7 +184,7 @@ func TestUnhashableSetAlias(t *testing.T) {
 						}})},
 					}}),
 				}),
-			}),
+			),
 		},
 	}
 
@@ -206,12 +200,9 @@ func TestUnhashableMapKeyAlias(t *testing.T) {
 	}{
 		{
 			td.PointMap{},
-			wire.NewValueMap(wire.Map{
-				KeyType:   wire.TStruct,
-				ValueType: wire.TStruct,
-				Size:      0,
-				Items:     wire.MapItemListFromSlice([]wire.MapItem{}),
-			}),
+			wire.NewValueMap(
+				wire.MapItemListFromSlice(wire.TStruct, wire.TStruct, []wire.MapItem{}),
+			),
 		},
 		{
 			td.PointMap{
@@ -228,11 +219,8 @@ func TestUnhashableMapKeyAlias(t *testing.T) {
 					Value: &ts.Point{X: 11, Y: 12},
 				},
 			},
-			wire.NewValueMap(wire.Map{
-				KeyType:   wire.TStruct,
-				ValueType: wire.TStruct,
-				Size:      3,
-				Items: wire.MapItemListFromSlice([]wire.MapItem{
+			wire.NewValueMap(
+				wire.MapItemListFromSlice(wire.TStruct, wire.TStruct, []wire.MapItem{
 					{
 						Key: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 							{ID: 1, Value: wire.NewValueDouble(1)},
@@ -264,7 +252,7 @@ func TestUnhashableMapKeyAlias(t *testing.T) {
 						}}),
 					},
 				}),
-			}),
+			),
 		},
 	}
 
@@ -280,25 +268,21 @@ func TestBinarySet(t *testing.T) {
 	}{
 		{
 			td.BinarySet{},
-			wire.NewValueSet(wire.Set{
-				ValueType: wire.TBinary,
-				Size:      0,
-				Items:     wire.ValueListFromSlice([]wire.Value{}),
-			}),
+			wire.NewValueSet(
+				wire.ValueListFromSlice(wire.TBinary, []wire.Value{}),
+			),
 		},
 		{
 			td.BinarySet{
 				{1, 2, 3},
 				{4, 5, 6},
 			},
-			wire.NewValueSet(wire.Set{
-				ValueType: wire.TBinary,
-				Size:      2,
-				Items: wire.ValueListFromSlice([]wire.Value{
+			wire.NewValueSet(
+				wire.ValueListFromSlice(wire.TBinary, []wire.Value{
 					wire.NewValueBinary([]byte{1, 2, 3}),
 					wire.NewValueBinary([]byte{4, 5, 6}),
 				}),
-			}),
+			),
 		},
 	}
 

--- a/gen/wire.go
+++ b/gen/wire.go
@@ -71,12 +71,7 @@ func (w *WireGenerator) ToWire(g Generator, spec compile.TypeSpec, varName strin
 		}
 
 		return g.TextTemplate(
-			`<.Wire>.NewValueMap(<.Wire>.Map{
-				KeyType: <typeCode .Spec.KeySpec>,
-				ValueType: <typeCode .Spec.ValueSpec>,
-				Size: len(<.Name>),
-				Items: <.MapItemList>(<.Name>),
-			}), error(nil)`,
+			`<.Wire>.NewValueMap(<.MapItemList>(<.Name>)), error(nil)`,
 			struct {
 				Wire        string
 				Name        string
@@ -91,11 +86,7 @@ func (w *WireGenerator) ToWire(g Generator, spec compile.TypeSpec, varName strin
 		}
 
 		return g.TextTemplate(
-			`<.Wire>.NewValueList(<.Wire>.List{
-				ValueType: <typeCode .Spec.ValueSpec>,
-				Size: len(<.Name>),
-				Items: <.ValueList>(<.Name>),
-			}), error(nil)`,
+			`<.Wire>.NewValueList(<.ValueList>(<.Name>)), error(nil)`,
 			struct {
 				Wire      string
 				Name      string
@@ -110,11 +101,7 @@ func (w *WireGenerator) ToWire(g Generator, spec compile.TypeSpec, varName strin
 		}
 
 		return g.TextTemplate(
-			`<.Wire>.NewValueSet(<.Wire>.Set{
-				ValueType: <typeCode .Spec.ValueSpec>,
-				Size: len(<.Name>),
-				Items: <.ValueList>(<.Name>),
-			}), error(nil)`,
+			`<.Wire>.NewValueSet(<.ValueList>(<.Name>)), error(nil)`,
 			struct {
 				Wire      string
 				Name      string

--- a/protocol/binary/lazy_list.go
+++ b/protocol/binary/lazy_list.go
@@ -52,6 +52,14 @@ type lazyValueList struct {
 	startOffset int64
 }
 
+func (ll *lazyValueList) ValueType() wire.Type {
+	return ll.typ
+}
+
+func (ll *lazyValueList) Size() int {
+	return int(ll.count)
+}
+
 func (ll *lazyValueList) ForEach(f func(wire.Value) error) error {
 	off := ll.startOffset
 
@@ -85,6 +93,18 @@ type lazyMapItemList struct {
 	count        int32
 	reader       *Reader
 	startOffset  int64
+}
+
+func (lm *lazyMapItemList) KeyType() wire.Type {
+	return lm.ktype
+}
+
+func (lm *lazyMapItemList) ValueType() wire.Type {
+	return lm.vtype
+}
+
+func (lm *lazyMapItemList) Size() int {
+	return int(lm.count)
 }
 
 func (lm *lazyMapItemList) ForEach(f func(wire.MapItem) error) error {

--- a/protocol/binary/writer.go
+++ b/protocol/binary/writer.go
@@ -148,51 +148,51 @@ func (bw *Writer) realWriteMapItem(item wire.MapItem) error {
 	return bw.WriteValue(item.Value)
 }
 
-func (bw *Writer) writeMap(m wire.Map) error {
+func (bw *Writer) writeMap(m wire.MapItemList) error {
 	// ktype:1
-	if err := bw.writeByte(byte(m.KeyType)); err != nil {
+	if err := bw.writeByte(byte(m.KeyType())); err != nil {
 		return err
 	}
 
 	// vtype:1
-	if err := bw.writeByte(byte(m.ValueType)); err != nil {
+	if err := bw.writeByte(byte(m.ValueType())); err != nil {
 		return err
 	}
 
 	// length:4
-	if err := bw.writeInt32(int32(m.Size)); err != nil {
+	if err := bw.writeInt32(int32(m.Size())); err != nil {
 		return err
 	}
 
-	return m.Items.ForEach(bw.writeMapItem)
+	return m.ForEach(bw.writeMapItem)
 }
 
-func (bw *Writer) writeSet(s wire.Set) error {
+func (bw *Writer) writeSet(s wire.ValueList) error {
 	// vtype:1
-	if err := bw.writeByte(byte(s.ValueType)); err != nil {
+	if err := bw.writeByte(byte(s.ValueType())); err != nil {
 		return err
 	}
 
 	// length:4
-	if err := bw.writeInt32(int32(s.Size)); err != nil {
+	if err := bw.writeInt32(int32(s.Size())); err != nil {
 		return err
 	}
 
-	return s.Items.ForEach(bw.writeValue)
+	return s.ForEach(bw.writeValue)
 }
 
-func (bw *Writer) writeList(l wire.List) error {
+func (bw *Writer) writeList(l wire.ValueList) error {
 	// vtype:1
-	if err := bw.writeByte(byte(l.ValueType)); err != nil {
+	if err := bw.writeByte(byte(l.ValueType())); err != nil {
 		return err
 	}
 
 	// length:4
-	if err := bw.writeInt32(int32(l.Size)); err != nil {
+	if err := bw.writeInt32(int32(l.Size())); err != nil {
 		return err
 	}
 
-	return l.Items.ForEach(bw.writeValue)
+	return l.ForEach(bw.writeValue)
 }
 
 // WriteValue writes the given Thrift value to the underlying stream using the

--- a/protocol/value_test.go
+++ b/protocol/value_test.go
@@ -62,28 +62,15 @@ func vfield(id int16, v wire.Value) wire.Field {
 }
 
 func vlist(typ wire.Type, vs ...wire.Value) wire.Value {
-	return wire.NewValueList(wire.List{
-		ValueType: typ,
-		Size:      len(vs),
-		Items:     wire.ValueListFromSlice(vs),
-	})
+	return wire.NewValueList(wire.ValueListFromSlice(typ, vs))
 }
 
 func vset(typ wire.Type, vs ...wire.Value) wire.Value {
-	return wire.NewValueSet(wire.Set{
-		ValueType: typ,
-		Size:      len(vs),
-		Items:     wire.ValueListFromSlice(vs),
-	})
+	return wire.NewValueSet(wire.ValueListFromSlice(typ, vs))
 }
 
 func vmap(kt, vt wire.Type, items ...wire.MapItem) wire.Value {
-	return wire.NewValueMap(wire.Map{
-		KeyType:   kt,
-		ValueType: vt,
-		Size:      len(items),
-		Items:     wire.MapItemListFromSlice(items),
-	})
+	return wire.NewValueMap(wire.MapItemListFromSlice(kt, vt, items))
 }
 
 func vitem(k, v wire.Value) wire.MapItem {

--- a/wire/evaluate.go
+++ b/wire/evaluate.go
@@ -37,8 +37,8 @@ func EvaluateValue(v Value) error {
 		return nil
 	case TMap:
 		m := v.GetMap()
-		defer m.Items.Close()
-		return m.Items.ForEach(func(item MapItem) error {
+		defer m.Close()
+		return m.ForEach(func(item MapItem) error {
 			if err := EvaluateValue(item.Key); err != nil {
 				return err
 			}
@@ -49,12 +49,12 @@ func EvaluateValue(v Value) error {
 		})
 	case TSet:
 		s := v.GetSet()
-		defer s.Items.Close()
-		return s.Items.ForEach(EvaluateValue)
+		defer s.Close()
+		return s.ForEach(EvaluateValue)
 	case TList:
 		l := v.GetList()
-		defer l.Items.Close()
-		return l.Items.ForEach(EvaluateValue)
+		defer l.Close()
+		return l.ForEach(EvaluateValue)
 	default:
 		return fmt.Errorf("unknown type %s", v.Type())
 	}

--- a/wire/lazy_list_test.go
+++ b/wire/lazy_list_test.go
@@ -35,7 +35,7 @@ func TestValueListFromSliceAll(t *testing.T) {
 	}
 
 	i := 0
-	err := ValueListFromSlice(slice).ForEach(func(v Value) error {
+	err := ValueListFromSlice(TI32, slice).ForEach(func(v Value) error {
 		assert.Equal(t, slice[i], v)
 		i++
 
@@ -56,7 +56,7 @@ func TestValueListFromSliceBreak(t *testing.T) {
 	expectedErr := fmt.Errorf("fail")
 
 	i := 0
-	err := ValueListFromSlice(slice).ForEach(func(v Value) error {
+	err := ValueListFromSlice(TBinary, slice).ForEach(func(v Value) error {
 		assert.Equal(t, slice[i], v)
 		i++
 		if i == 2 {
@@ -90,7 +90,7 @@ func TestMapItemListFromSliceAll(t *testing.T) {
 	}
 
 	i := 0
-	err := MapItemListFromSlice(slice).ForEach(func(v MapItem) error {
+	err := MapItemListFromSlice(TI32, TBinary, slice).ForEach(func(v MapItem) error {
 		assert.Equal(t, slice[i], v)
 		i++
 
@@ -120,7 +120,7 @@ func TestMapItemListFromSliceBreak(t *testing.T) {
 	expectedErr := fmt.Errorf("fail")
 
 	i := 0
-	err := MapItemListFromSlice(slice).ForEach(func(v MapItem) error {
+	err := MapItemListFromSlice(TI64, TI32, slice).ForEach(func(v MapItem) error {
 		assert.Equal(t, slice[i], v)
 		i++
 		if i == 2 {

--- a/wire/value.go
+++ b/wire/value.go
@@ -39,9 +39,9 @@ type Value struct {
 	ti64    int64
 	tbinary []byte
 	tstruct Struct
-	tmap    Map
-	tset    Set
-	tlist   List
+	tmap    MapItemList
+	tset    ValueList
+	tlist   ValueList
 }
 
 // Type retrieves the type of value inside a Value.
@@ -197,7 +197,7 @@ func (v *Value) GetStruct() Struct {
 }
 
 // NewValueMap constructs a new Value that contains a map.
-func NewValueMap(v Map) Value {
+func NewValueMap(v MapItemList) Value {
 	return Value{
 		typ:  TMap,
 		tmap: v,
@@ -205,12 +205,12 @@ func NewValueMap(v Map) Value {
 }
 
 // GetMap gets the Map value from a Value.
-func (v *Value) GetMap() Map {
+func (v *Value) GetMap() MapItemList {
 	return v.tmap
 }
 
 // NewValueSet constructs a new Value that contains a set.
-func NewValueSet(v Set) Value {
+func NewValueSet(v ValueList) Value {
 	return Value{
 		typ:  TSet,
 		tset: v,
@@ -218,12 +218,12 @@ func NewValueSet(v Set) Value {
 }
 
 // GetSet gets the Set value from a Value.
-func (v *Value) GetSet() Set {
+func (v *Value) GetSet() ValueList {
 	return v.tset
 }
 
 // NewValueList constructs a new Value that contains a list.
-func NewValueList(v List) Value {
+func NewValueList(v ValueList) Value {
 	return Value{
 		typ:   TList,
 		tlist: v,
@@ -231,7 +231,7 @@ func NewValueList(v List) Value {
 }
 
 // GetList gets the List value from a Value.
-func (v *Value) GetList() List {
+func (v *Value) GetList() ValueList {
 	return v.tlist
 }
 
@@ -295,60 +295,6 @@ type Field struct {
 
 func (f Field) String() string {
 	return fmt.Sprintf("%v: %v", f.ID, f.Value)
-}
-
-// Set is a set of values.
-type Set struct {
-	ValueType Type
-	Size      int
-	Items     ValueList
-}
-
-func (s Set) String() string {
-	items := make([]string, 0, s.Size)
-	s.Items.ForEach(func(item Value) error {
-		items = append(items, item.String())
-		return nil
-	})
-
-	return fmt.Sprintf("[set]%v{%s}", s.ValueType, strings.Join(items, ", "))
-}
-
-// List is a list of values.
-type List struct {
-	ValueType Type
-	Size      int
-	Items     ValueList
-}
-
-func (l List) String() string {
-	items := make([]string, 0, l.Size)
-	l.Items.ForEach(func(item Value) error {
-		items = append(items, item.String())
-		return nil
-	})
-
-	return fmt.Sprintf("[]%v{%s}", l.ValueType, strings.Join(items, ", "))
-}
-
-// Map is a collection of key-value pairs.
-type Map struct {
-	KeyType   Type
-	ValueType Type
-	Size      int
-	Items     MapItemList
-}
-
-func (m Map) String() string {
-	items := make([]string, 0, m.Size)
-	m.Items.ForEach(func(item MapItem) error {
-		items = append(items, item.String())
-		return nil
-	})
-
-	return fmt.Sprintf(
-		"map[%v]%v{%s}", m.KeyType, m.ValueType, strings.Join(items, ", "),
-	)
 }
 
 // MapItem is a single item in a Map.

--- a/wire/value_test.go
+++ b/wire/value_test.go
@@ -35,28 +35,15 @@ func vbinary(s string) Value {
 }
 
 func vlist(typ Type, vs ...Value) Value {
-	return NewValueList(List{
-		ValueType: typ,
-		Size:      len(vs),
-		Items:     ValueListFromSlice(vs),
-	})
+	return NewValueList(ValueListFromSlice(typ, vs))
 }
 
 func vset(typ Type, vs ...Value) Value {
-	return NewValueSet(Set{
-		ValueType: typ,
-		Size:      len(vs),
-		Items:     ValueListFromSlice(vs),
-	})
+	return NewValueSet(ValueListFromSlice(typ, vs))
 }
 
 func vmap(kt, vt Type, items ...MapItem) Value {
-	return NewValueMap(Map{
-		KeyType:   kt,
-		ValueType: vt,
-		Size:      len(items),
-		Items:     MapItemListFromSlice(items),
-	})
+	return NewValueMap(MapItemListFromSlice(kt, vt, items))
 }
 
 func vitem(k, v Value) MapItem {


### PR DESCRIPTION
This allows us to get rid of the expensive Set, Map, and List structs,
reducing the overall size of the Value object.

So instead of value being one of,

    Set(ValueType, Size, ValueList)
    List(ValueType, Size, ValueList)
    Map(KeyType, ValueType, Size, MapItemList)

It's simply one of the corresponding lazy lists, and the lazy lists themselves
define `ValueType()`, `Size()`, etc. functions.

----

Testing against the degenerative test case with a `list<map<i32,set<string>>>` where each collection is 1000 elements, this showed a _slight_ improvement in serialization performance and the same number of allocs.

Before:

```
BenchmarkThriftRWWriteNestedMixed-8	     300	   5954503 ns/op	    2101 B/op	      63 allocs/op
```

After

```
BenchmarkThriftRWWriteNestedMixed-8	     300	   5521817 ns/op	    1940 B/op	      63 allocs/op
```