### PR TITLE
internal: Implement concurrent.Range

### DIFF
--- a/internal/concurrent/range.go
+++ b/internal/concurrent/range.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package concurrent
+
+import (
+	"log"
+	"reflect"
+	"sync"
+
+	"github.com/thriftrw/thriftrw-go/internal"
+)
+
+var (
+	_typeOfError = reflect.TypeOf((*error)(nil)).Elem()
+	_typeOfInt   = reflect.TypeOf(int(0))
+)
+
+// Range calls the function f on all items in c concurrently and waits for all
+// calls to finish.
+//
+// c may be a slice or a map. If c is a map, f must accept the key and the value
+// as its arguments, and otherwise it must accept an int index and the value as
+// its arguments.
+//
+// f may return nothing or error.
+func Range(c, f interface{}) error {
+	if c == nil || f == nil {
+		log.Panicf("ConcurrentRange(%T, %T): both arguments must be non-nil", c, f)
+	}
+
+	cv := reflect.ValueOf(c)
+	fv := reflect.ValueOf(f)
+	ct := cv.Type()
+	ft := fv.Type()
+
+	if ft.NumIn() != 2 {
+		log.Panicf("ConcurrentRange(%T, %T): f must accept exactly two arguments", c, f)
+	}
+
+	switch ft.NumOut() {
+	case 0:
+		// adapt into a function that always returns a nil error
+		fv = alwaysReturnNoError(fv)
+		ft = fv.Type()
+	case 1:
+		if ft.Out(0) != _typeOfError {
+			log.Panicf("ConcurrentRange(%T, %T): f may only return error or nothing", c, f)
+		}
+	case 2:
+		log.Panicf("ConcurrentRange(%T, %T): f may only return error or nothing", c, f)
+	}
+
+	var (
+		wg     sync.WaitGroup
+		lock   sync.Mutex
+		errors []error
+	)
+
+	switch ct.Kind() {
+	case reflect.Map:
+		if ft.In(0) != ct.Key() {
+			log.Panicf("ConcurrentRange(%T, %T): f's first argument must be a %v", c, f, ct.Key())
+		}
+
+		if ft.In(1) != ct.Elem() {
+			log.Panicf("ConcurrentRange(%T, %T): f's second argument must be a %v", c, f, ct.Elem())
+		}
+
+		for _, key := range cv.MapKeys() {
+			value := cv.MapIndex(key)
+			wg.Add(1)
+			go func(key, value reflect.Value) {
+				defer wg.Done()
+				err, ok := fv.Call([]reflect.Value{key, value})[0].Interface().(error)
+				if ok && err != nil {
+					lock.Lock()
+					errors = append(errors, err)
+					lock.Unlock()
+				}
+			}(key, value)
+		}
+
+	case reflect.Slice:
+		if ft.In(0) != _typeOfInt {
+			log.Panicf("ConcurrentRange(%T, %T): f's first argument must be an int", c, f)
+		}
+
+		if ft.In(1) != ct.Elem() {
+			log.Panicf("ConcurrentRange(%T, %T): f's second argument must be a %v", c, f, ct.Elem())
+		}
+
+		for i := 0; i < cv.Len(); i++ {
+			value := cv.Index(i)
+			wg.Add(1)
+			go func(key, value reflect.Value) {
+				defer wg.Done()
+				err, ok := fv.Call([]reflect.Value{key, value})[0].Interface().(error)
+				if ok && err != nil {
+					lock.Lock()
+					errors = append(errors, err)
+					lock.Unlock()
+				}
+			}(reflect.ValueOf(i), value)
+		}
+
+	default:
+		log.Panicf("ConcurrentRange(%T, %T): called with a type that is not a slice or a map", c, f)
+	}
+
+	wg.Wait()
+	return internal.MultiError(errors)
+}
+
+func alwaysReturnNoError(f reflect.Value) reflect.Value {
+	var (
+		ft       = f.Type()
+		in       []reflect.Type
+		variadic = ft.IsVariadic()
+	)
+
+	for i := 0; i < ft.NumIn(); i++ {
+		in = append(in, ft.In(i))
+	}
+
+	newFt := reflect.FuncOf(in, []reflect.Type{_typeOfError}, variadic)
+	return reflect.MakeFunc(newFt, func(args []reflect.Value) []reflect.Value {
+		f.Call(args)
+		return []reflect.Value{reflect.Zero(_typeOfError)}
+	})
+}

