### PR TITLE
enums: Don't generate const decl for empty enums

### DIFF
--- a/gen/enum.go
+++ b/gen/enum.go
@@ -65,11 +65,13 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		<$enumName := typeName .Spec>
 		type <$enumName> int32
 
-		const (
-		<range .Spec.Items>
-			<$enumName><goCase .Name> <$enumName> = <.Value>
+		<if .Spec.Items>
+			const (
+			<range .Spec.Items>
+				<$enumName><goCase .Name> <$enumName> = <.Value>
+			<end>
+			)
 		<end>
-		)
 
 		<$v := newVar "v">
 		func (<$v> <$enumName>) ToWire() (<$wire>.Value, error) {

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -10,8 +10,6 @@ import (
 
 type EmptyEnum int32
 
-const ()
-
 func (v EmptyEnum) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }


### PR DESCRIPTION
This fixes a `const ()` declaration being generated for empty enums.

@prashantv