### PR TITLE
yarpc: Rename {Request,Response} to {Req,Res}Meta

### DIFF
--- a/gen/yarpc.go
+++ b/gen/yarpc.go
@@ -151,7 +151,7 @@ func (yg yarpcGenerator) server(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 				var <$response> <$thrift>.Response
 				if err == nil {
 					<$response>.IsApplicationError = <$hadError>
-					<$response>.ResMeta = <$resMeta>
+					<$response>.Meta = <$resMeta>
 					<$response>.Body, err = <$result>.ToWire()
 				}
 				return <$response>, err


### PR DESCRIPTION
Related YARPC change: https://github.com/yarpc/yarpc-go/pull/177

@prashantv @breerly @kriskowal