--- a/internal/concurrent/range_test.go
+++ b/internal/concurrent/range_test.go
@@ -1,0 +1,205 @@
+package concurrent
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRangeInvalid(t *testing.T) {
+	tests := []struct {
+		desc string
+		c    interface{}
+		f    interface{}
+	}{
+		{
+			desc: "nil values",
+		},
+		{
+			desc: "c: string",
+			c:    "foo",
+			f:    func(int, string) {},
+		},
+		{
+			desc: "f: 0 args",
+			c:    []int{1, 2, 3},
+			f:    func() {},
+		},
+		{
+			desc: "f: 1 args",
+			c:    []int{1, 2, 3},
+			f:    func(int) {},
+		},
+		{
+			desc: "f: 3 args",
+			c:    []int{1, 2, 3},
+			f:    func(int, int, int) {},
+		},
+		{
+			desc: "f: 2 returns",
+			c:    []int{1, 2, 3},
+			f:    func(int, int) (string, error) { return "", nil },
+		},
+		{
+			desc: "f: return non-error",
+			c:    []int{1, 2},
+			f:    func(int, int) string { return "" },
+		},
+		{
+			desc: "f: slice: arg 1 type mismatch",
+			c:    []string{},
+			f:    func(string, int) {},
+		},
+		{
+			desc: "f: slice: arg 2 type mismatch",
+			c:    []string{},
+			f:    func(int, int) {},
+		},
+		{
+			desc: "f: map: arg 1 type mismatch",
+			c:    map[string]int{},
+			f:    func(int, int) {},
+		},
+		{
+			desc: "f: map: arg 2 type mismatch",
+			c:    map[string]int{},
+			f:    func(string, string) {},
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Panics(t, func() {
+			Range(tt.c, tt.f)
+		}, tt.desc)
+	}
+}
+
+func TestRangeSlice(t *testing.T) {
+	tests := []struct {
+		desc string
+		c    interface{}
+		f    interface{}
+
+		shouldFail bool
+	}{
+		{
+			desc: "slice: empty",
+			c:    []string{},
+			f: func(int, string) {
+				t.Errorf("unexpected call to function for empty collection")
+			},
+		},
+		{
+			desc: "slice: no return",
+			c:    []int32{1, 2, 3},
+			f: func(i int, v int32) {
+				switch i {
+				case 0:
+					assert.EqualValues(t, 1, v)
+				case 1:
+					assert.EqualValues(t, 2, v)
+				case 2:
+					assert.EqualValues(t, 3, v)
+				}
+			},
+		},
+		{
+			desc: "slice: fail all",
+			c:    []int32{1, 2, 3},
+			f: func(i int, v int32) error {
+				switch i {
+				case 0:
+					assert.EqualValues(t, 1, v)
+				case 1:
+					assert.EqualValues(t, 2, v)
+				case 2:
+					assert.EqualValues(t, 3, v)
+				}
+				return errors.New("foo")
+			},
+			shouldFail: true,
+		},
+		{
+			desc: "slice: fail one",
+			c:    []string{"hello", "world"},
+			f: func(i int, v string) error {
+				switch i {
+				case 0:
+					assert.Equal(t, "hello", v)
+				case 1:
+					assert.Equal(t, "world", v)
+					return errors.New("foo")
+				}
+				return nil
+			},
+			shouldFail: true,
+		},
+		{
+			desc: "map: empty",
+			c:    map[string]int{},
+			f: func(string, int) {
+				t.Errorf("unexpected call to function for empty collection")
+			},
+		},
+		{
+			desc: "map: no return",
+			c: map[string]int{
+				"hello": 1,
+				"world": 2,
+			},
+			f: func(k string, v int) {
+				switch k {
+				case "hello":
+					assert.Equal(t, v, 1)
+				case "world":
+					assert.Equal(t, v, 2)
+				}
+			},
+		},
+		{
+			desc: "map: fail all",
+			c: map[string]int{
+				"hello": 1,
+				"world": 2,
+			},
+			f: func(k string, v int) error {
+				switch k {
+				case "hello":
+					assert.Equal(t, v, 1)
+				case "world":
+					assert.Equal(t, v, 2)
+				}
+				return errors.New("great sadness")
+			},
+			shouldFail: true,
+		},
+		{
+			desc: "map: fail one",
+			c: map[string]int{
+				"hello": 1,
+				"world": 2,
+			},
+			f: func(k string, v int) error {
+				switch k {
+				case "hello":
+					assert.Equal(t, v, 1)
+				case "world":
+					assert.Equal(t, v, 2)
+					return errors.New("great sadness")
+				}
+				return nil
+			},
+			shouldFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		err := Range(tt.c, tt.f)
+		if tt.shouldFail {
+			assert.Error(t, err, tt.desc)
+		} else {
+			assert.NoError(t, err, tt.desc)
+		}
+	}
+}


### PR DESCRIPTION
This uses reflection to abstract away the common pattern where you need to run
a function concurrently on all elements on a list and wait for them all to
finish, any of the operations optionally failing with an error.

The following,

```go
err := concurrent.Range(xs, func(x ..) error {
    // do stuff with x
    return err
})
```

Is equivalent to,

```go
var (
    wg sync.WaitGroup
    lock sync.Mutex
    errors []error
)

for _, x := range xs {
    wg.Add(1)
    go func(x ...) {
        defer wg.Done()
        err := // do stuff with x
        if err != nil {
            lock.Lock()
            errors = append(errors, err)
            lock.Unlock()
        }
    }(x)
}

wg.Wait()
err = MultiError(errors)
```

CC @breerly @kriskowal @prashantv