### PR TITLE
internal: Add multiplex.{Client,Handler}

### DIFF
--- a/internal/multiplex/client.go
+++ b/internal/multiplex/client.go
@@ -1,0 +1,24 @@
+package multiplex
+
+import (
+	"github.com/thriftrw/thriftrw-go/internal/envelope"
+	"github.com/thriftrw/thriftrw-go/wire"
+)
+
+// NewClient builds a new multiplexing client.
+//
+// name is the name of the service for which requests are being sent through
+// this client.
+func NewClient(name string, c envelope.Client) envelope.Client {
+	return client{name: name, c: c}
+}
+
+// client is a multiplexing client.
+type client struct {
+	c    envelope.Client
+	name string
+}
+
+func (c client) Send(name string, reqValue wire.Value) (wire.Value, error) {
+	return c.c.Send(c.name+":"+name, reqValue)
+}

--- a/internal/multiplex/client_test.go
+++ b/internal/multiplex/client_test.go
@@ -1,0 +1,24 @@
+package multiplex
+
+import (
+	"testing"
+
+	"github.com/thriftrw/thriftrw-go/internal/envelope/envelopetest"
+	"github.com/thriftrw/thriftrw-go/wire"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockClient := envelopetest.NewMockClient(mockCtrl)
+	mockClient.EXPECT().Send("Foo:hello", wire.NewValueStruct(wire.Struct{})).
+		Return(wire.NewValueStruct(wire.Struct{}), nil)
+
+	client := NewClient("Foo", mockClient)
+	_, err := client.Send("hello", wire.NewValueStruct(wire.Struct{}))
+	assert.NoError(t, err)
+}

--- a/internal/multiplex/handler.go
+++ b/internal/multiplex/handler.go
@@ -1,0 +1,40 @@
+package multiplex
+
+import (
+	"strings"
+
+	"github.com/thriftrw/thriftrw-go/internal/envelope"
+	"github.com/thriftrw/thriftrw-go/wire"
+)
+
+// Handler implements a service multiplexer
+type Handler struct {
+	services map[string]envelope.Handler
+}
+
+// NewHandler builds a new handler.
+func NewHandler() Handler {
+	return Handler{services: make(map[string]envelope.Handler)}
+}
+
+// Put adds the given service to the multiplexer.
+func (h Handler) Put(name string, service envelope.Handler) {
+	h.services[name] = service
+}
+
+// Handle handles the given request, dispatching to one of the
+// registered services.
+func (h Handler) Handle(name string, req wire.Value) (wire.Value, error) {
+	parts := strings.SplitN(name, ":", 2)
+	if len(parts) < 2 {
+		return wire.Value{}, envelope.ErrUnknownMethod(name)
+	}
+
+	service, ok := h.services[parts[0]]
+	if !ok {
+		return wire.Value{}, envelope.ErrUnknownMethod(name)
+	}
+
+	name = parts[1]
+	return service.Handle(name, req)
+}

--- a/internal/multiplex/handler_test.go
+++ b/internal/multiplex/handler_test.go
@@ -1,0 +1,64 @@
+package multiplex
+
+import (
+	"testing"
+
+	"github.com/thriftrw/thriftrw-go/internal/envelope"
+	"github.com/thriftrw/thriftrw-go/internal/envelope/envelopetest"
+	"github.com/thriftrw/thriftrw-go/wire"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandlerErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		expect    func(meta, kv *envelopetest.MockHandler)
+		wantError error
+	}{
+		{
+			name: "Meta:health",
+			expect: func(meta, kv *envelopetest.MockHandler) {
+				meta.EXPECT().Handle("health", gomock.Any()).
+					Return(wire.NewValueStruct(wire.Struct{}), nil)
+			},
+		},
+		{
+			name: "KeyValue:setValue",
+			expect: func(meta, kv *envelopetest.MockHandler) {
+				kv.EXPECT().Handle("setValue", gomock.Any()).
+					Return(wire.NewValueStruct(wire.Struct{}), nil)
+			},
+		},
+		{
+			name:      "keyValue:setValue",
+			wantError: envelope.ErrUnknownMethod("keyValue:setValue"),
+		},
+		{
+			name:      "setValue",
+			wantError: envelope.ErrUnknownMethod("setValue"),
+		},
+	}
+
+	for _, tt := range tests {
+		func() {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			meta := envelopetest.NewMockHandler(mockCtrl)
+			kv := envelopetest.NewMockHandler(mockCtrl)
+
+			handler := NewHandler()
+			handler.Put("Meta", meta)
+			handler.Put("KeyValue", kv)
+
+			if tt.expect != nil {
+				tt.expect(meta, kv)
+			}
+
+			_, err := handler.Handle(tt.name, wire.NewValueStruct(wire.Struct{}))
+			assert.Equal(t, tt.wantError, err)
+		}()
+	}
+}


### PR DESCRIPTION
This provides, `multiplex.{Client, Handler}` which are
`TMultiplexedProtocol`-compatible versions of the `envelope.{Client, Handler}`
interfaces from #180.

----

Depends on #180. This PR will be rebased on master when that lands. Individual
commits are separately reviewable.

@breerly @prashantv @kriskowal 