### PR TITLE
wire/value: Reduce number of fields

### DIFF
--- a/wire/value.go
+++ b/wire/value.go
@@ -39,9 +39,7 @@ type Value struct {
 	ti64    int64
 	tbinary []byte
 	tstruct Struct
-	tmap    MapItemList
-	tset    ValueList
-	tlist   ValueList
+	tcoll   interface{} // set/map/list
 }
 
 // Type retrieves the type of value inside a Value.
@@ -68,12 +66,8 @@ func (v *Value) Get() interface{} {
 		return v.tbinary
 	case TStruct:
 		return v.tstruct
-	case TMap:
-		return v.tmap
-	case TSet:
-		return v.tset
-	case TList:
-		return v.tlist
+	case TMap, TSet, TList:
+		return v.tcoll
 	default:
 		panic(fmt.Sprintf("Unknown value type %v", v.typ))
 	}
@@ -199,40 +193,40 @@ func (v *Value) GetStruct() Struct {
 // NewValueMap constructs a new Value that contains a map.
 func NewValueMap(v MapItemList) Value {
 	return Value{
-		typ:  TMap,
-		tmap: v,
+		typ:   TMap,
+		tcoll: v,
 	}
 }
 
 // GetMap gets the Map value from a Value.
 func (v *Value) GetMap() MapItemList {
-	return v.tmap
+	return v.tcoll.(MapItemList)
 }
 
 // NewValueSet constructs a new Value that contains a set.
 func NewValueSet(v ValueList) Value {
 	return Value{
-		typ:  TSet,
-		tset: v,
+		typ:   TSet,
+		tcoll: v,
 	}
 }
 
 // GetSet gets the Set value from a Value.
 func (v *Value) GetSet() ValueList {
-	return v.tset
+	return v.tcoll.(ValueList)
 }
 
 // NewValueList constructs a new Value that contains a list.
 func NewValueList(v ValueList) Value {
 	return Value{
 		typ:   TList,
-		tlist: v,
+		tcoll: v,
 	}
 }
 
 // GetList gets the List value from a Value.
 func (v *Value) GetList() ValueList {
-	return v.tlist
+	return v.tcoll.(ValueList)
 }
 
 func (v Value) String() string {
@@ -254,11 +248,11 @@ func (v Value) String() string {
 	case TStruct:
 		return fmt.Sprintf("TStruct(%v)", v.tstruct)
 	case TMap:
-		return fmt.Sprintf("TMap(%v)", v.tmap)
+		return fmt.Sprintf("TMap(%v)", v.tcoll)
 	case TSet:
-		return fmt.Sprintf("TSet(%v)", v.tset)
+		return fmt.Sprintf("TSet(%v)", v.tcoll)
 	case TList:
-		return fmt.Sprintf("TList(%v)", v.tlist)
+		return fmt.Sprintf("TList(%v)", v.tcoll)
 	default:
 		panic(fmt.Sprintf("Unknown value type %v", v.typ))
 	}

--- a/wire/value.go
+++ b/wire/value.go
@@ -22,6 +22,7 @@ package wire
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -31,12 +32,7 @@ import (
 type Value struct {
 	typ Type
 
-	tbool   bool
-	tdouble float64
-	ti8     int8
-	ti16    int16
-	ti32    int32
-	ti64    int64
+	tnumber uint64
 	tbinary []byte
 	tstruct Struct
 	tcoll   interface{} // set/map/list
@@ -51,23 +47,25 @@ func (v *Value) Type() Type {
 func (v *Value) Get() interface{} {
 	switch v.typ {
 	case TBool:
-		return v.tbool
+		return v.GetBool()
 	case TI8:
-		return v.ti8
+		return v.GetI8()
 	case TDouble:
-		return v.tdouble
+		return v.GetDouble()
 	case TI16:
-		return v.ti16
+		return v.GetI16()
 	case TI32:
-		return v.ti32
+		return v.GetI32()
 	case TI64:
-		return v.ti64
+		return v.GetI64()
 	case TBinary:
-		return v.tbinary
+		return v.GetBinary()
 	case TStruct:
-		return v.tstruct
-	case TMap, TSet, TList:
-		return v.tcoll
+		return v.GetStruct()
+	case TMap:
+		return v.GetMap()
+	case TSet, TList:
+		return v.GetList()
 	default:
 		panic(fmt.Sprintf("Unknown value type %v", v.typ))
 	}
@@ -75,80 +73,84 @@ func (v *Value) Get() interface{} {
 
 // NewValueBool constructs a new Value that contains a boolean.
 func NewValueBool(v bool) Value {
+	var n uint64 = 0
+	if v {
+		n = 1
+	}
 	return Value{
-		typ:   TBool,
-		tbool: v,
+		typ:     TBool,
+		tnumber: n,
 	}
 }
 
 // GetBool gets the Bool value from a Value.
 func (v *Value) GetBool() bool {
-	return v.tbool
+	return v.tnumber != 0
 }
 
 // NewValueI8 constructs a new Value that contains a byte
 func NewValueI8(v int8) Value {
 	return Value{
-		typ: TI8,
-		ti8: v,
+		typ:     TI8,
+		tnumber: uint64(v),
 	}
 }
 
 // GetI8 gets the I8 value from a Value.
 func (v *Value) GetI8() int8 {
-	return v.ti8
+	return int8(v.tnumber)
 }
 
 // NewValueDouble constructs a new Value that contains a double.
 func NewValueDouble(v float64) Value {
 	return Value{
 		typ:     TDouble,
-		tdouble: v,
+		tnumber: math.Float64bits(v),
 	}
 }
 
 // GetDouble gets the Double value from a Value.
 func (v *Value) GetDouble() float64 {
-	return v.tdouble
+	return math.Float64frombits(v.tnumber)
 }
 
 // NewValueI16 constructs a new Value that contains a 16-bit integer.
 func NewValueI16(v int16) Value {
 	return Value{
-		typ:  TI16,
-		ti16: v,
+		typ:     TI16,
+		tnumber: uint64(v),
 	}
 }
 
 // GetI16 gets the I16 value from a Value.
 func (v *Value) GetI16() int16 {
-	return v.ti16
+	return int16(v.tnumber)
 }
 
 // NewValueI32 constructs a new Value that contains a 32-bit integer.
 func NewValueI32(v int32) Value {
 	return Value{
-		typ:  TI32,
-		ti32: v,
+		typ:     TI32,
+		tnumber: uint64(v),
 	}
 }
 
 // GetI32 gets the I32 value from a Value.
 func (v *Value) GetI32() int32 {
-	return v.ti32
+	return int32(v.tnumber)
 }
 
 // NewValueI64 constructs a new Value that contains a 64-bit integer.
 func NewValueI64(v int64) Value {
 	return Value{
-		typ:  TI64,
-		ti64: v,
+		typ:     TI64,
+		tnumber: uint64(v),
 	}
 }
 
 // GetI64 gets the I64 value from a Value.
 func (v *Value) GetI64() int64 {
-	return v.ti64
+	return int64(v.tnumber)
 }
 
 // NewValueBinary constructs a new Value that contains a binary string.
@@ -232,17 +234,17 @@ func (v *Value) GetList() ValueList {
 func (v Value) String() string {
 	switch v.typ {
 	case TBool:
-		return fmt.Sprintf("TBool(%v)", v.tbool)
+		return fmt.Sprintf("TBool(%v)", v.GetBool())
 	case TI8:
-		return fmt.Sprintf("TI8(%v)", v.ti8)
+		return fmt.Sprintf("TI8(%v)", v.GetI8())
 	case TDouble:
-		return fmt.Sprintf("TDouble(%v)", v.tdouble)
+		return fmt.Sprintf("TDouble(%v)", v.GetDouble())
 	case TI16:
-		return fmt.Sprintf("TI16(%v)", v.ti16)
+		return fmt.Sprintf("TI16(%v)", v.GetI16())
 	case TI32:
-		return fmt.Sprintf("TI32(%v)", v.ti32)
+		return fmt.Sprintf("TI32(%v)", v.GetI32())
 	case TI64:
-		return fmt.Sprintf("TI64(%v)", v.ti64)
+		return fmt.Sprintf("TI64(%v)", v.GetI64())
 	case TBinary:
 		return fmt.Sprintf("TBinary(%v)", v.tbinary)
 	case TStruct:

--- a/wire/value.go
+++ b/wire/value.go
@@ -73,7 +73,7 @@ func (v *Value) Get() interface{} {
 
 // NewValueBool constructs a new Value that contains a boolean.
 func NewValueBool(v bool) Value {
-	var n uint64 = 0
+	n := uint64(0)
 	if v {
 		n = 1
 	}

--- a/wire/value_equals.go
+++ b/wire/value_equals.go
@@ -54,11 +54,11 @@ func ValuesAreEqual(left, right Value) bool {
 	case TStruct:
 		return StructsAreEqual(left.tstruct, right.tstruct)
 	case TMap:
-		return MapsAreEqual(left.tmap, right.tmap)
+		return MapsAreEqual(left.tcoll.(MapItemList), right.tcoll.(MapItemList))
 	case TSet:
-		return SetsAreEqual(left.tset, right.tset)
+		return SetsAreEqual(left.tcoll.(ValueList), right.tcoll.(ValueList))
 	case TList:
-		return ListsAreEqual(left.tlist, right.tlist)
+		return ListsAreEqual(left.tcoll.(ValueList), right.tcoll.(ValueList))
 	default:
 		return false
 	}

--- a/wire/value_equals.go
+++ b/wire/value_equals.go
@@ -38,17 +38,17 @@ func ValuesAreEqual(left, right Value) bool {
 
 	switch left.typ {
 	case TBool:
-		return left.tbool == right.tbool
+		return left.GetBool() == right.GetBool()
 	case TI8:
-		return left.ti8 == right.ti8
+		return left.GetI8() == right.GetI8()
 	case TDouble:
-		return left.tdouble == right.tdouble
+		return left.GetDouble() == right.GetDouble()
 	case TI16:
-		return left.ti16 == right.ti16
+		return left.GetI16() == right.GetI16()
 	case TI32:
-		return left.ti32 == right.ti32
+		return left.GetI32() == right.GetI32()
 	case TI64:
-		return left.ti64 == right.ti64
+		return left.GetI64() == right.GetI64()
 	case TBinary:
 		return bytes.Equal(left.tbinary, right.tbinary)
 	case TStruct:


### PR DESCRIPTION
This significantly decreases the size of Value objects by combining all lazy lists into one `interface{}`, and all numeric fields and boolean into one `uint64`.