### PR TITLE
gen/containers: Gracefully handle nil items

### DIFF
--- a/gen/list.go
+++ b/gen/list.go
@@ -52,14 +52,23 @@ func (l *listGenerator) ValueList(g Generator, spec *compile.ListSpec) (string, 
 			<$wire := import "github.com/thriftrw/thriftrw-go/wire">
 			type <.Name> <typeReference .Spec>
 
+			<$i := newVar "i">
 			<$v := newVar "v">
 			<$x := newVar "x">
 			<$f := newVar "f">
 			<$w := newVar "w">
 			func (<$v> <.Name>) ForEach(<$f> func(<$wire>.Value) error) error {
+				<if isPrimitiveType .Spec.ValueSpec>
 				for _, <$x> := range <$v> {
+				<else>
+				for <$i>, <$x> := range <$v> {
+					if <$x> == nil {
+						return <import "fmt">.Errorf("invalid [%v]: value is nil", <$i>)
+					}
+				<end>
 					<$w>, err := <toWire .Spec.ValueSpec $x>
 					if err != nil {
+						// TODO(abg): nested error "invalid [%v]: %v"
 						return err
 					}
 					err = <$f>(<$w>)

--- a/gen/map.go
+++ b/gen/map.go
@@ -72,12 +72,27 @@ func (m *mapGenerator) ItemList(g Generator, spec *compile.MapSpec) (string, err
 						<$k> := <$i>.Key
 						<$v> := <$i>.Value
 				<end>
+						<if not (isPrimitiveType .Spec.KeySpec)>
+							if <$k> == nil {
+								return <import "fmt">.Errorf("invalid map key: value is nil")
+							}
+						<end>
+
+						<if not (isPrimitiveType .Spec.ValueSpec)>
+							if <$v> == nil {
+								return <import "fmt">.Errorf("invalid [%v]: value is nil", <$k>)
+							}
+						<end>
+
 						<$kw>, err := <toWire .Spec.KeySpec $k>
 						if err != nil {
+							// TODO(abg): nested error "invalid map key: %v"
 							return err
 						}
+
 						<$vw>, err := <toWire .Spec.ValueSpec $v>
 						if err != nil {
+							// TODO(abg): nested error "invalid [%v]: %v"
 							return err
 						}
 						err = <$f>(<$wire>.MapItem{Key: <$kw>, Value: <$vw>})

--- a/gen/set.go
+++ b/gen/set.go
@@ -63,8 +63,15 @@ func (s *setGenerator) ValueList(g Generator, spec *compile.SetSpec) (string, er
 				<else>
 					for _, <$x> := range <$v> {
 				<end>
+						<if not (isPrimitiveType .Spec.ValueSpec)>
+							if <$x> == nil {
+								return <import "fmt">.Errorf("invalid set item: value is nil")
+							}
+						<end>
+
 						<$w>, err := <toWire .Spec.ValueSpec $x>
 						if err != nil {
+							// TODO(abg): nested error "invalid set item: %v"
 							return err
 						}
 						err = <$f>(<$w>)

--- a/gen/testdata/containers/types.go
+++ b/gen/testdata/containers/types.go
@@ -62,7 +62,10 @@ func (_List_I32_ValueList) Close() {
 type _List_List_I32_ValueList [][]int32
 
 func (v _List_List_I32_ValueList) ForEach(f func(wire.Value) error) error {
-	for _, x := range v {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
 		w, err := wire.NewValueList(_List_I32_ValueList(x)), error(nil)
 		if err != nil {
 			return err
@@ -116,7 +119,10 @@ func (_Set_I32_ValueList) Close() {
 type _List_Set_I32_ValueList []map[int32]struct{}
 
 func (v _List_Set_I32_ValueList) ForEach(f func(wire.Value) error) error {
-	for _, x := range v {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
 		w, err := wire.NewValueSet(_Set_I32_ValueList(x)), error(nil)
 		if err != nil {
 			return err
@@ -178,7 +184,10 @@ func (_Map_I32_I32_MapItemList) Close() {
 type _List_Map_I32_I32_ValueList []map[int32]int32
 
 func (v _List_Map_I32_I32_ValueList) ForEach(f func(wire.Value) error) error {
-	for _, x := range v {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
 		w, err := wire.NewValueMap(_Map_I32_I32_MapItemList(x)), error(nil)
 		if err != nil {
 			return err
@@ -233,6 +242,9 @@ type _Set_Set_String_ValueList []map[string]struct{}
 
 func (v _Set_Set_String_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid set item: value is nil")
+		}
 		w, err := wire.NewValueSet(_Set_String_ValueList(x)), error(nil)
 		if err != nil {
 			return err
@@ -287,6 +299,9 @@ type _Set_List_String_ValueList [][]string
 
 func (v _Set_List_String_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid set item: value is nil")
+		}
 		w, err := wire.NewValueList(_List_String_ValueList(x)), error(nil)
 		if err != nil {
 			return err
@@ -349,6 +364,9 @@ type _Set_Map_String_String_ValueList []map[string]string
 
 func (v _Set_Map_String_String_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid set item: value is nil")
+		}
 		w, err := wire.NewValueMap(_Map_String_String_MapItemList(x)), error(nil)
 		if err != nil {
 			return err
@@ -416,6 +434,9 @@ func (m _Map_Map_String_I32_I64_MapItemList) ForEach(f func(wire.MapItem) error)
 	for _, i := range m {
 		k := i.Key
 		v := i.Value
+		if k == nil {
+			return fmt.Errorf("invalid map key: value is nil")
+		}
 		kw, err := wire.NewValueMap(_Map_String_I32_MapItemList(k)), error(nil)
 		if err != nil {
 			return err
@@ -483,6 +504,12 @@ func (m _Map_List_I32_Set_I64_MapItemList) ForEach(f func(wire.MapItem) error) e
 	for _, i := range m {
 		k := i.Key
 		v := i.Value
+		if k == nil {
+			return fmt.Errorf("invalid map key: value is nil")
+		}
+		if v == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", k)
+		}
 		kw, err := wire.NewValueList(_List_I32_ValueList(k)), error(nil)
 		if err != nil {
 			return err
@@ -550,6 +577,12 @@ func (m _Map_Set_I32_List_Double_MapItemList) ForEach(f func(wire.MapItem) error
 	for _, i := range m {
 		k := i.Key
 		v := i.Value
+		if k == nil {
+			return fmt.Errorf("invalid map key: value is nil")
+		}
+		if v == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", k)
+		}
 		kw, err := wire.NewValueSet(_Set_I32_ValueList(k)), error(nil)
 		if err != nil {
 			return err
@@ -1405,6 +1438,215 @@ func (v *EnumContainers) String() string {
 	return fmt.Sprintf("EnumContainers{%v}", strings.Join(fields[:i], ", "))
 }
 
+type MapOfBinaryAndString struct {
+	BinaryToString []struct {
+		Key   []byte
+		Value string
+	} `json:"binaryToString"`
+	StringToBinary map[string][]byte `json:"stringToBinary"`
+}
+
+type _Map_Binary_String_MapItemList []struct {
+	Key   []byte
+	Value string
+}
+
+func (m _Map_Binary_String_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for _, i := range m {
+		k := i.Key
+		v := i.Value
+		if k == nil {
+			return fmt.Errorf("invalid map key: value is nil")
+		}
+		kw, err := wire.NewValueBinary(k), error(nil)
+		if err != nil {
+			return err
+		}
+		vw, err := wire.NewValueString(v), error(nil)
+		if err != nil {
+			return err
+		}
+		err = f(wire.MapItem{Key: kw, Value: vw})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_Binary_String_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_Binary_String_MapItemList) KeyType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_Binary_String_MapItemList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_Binary_String_MapItemList) Close() {
+}
+
+type _Map_String_Binary_MapItemList map[string][]byte
+
+func (m _Map_String_Binary_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for k, v := range m {
+		if v == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", k)
+		}
+		kw, err := wire.NewValueString(k), error(nil)
+		if err != nil {
+			return err
+		}
+		vw, err := wire.NewValueBinary(v), error(nil)
+		if err != nil {
+			return err
+		}
+		err = f(wire.MapItem{Key: kw, Value: vw})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_String_Binary_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_String_Binary_MapItemList) KeyType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_Binary_MapItemList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_Binary_MapItemList) Close() {
+}
+
+func (v *MapOfBinaryAndString) ToWire() (wire.Value, error) {
+	var (
+		fields [2]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+	if v.BinaryToString != nil {
+		w, err = wire.NewValueMap(_Map_Binary_String_MapItemList(v.BinaryToString)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 1, Value: w}
+		i++
+	}
+	if v.StringToBinary != nil {
+		w, err = wire.NewValueMap(_Map_String_Binary_MapItemList(v.StringToBinary)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 2, Value: w}
+		i++
+	}
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _Map_Binary_String_Read(m wire.MapItemList) ([]struct {
+	Key   []byte
+	Value string
+}, error) {
+	if m.KeyType() != wire.TBinary {
+		return nil, nil
+	}
+	if m.ValueType() != wire.TBinary {
+		return nil, nil
+	}
+	o := make([]struct {
+		Key   []byte
+		Value string
+	}, 0, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
+		k, err := x.Key.GetBinary(), error(nil)
+		if err != nil {
+			return err
+		}
+		v, err := x.Value.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+		o = append(o, struct {
+			Key   []byte
+			Value string
+		}{k, v})
+		return nil
+	})
+	m.Close()
+	return o, err
+}
+
+func _Map_String_Binary_Read(m wire.MapItemList) (map[string][]byte, error) {
+	if m.KeyType() != wire.TBinary {
+		return nil, nil
+	}
+	if m.ValueType() != wire.TBinary {
+		return nil, nil
+	}
+	o := make(map[string][]byte, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
+		k, err := x.Key.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+		v, err := x.Value.GetBinary(), error(nil)
+		if err != nil {
+			return err
+		}
+		o[k] = v
+		return nil
+	})
+	m.Close()
+	return o, err
+}
+
+func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
+	var err error
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 1:
+			if field.Value.Type() == wire.TMap {
+				v.BinaryToString, err = _Map_Binary_String_Read(field.Value.GetMap())
+				if err != nil {
+					return err
+				}
+			}
+		case 2:
+			if field.Value.Type() == wire.TMap {
+				v.StringToBinary, err = _Map_String_Binary_Read(field.Value.GetMap())
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (v *MapOfBinaryAndString) String() string {
+	var fields [2]string
+	i := 0
+	if v.BinaryToString != nil {
+		fields[i] = fmt.Sprintf("BinaryToString: %v", v.BinaryToString)
+		i++
+	}
+	if v.StringToBinary != nil {
+		fields[i] = fmt.Sprintf("StringToBinary: %v", v.StringToBinary)
+		i++
+	}
+	return fmt.Sprintf("MapOfBinaryAndString{%v}", strings.Join(fields[:i], ", "))
+}
+
 type PrimitiveContainers struct {
 	ListOfBinary      [][]byte            `json:"listOfBinary"`
 	ListOfInts        []int64             `json:"listOfInts"`
@@ -1417,7 +1659,10 @@ type PrimitiveContainers struct {
 type _List_Binary_ValueList [][]byte
 
 func (v _List_Binary_ValueList) ForEach(f func(wire.Value) error) error {
-	for _, x := range v {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
 		w, err := wire.NewValueBinary(x), error(nil)
 		if err != nil {
 			return err

--- a/gen/testdata/services/service/keyvalue/getmanyvalues.go
+++ b/gen/testdata/services/service/keyvalue/getmanyvalues.go
@@ -121,7 +121,10 @@ type GetManyValuesResult struct {
 type _List_ArbitraryValue_ValueList []*unions.ArbitraryValue
 
 func (v _List_ArbitraryValue_ValueList) ForEach(f func(wire.Value) error) error {
-	for _, x := range v {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
 		w, err := x.ToWire()
 		if err != nil {
 			return err

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -613,7 +613,10 @@ type Graph struct {
 type _List_Edge_ValueList []*Edge
 
 func (v _List_Edge_ValueList) ForEach(f func(wire.Value) error) error {
-	for _, x := range v {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
 		w, err := x.ToWire()
 		if err != nil {
 			return err

--- a/gen/testdata/thrift/containers.thrift
+++ b/gen/testdata/thrift/containers.thrift
@@ -34,3 +34,8 @@ struct ContainersOfContainers {
     8: optional map<list<i32>, set<i64>> mapOfListToSet;
     9: optional map<set<i32>, list<double>> mapOfSetToListOfDouble;
 }
+
+struct MapOfBinaryAndString {
+    1: optional map<binary, string> binaryToString;
+    2: optional map<string, binary> stringToBinary;
+}

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -16,6 +16,9 @@ type _Set_Binary_ValueList [][]byte
 
 func (v _Set_Binary_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid set item: value is nil")
+		}
 		w, err := wire.NewValueBinary(x), error(nil)
 		if err != nil {
 			return err
@@ -83,6 +86,12 @@ func (m _Map_Edge_Edge_MapItemList) ForEach(f func(wire.MapItem) error) error {
 	for _, i := range m {
 		k := i.Key
 		v := i.Value
+		if k == nil {
+			return fmt.Errorf("invalid map key: value is nil")
+		}
+		if v == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", k)
+		}
 		kw, err := k.ToWire()
 		if err != nil {
 			return err
@@ -269,7 +278,10 @@ func (v *Event) String() string {
 type _List_Event_ValueList []*Event
 
 func (v _List_Event_ValueList) ForEach(f func(wire.Value) error) error {
-	for _, x := range v {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
 		w, err := x.ToWire()
 		if err != nil {
 			return err
@@ -338,6 +350,9 @@ type _Set_Frame_ValueList []*structs.Frame
 
 func (v _Set_Frame_ValueList) ForEach(f func(wire.Value) error) error {
 	for _, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid set item: value is nil")
+		}
 		w, err := x.ToWire()
 		if err != nil {
 			return err
@@ -453,6 +468,12 @@ func (m _Map_Point_Point_MapItemList) ForEach(f func(wire.MapItem) error) error 
 	for _, i := range m {
 		k := i.Key
 		v := i.Value
+		if k == nil {
+			return fmt.Errorf("invalid map key: value is nil")
+		}
+		if v == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", k)
+		}
 		kw, err := k.ToWire()
 		if err != nil {
 			return err

--- a/gen/testdata/unions/types.go
+++ b/gen/testdata/unions/types.go
@@ -21,7 +21,10 @@ type ArbitraryValue struct {
 type _List_ArbitraryValue_ValueList []*ArbitraryValue
 
 func (v _List_ArbitraryValue_ValueList) ForEach(f func(wire.Value) error) error {
-	for _, x := range v {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
 		w, err := x.ToWire()
 		if err != nil {
 			return err
@@ -49,6 +52,9 @@ type _Map_String_ArbitraryValue_MapItemList map[string]*ArbitraryValue
 
 func (m _Map_String_ArbitraryValue_MapItemList) ForEach(f func(wire.MapItem) error) error {
 	for k, v := range m {
+		if v == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", k)
+		}
 		kw, err := wire.NewValueString(k), error(nil)
 		if err != nil {
 			return err

--- a/wire/value.go
+++ b/wire/value.go
@@ -26,6 +26,10 @@ import (
 	"strings"
 )
 
+// An empty []byte with zero length and capacity. We'll use this rather than
+// allocating new byte slices for empty []byte.
+var _emptyByteSlice = make([]byte, 0, 0)
+
 // Value holds the over-the-wire representation of a Thrift value.
 //
 // The Type of the value determines which field in the Value is valid.
@@ -155,6 +159,9 @@ func (v *Value) GetI64() int64 {
 
 // NewValueBinary constructs a new Value that contains a binary string.
 func NewValueBinary(v []byte) Value {
+	if v == nil {
+		v = _emptyByteSlice
+	}
 	return Value{
 		typ:     TBinary,
 		tbinary: v,


### PR DESCRIPTION
It's incorrect to pass nil as an item in a list, set or map (whether as a key
or as a value). Thrift does not support nil values inside containers.

Previously, we would simply panic if a user tried to do this. (The system
would call `ToWire` on the nill value and panic.) With this change, we instead
send an error back to the user indicating that nil values are not allowed.

@prashantv @breerly @kriskowal