### PR TITLE
yarpc: Use top-level {Req,Res}Meta* objects

### DIFF
--- a/gen/yarpc.go
+++ b/gen/yarpc.go
@@ -118,7 +118,7 @@ func (yg yarpcGenerator) server(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 			<$body := $vars.NewName "body">
 
 			func (h handler) <goCase .Name>(
-				<$reqMeta> <$yarpc>.ReqMetaIn,
+				<$reqMeta> <$yarpc>.ReqMeta,
 				<$body> <$wire>.Value,
 			) (<$thrift>.Response, error) {
 
@@ -297,7 +297,7 @@ func (yg yarpcGenerator) iface(s *compile.ServiceSpec, isServer bool) error {
 				<$params := newNamespace>
 				<goCase .Name>(
 					<if isServer>
-						<$params.NewName "reqMeta"> <$yarpc>.ReqMetaIn,
+						<$params.NewName "reqMeta"> <$yarpc>.ReqMeta,
 					<else>
 						<$params.NewName "reqMeta"> <$yarpc>.ReqMetaOut,
 					<end>
@@ -313,7 +313,7 @@ func (yg yarpcGenerator) iface(s *compile.ServiceSpec, isServer bool) error {
 						<typeReference .ResultSpec.ReturnType>,
 					<end>
 					<if isServer>
-						<$yarpc>.ResMetaOut,
+						<$yarpc>.ResMeta,
 					<else>
 						<$yarpc>.ResMetaIn,
 					<end>

--- a/gen/yarpc.go
+++ b/gen/yarpc.go
@@ -78,6 +78,7 @@ func (yg yarpcGenerator) server(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 
 	err := yg.g.DeclareFromTemplate(
 		`
+		<$yarpc := import "github.com/yarpc/yarpc-go">
 		<$thrift := import "github.com/yarpc/yarpc-go/encoding/thrift">
 		<$protocol := import "github.com/thriftrw/thriftrw-go/protocol">
 		<$wire := import "github.com/thriftrw/thriftrw-go/wire">
@@ -117,7 +118,7 @@ func (yg yarpcGenerator) server(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 			<$body := $vars.NewName "body">
 
 			func (h handler) <goCase .Name>(
-				<$reqMeta> *<$thrift>.ReqMeta,
+				<$reqMeta> <$yarpc>.ReqMetaIn,
 				<$body> <$wire>.Value,
 			) (<$thrift>.Response, error) {
 
@@ -180,6 +181,7 @@ func (yg yarpcGenerator) client(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 
 	err := yg.g.DeclareFromTemplate(
 		`
+		<$yarpc := import "github.com/yarpc/yarpc-go">
 		<$transport := import "github.com/yarpc/yarpc-go/transport">
 		<$thrift := import "github.com/yarpc/yarpc-go/encoding/thrift">
 		<$protocol := import "github.com/thriftrw/thriftrw-go/protocol">
@@ -206,7 +208,7 @@ func (yg yarpcGenerator) client(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 
 			<$vars := newNamespace>
 			func (c client) <goCase .Name>(
-				<$vars.NewName "reqMeta"> *<$thrift>.ReqMeta,
+				<$vars.NewName "reqMeta"> <$yarpc>.ReqMetaOut,
 				<range .ArgsSpec>
 					<if .Required>
 						<$vars.NewName .Name> <typeReference .Type>,
@@ -218,7 +220,7 @@ func (yg yarpcGenerator) client(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 				<if .ResultSpec.ReturnType>
 					<$vars.NewName "success"> <typeReference .ResultSpec.ReturnType>,
 				<end>
-				<$vars.NewName "resMeta"> *<$thrift>.ResMeta,
+				<$vars.NewName "resMeta"> <$yarpc>.ResMetaIn,
 				err error,
 			 ) {
 				<$reqMeta := $vars.Rotate "reqMeta">
@@ -279,6 +281,7 @@ func (yg yarpcGenerator) client(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 func (yg yarpcGenerator) iface(s *compile.ServiceSpec, isServer bool) error {
 	return yg.g.DeclareFromTemplate(
 		`
+		<$yarpc := import "github.com/yarpc/yarpc-go">
 		<$thrift := import "github.com/yarpc/yarpc-go/encoding/thrift">
 
 		type Interface interface {
@@ -293,7 +296,11 @@ func (yg yarpcGenerator) iface(s *compile.ServiceSpec, isServer bool) error {
 			<range .Functions>
 				<$params := newNamespace>
 				<goCase .Name>(
-					<$params.NewName "reqMeta"> *<$thrift>.ReqMeta,
+					<if isServer>
+						<$params.NewName "reqMeta"> <$yarpc>.ReqMetaIn,
+					<else>
+						<$params.NewName "reqMeta"> <$yarpc>.ReqMetaOut,
+					<end>
 					<range .ArgsSpec>
 						<if .Required>
 							<$params.NewName .Name> <typeReference .Type>,
@@ -305,7 +312,11 @@ func (yg yarpcGenerator) iface(s *compile.ServiceSpec, isServer bool) error {
 					<if .ResultSpec.ReturnType>
 						<typeReference .ResultSpec.ReturnType>,
 					<end>
-					*<$thrift>.ResMeta,
+					<if isServer>
+						<$yarpc>.ResMetaOut,
+					<else>
+						<$yarpc>.ResMetaIn,
+					<end>
 					 error,
 				 )
 			<end>

--- a/gen/yarpc.go
+++ b/gen/yarpc.go
@@ -208,7 +208,7 @@ func (yg yarpcGenerator) client(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 
 			<$vars := newNamespace>
 			func (c client) <goCase .Name>(
-				<$vars.NewName "reqMeta"> <$yarpc>.ReqMetaOut,
+				<$vars.NewName "reqMeta"> <$yarpc>.CallReqMeta,
 				<range .ArgsSpec>
 					<if .Required>
 						<$vars.NewName .Name> <typeReference .Type>,
@@ -220,7 +220,7 @@ func (yg yarpcGenerator) client(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 				<if .ResultSpec.ReturnType>
 					<$vars.NewName "success"> <typeReference .ResultSpec.ReturnType>,
 				<end>
-				<$vars.NewName "resMeta"> <$yarpc>.ResMetaIn,
+				<$vars.NewName "resMeta"> <$yarpc>.CallResMeta,
 				err error,
 			 ) {
 				<$reqMeta := $vars.Rotate "reqMeta">
@@ -299,7 +299,7 @@ func (yg yarpcGenerator) iface(s *compile.ServiceSpec, isServer bool) error {
 					<if isServer>
 						<$params.NewName "reqMeta"> <$yarpc>.ReqMeta,
 					<else>
-						<$params.NewName "reqMeta"> <$yarpc>.ReqMetaOut,
+						<$params.NewName "reqMeta"> <$yarpc>.CallReqMeta,
 					<end>
 					<range .ArgsSpec>
 						<if .Required>
@@ -315,7 +315,7 @@ func (yg yarpcGenerator) iface(s *compile.ServiceSpec, isServer bool) error {
 					<if isServer>
 						<$yarpc>.ResMeta,
 					<else>
-						<$yarpc>.ResMetaIn,
+						<$yarpc>.CallResMeta,
 					<end>
 					 error,
 				 )


### PR DESCRIPTION
This is the code generation change for https://github.com/yarpc/yarpc-go/pull/230