### PR TITLE
plugin: Add templating system

### DIFF
--- a/gen/namespace.go
+++ b/gen/namespace.go
@@ -20,7 +20,11 @@
 
 package gen
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/thriftrw/thriftrw-go/internal/goast"
+)
 
 // Namespace allows finding names that don't conflict with other names in
 // certain scopes.
@@ -81,7 +85,7 @@ func (n *namespace) isTaken(name string) bool {
 	if n.parent != nil {
 		return n.parent.isTaken(name)
 	}
-	return isReservedKeyword(name)
+	return goast.IsReservedKeyword(name)
 }
 
 func (n *namespace) NewName(base string) string {

--- a/glide.lock
+++ b/glide.lock
@@ -13,4 +13,8 @@ imports:
   version: d77da356e56a7428ad25149ca77381849a6a5232
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
+- name: golang.org/x/tools
+  version: 8ea9d4606980305f7f46cabde046adbb530e71c8
+  subpackages:
+  - go/ast/astutil
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,3 +7,6 @@ import:
   - gomock
 - package: github.com/kr/pretty
 - package: github.com/kr/text
+- package: golang.org/x/tools
+  subpackages:
+  - go/ast/astutil

--- a/internal/goast/package.go
+++ b/internal/goast/package.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goast
+
+import (
+	"go/build"
+	"path/filepath"
+)
+
+// DeterminePackageName determines the name of the package at the given import
+// path.
+func DeterminePackageName(importPath string) string {
+	// TODO(abg): This can be a lot faster by using build.FindOnly and parsing one
+	// of the .go files in the directory with parser.PackageClauseOnly set. See
+	// how goimports does this:
+	// https://github.com/golang/tools/blob/0e9f43fcb67267967af8c15d7dc54b373e341d20/imports/fix.go#L284
+
+	pkg, err := build.Import(importPath, "", 0)
+	if err != nil {
+		return filepath.Base(importPath)
+	}
+	return pkg.Name
+}

--- a/internal/goast/reserved.go
+++ b/internal/goast/reserved.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package gen
+package goast
 
 var _reservedNames = make(map[string]struct{})
 
@@ -36,8 +36,8 @@ func init() {
 	}
 }
 
-// isReservedKeyword returns true if the given word is a reserved keyword.
-func isReservedKeyword(n string) bool {
+// IsReservedKeyword returns true if the given word is a reserved keyword.
+func IsReservedKeyword(n string) bool {
 	_, ok := _reservedNames[n]
 	return ok
 }

--- a/plugin/template.go
+++ b/plugin/template.go
@@ -52,7 +52,7 @@ type TemplateOption struct {
 // 	)
 func TemplateFunc(name string, f interface{}) TemplateOption {
 	return TemplateOption{apply: func(t *goFileGenerator) {
-		t.funcs[name] = f
+		t.templateFuncs[name] = f
 	}}
 }
 
@@ -76,8 +76,8 @@ func GoFileImportPath(path string) TemplateOption {
 
 // goFileGenerator generates a single Go file.
 type goFileGenerator struct {
-	importPath string
-	funcs      map[string]interface{}
+	importPath    string
+	templateFuncs template.FuncMap
 
 	// Names of known globals. All global variables share this namespace.
 	globals map[string]struct{}
@@ -91,7 +91,7 @@ type goFileGenerator struct {
 
 func newGoFileGenerator(opts []TemplateOption) *goFileGenerator {
 	t := goFileGenerator{
-		funcs:         make(map[string]interface{}),
+		templateFuncs: make(template.FuncMap),
 		globals:       make(map[string]struct{}),
 		imports:       make(map[string]string),
 		importedNames: make(map[string]string),
@@ -207,7 +207,7 @@ func (g *goFileGenerator) Generate(filename, tmpl string, data interface{}) ([]b
 		"import":     g.Import,
 		"formatType": g.FormatType,
 	}
-	for k, v := range g.funcs {
+	for k, v := range g.templateFuncs {
 		funcs[k] = v
 	}
 

--- a/plugin/template.go
+++ b/plugin/template.go
@@ -56,12 +56,18 @@ func TemplateFunc(name string, f interface{}) TemplateOption {
 	}}
 }
 
-// GoFileImportPath is a TemplateOption that specifies the intended import path
-// for the file being generated.
+// GoFileImportPath is a TemplateOption that specifies the intended absolute
+// import path for the file being generated.
 //
-// If specified, this changes the behavior of the `formatType` template function
-// to NOT import this package and instead use the types directly since they are
-// available in the same package.
+// 	GoFileFromTemplate(
+// 		filename,
+// 		mytemplate,
+// 		GoFileImportPath("github.com/thriftrw/thriftrw-go/myservice"),
+// 	)
+//
+// If specified, this changes the behavior of the `formatType` template
+// function to NOT import this package and instead use the types directly
+// since they are available in the same package.
 func GoFileImportPath(path string) TemplateOption {
 	return TemplateOption{apply: func(t *goFileGenerator) {
 		t.importPath = path

--- a/plugin/template.go
+++ b/plugin/template.go
@@ -159,11 +159,7 @@ func (g *goFileGenerator) FormatType(t *api.Type) (string, error) {
 		}
 	case t.SliceType != nil:
 		v, err := g.FormatType(t.SliceType)
-		if err != nil {
-			return "", err
-		}
-
-		return "[]" + v, nil
+		return "[]" + v, err
 	case t.KeyValueSliceType != nil:
 		k, err := g.FormatType(t.KeyValueSliceType.Left)
 		if err != nil {
@@ -190,11 +186,7 @@ func (g *goFileGenerator) FormatType(t *api.Type) (string, error) {
 		return importName + "." + t.ReferenceType.Name, nil
 	case t.PointerType != nil:
 		v, err := g.FormatType(t.PointerType)
-		if err != nil {
-			return "", err
-		}
-
-		return "*" + v, nil
+		return "*" + v, err
 	default:
 		return "", fmt.Errorf("unknown type: %v", t)
 	}

--- a/plugin/template.go
+++ b/plugin/template.go
@@ -102,6 +102,11 @@ func newGoFileGenerator(opts []TemplateOption) *goFileGenerator {
 	return &t
 }
 
+func (g *goFileGenerator) isGlobalTaken(name string) bool {
+	_, taken := g.globals[name]
+	return taken || goast.IsReservedKeyword(name)
+}
+
 // Import the given import path and return the imported name for this package.
 func (g *goFileGenerator) Import(path string) string {
 	if name, ok := g.importedNames[path]; ok {
@@ -113,7 +118,7 @@ func (g *goFileGenerator) Import(path string) string {
 	// Find an import name that does not conflict with any known globals.
 	importedName := name
 	for i := 2; ; i++ {
-		if _, conflict := g.globals[importedName]; !conflict {
+		if !g.isGlobalTaken(importedName) {
 			break
 		}
 		importedName = fmt.Sprintf("%s%d", name, i)

--- a/plugin/template.go
+++ b/plugin/template.go
@@ -1,0 +1,284 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package plugin
+
+import (
+	"bytes"
+	"fmt"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"sort"
+	"text/template"
+
+	"github.com/thriftrw/thriftrw-go/internal/goast"
+	"github.com/thriftrw/thriftrw-go/plugin/api"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+// TemplateOption provides optional arguments to GoFileFromTemplate.
+type TemplateOption struct {
+	apply func(*goFileGenerator)
+}
+
+// TemplateFunc is a TemplateOption that makes a function available in the
+// template.
+//
+// The function may be anything accepted by text/template.
+//
+// 	GoFileFromTemplate(
+// 		filename,
+// 		`package <lower "HELLO">`,
+// 		TemplateFunc("lower", strings.ToLower),
+// 	)
+func TemplateFunc(name string, f interface{}) TemplateOption {
+	return TemplateOption{apply: func(t *goFileGenerator) {
+		t.funcs[name] = f
+	}}
+}
+
+// GoFileImportPath is a TemplateOption that specifies the intended import path
+// for the file being generated.
+//
+// If specified, this changes the behavior of the `formatType` template function
+// to NOT import this package and instead use the types directly since they are
+// available in the same package.
+func GoFileImportPath(path string) TemplateOption {
+	return TemplateOption{apply: func(t *goFileGenerator) {
+		t.importPath = path
+	}}
+}
+
+// goFileGenerator generates a single Go file.
+type goFileGenerator struct {
+	importPath string
+	funcs      map[string]interface{}
+
+	// Names of known globals. All global variables share this namespace.
+	globals map[string]struct{}
+
+	// import path -> empty string or import name for named imports
+	imports map[string]string
+
+	// import path -> package name or import name for named imports
+	importedNames map[string]string
+}
+
+func newGoFileGenerator(opts []TemplateOption) *goFileGenerator {
+	t := goFileGenerator{
+		funcs:         make(map[string]interface{}),
+		globals:       make(map[string]struct{}),
+		imports:       make(map[string]string),
+		importedNames: make(map[string]string),
+	}
+	for _, opt := range opts {
+		opt.apply(&t)
+	}
+	return &t
+}
+
+// Import the given import path and return the imported name for this package.
+func (g *goFileGenerator) Import(path string) string {
+	if name, ok := g.importedNames[path]; ok {
+		return name
+	}
+
+	name := goast.DeterminePackageName(path)
+
+	// Find an import name that does not conflict with any known globals.
+	importedName := name
+	for i := 2; ; i++ {
+		if _, conflict := g.globals[importedName]; !conflict {
+			break
+		}
+		importedName = fmt.Sprintf("%s%d", name, i)
+	}
+
+	if importedName == name {
+		// Package name is available so no named import
+		g.imports[path] = ""
+	} else {
+		g.imports[path] = importedName
+	}
+	g.importedNames[path] = importedName
+	g.globals[importedName] = struct{}{}
+	return importedName
+}
+
+// FormatType formats the given api.Type into a Go type, importing packages
+// necessary to reference this type.
+func (g *goFileGenerator) FormatType(t *api.Type) (string, error) {
+	switch {
+	case t.SimpleType != nil:
+		switch *t.SimpleType {
+		case api.SimpleTypeBool:
+			return "bool", nil
+		case api.SimpleTypeByte:
+			return "byte", nil
+		case api.SimpleTypeInt8:
+			return "int8", nil
+		case api.SimpleTypeInt16:
+			return "int16", nil
+		case api.SimpleTypeInt32:
+			return "int32", nil
+		case api.SimpleTypeInt64:
+			return "int64", nil
+		case api.SimpleTypeFloat64:
+			return "float64", nil
+		case api.SimpleTypeString:
+			return "string", nil
+		case api.SimpleTypeStructEmpty:
+			return "struct{}", nil
+		default:
+			return "", fmt.Errorf("unknown simple type: %v", *t.SimpleType)
+		}
+	case t.SliceType != nil:
+		v, err := g.FormatType(t.SliceType)
+		if err != nil {
+			return "", err
+		}
+
+		return "[]" + v, nil
+	case t.KeyValueSliceType != nil:
+		k, err := g.FormatType(t.KeyValueSliceType.Left)
+		if err != nil {
+			return "", err
+		}
+
+		v, err := g.FormatType(t.KeyValueSliceType.Right)
+		return fmt.Sprintf("[]struct{Key %v; Value %v}", k, v), err
+	case t.MapType != nil:
+		k, err := g.FormatType(t.MapType.Left)
+		if err != nil {
+			return "", err
+		}
+
+		v, err := g.FormatType(t.MapType.Right)
+		return fmt.Sprintf("map[%v]%v", k, v), err
+	case t.ReferenceType != nil:
+		if g.importPath == t.ReferenceType.Package {
+			// Target is in the same package. No need to import.
+			return t.ReferenceType.Name, nil
+		}
+
+		importName := g.Import(t.ReferenceType.Package)
+		return importName + "." + t.ReferenceType.Name, nil
+	case t.PointerType != nil:
+		v, err := g.FormatType(t.PointerType)
+		if err != nil {
+			return "", err
+		}
+
+		return "*" + v, nil
+	default:
+		return "", fmt.Errorf("unknown type: %v", t)
+	}
+}
+
+// Generates a Go file with the given name using the provided template and
+// template data.
+func (g *goFileGenerator) Generate(filename, tmpl string, data interface{}) ([]byte, error) {
+	funcs := template.FuncMap{
+		"import":     g.Import,
+		"formatType": g.FormatType,
+	}
+	for k, v := range g.funcs {
+		funcs[k] = v
+	}
+
+	t, err := template.New(filename).Delims("<", ">").Funcs(funcs).Parse(tmpl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template %q: %v", filename, err)
+	}
+
+	var buff bytes.Buffer
+	if err := t.Execute(&buff, data); err != nil {
+		return nil, err
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, buff.Bytes(), parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse generated code: %v:\n%s", err, buff.String())
+	}
+
+	if len(f.Imports) > 0 {
+		return nil, fmt.Errorf(
+			"plain imports are not allowed with GoFileFromTemplate: use the import function")
+	}
+
+	importPaths := make([]string, 0, len(g.imports))
+	for path := range g.imports {
+		importPaths = append(importPaths, path)
+	}
+	sort.Strings(importPaths)
+	for _, path := range importPaths {
+		astutil.AddNamedImport(fset, f, g.imports[path], path)
+	}
+
+	cfg := printer.Config{
+		Mode:     printer.UseSpaces | printer.TabIndent,
+		Tabwidth: 8,
+	}
+
+	buff = bytes.Buffer{}
+	if err := cfg.Fprint(&buff, fset, f); err != nil {
+		return nil, err // TODO wrap error
+	}
+
+	return buff.Bytes(), nil
+}
+
+// GoFileFromTemplate generates a Go file from the given template and template
+// data.
+//
+// The templating system follows the text/template templating format but with "<"
+// and ">" as the delimiters.
+//
+// The following functions are provided inside the template:
+//
+// import: Use this if you need to import other packages. Import may be called
+// anywhere in the template with an import path to ensure that that package is
+// imported in the generated file. The import is automatically converted into a
+// named import if there's a conflict with another import. This returns the
+// imported name of the package. Use the return value of this function to
+// reference the imported package.
+//
+// 	<$wire := import "github.com/thriftrw/thriftrw-go/wire">
+// 	var value <$wire>.Value
+//
+// formatType: Formats an api.Type into a Go type representation, automatically
+// importing packages needed for type references. By default, this imports all
+// packages referenced in the api.Type. If the GoFileImportPath option is
+// specified, types from that package will not be imported and instead, will be
+// assumed to be available in the same package.
+//
+// 	var value <formatType .Type>
+//
+// More functions may be added to the template using the TemplateFunc template
+// option. If the name of a TemplateFunc conflicts with a pre-defined function,
+// the TemplateFunc takes precedence.
+//
+// Code generated by this is automatically reformatted to comply with gofmt.
+func GoFileFromTemplate(filename, tmpl string, data interface{}, opts ...TemplateOption) ([]byte, error) {
+	return newGoFileGenerator(opts).Generate(filename, tmpl, data)
+}

--- a/plugin/template_test.go
+++ b/plugin/template_test.go
@@ -161,6 +161,27 @@ func TestGoFileFromTemplate(t *testing.T) {
 			wantError: "plain imports are not allowed with GoFileFromTemplate: " +
 				"use the import function",
 		},
+		{
+			desc: "import keyword",
+			template: `
+				package hello
+
+				<$foo := import "github.com/thriftrw/thriftrw-go/range">
+
+				type foo struct {
+					<$foo>.Range
+				}
+			`,
+			wantBody: unlines(
+				`package hello`,
+				``,
+				`import range2 "github.com/thriftrw/thriftrw-go/range"`,
+				``,
+				`type foo struct {`,
+				`	range2.Range`,
+				`}`,
+			),
+		},
 	}
 
 	for _, tt := range tests {

--- a/plugin/template_test.go
+++ b/plugin/template_test.go
@@ -1,0 +1,180 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thriftrw/thriftrw-go/plugin/api"
+)
+
+func TestGoFileFromTemplate(t *testing.T) {
+	tests := []struct {
+		desc     string
+		template string
+		data     interface{}
+		options  []TemplateOption
+
+		wantBody  string
+		wantError string
+	}{
+		{
+			desc:     "simple",
+			template: "package foo",
+			wantBody: unlines("package foo"),
+		},
+		{
+			desc: "type reference",
+			template: `
+				package foo
+
+				var foo <formatType .> = nil
+			`,
+			data: &api.Type{
+				ReferenceType: &api.TypeReference{
+					Name:    "Foo",
+					Package: "github.com/thriftrw/thriftrw-go/bar",
+				},
+			},
+			wantBody: unlines(
+				`package foo`,
+				``,
+				`import "github.com/thriftrw/thriftrw-go/bar"`,
+				``,
+				`var foo bar.Foo = nil`,
+			),
+		},
+		{
+			desc: "type reference in the same package",
+			template: `
+				package bar
+
+				func hello() <formatType .> {
+					return nil
+				}
+			`,
+			data: &api.Type{
+				ReferenceType: &api.TypeReference{
+					Name:    "Foo",
+					Package: "github.com/thriftrw/thriftrw-go/hello",
+				},
+			},
+			options: []TemplateOption{
+				GoFileImportPath("github.com/thriftrw/thriftrw-go/hello"),
+			},
+			wantBody: unlines(
+				`package bar`,
+				``,
+				`func hello() Foo {`,
+				`	return nil`,
+				`}`,
+			),
+		},
+		{
+			desc: "import",
+			template: `
+				package hello
+
+				<$foo := import "github.com/thriftrw/thriftrw-go/plugin">
+				<$bar := import "github.com/thriftrw/thriftrw-go/hello">
+
+				func main() {
+					<$foo>.Main(<$bar>.Baz)
+				}
+			`,
+			wantBody: unlines(
+				`package hello`,
+				``,
+				`import (`,
+				`	"github.com/thriftrw/thriftrw-go/hello"`,
+				`	"github.com/thriftrw/thriftrw-go/plugin"`,
+				`)`,
+				``,
+				`func main() {`,
+				`	plugin.Main(hello.Baz)`,
+				`}`,
+			),
+		},
+		{
+			desc: "import conflicts",
+			template: `
+				package hello
+
+				<$foo := import "context">
+				<$bar := import "golang.org/x/net/context">
+
+				// foo does stuff
+				func foo() <$foo>.Context { return nil }
+				func bar() <$bar>.Context { return nil }
+			`,
+			wantBody: unlines(
+				`package hello`,
+				``,
+				`import (`,
+				`	"context"`,
+				`	context2 "golang.org/x/net/context"`,
+				`)`,
+				``,
+				`// foo does stuff`,
+				`func foo() context.Context  { return nil }`,
+				`func bar() context2.Context { return nil }`,
+			),
+		},
+		{
+			desc: "import twice",
+			template: `
+				package foo
+
+				<$fmt := import "fmt">
+
+				func ErrFail(err error) error {
+					return <import "fmt">.Errorf("great sadness: %v", err)
+				}
+			`,
+			wantBody: unlines(
+				`package foo`,
+				``,
+				`import "fmt"`,
+				``,
+				`func ErrFail(err error) error {`,
+				`	return fmt.Errorf("great sadness: %v", err)`,
+				`}`,
+			),
+		},
+		{
+			desc:      "invalid template",
+			template:  `<import "`,
+			wantError: `failed to parse template "test.go":`,
+		},
+		{
+			desc:      "invalid Go code",
+			template:  `func main() {}`,
+			wantError: `failed to parse generated code: test.go:`,
+		},
+		{
+			desc: "explicit import",
+			template: `
+				package main
+
+				import "fmt"
+			`,
+			wantError: "plain imports are not allowed with GoFileFromTemplate: " +
+				"use the import function",
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := GoFileFromTemplate("test.go", tt.template, tt.data, tt.options...)
+		if tt.wantError != "" {
+			assert.Contains(t, err.Error(), tt.wantError, tt.desc)
+		} else {
+			assert.Equal(t, tt.wantBody, string(got), tt.desc)
+		}
+	}
+}
+
+// unlines joins the given lines with newlines in between followied by a
+// trailing newline.
+func unlines(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/plugin/template_test.go
+++ b/plugin/template_test.go
@@ -56,11 +56,11 @@ func TestGoFileFromTemplate(t *testing.T) {
 			data: &api.Type{
 				ReferenceType: &api.TypeReference{
 					Name:    "Foo",
-					Package: "github.com/thriftrw/thriftrw-go/hello",
+					Package: "github.com/thriftrw/thriftrw-go/bar",
 				},
 			},
 			options: []TemplateOption{
-				GoFileImportPath("github.com/thriftrw/thriftrw-go/hello"),
+				GoFileImportPath("github.com/thriftrw/thriftrw-go/bar"),
 			},
 			wantBody: unlines(
 				`package bar`,


### PR DESCRIPTION
Plugin authors will be able to use this to generate code using a templating
system similar to what ThriftRW uses internally. This is significantly simpler
than what ThriftRW uses internally but should suffice for most use cases.

Depends on #184.

@prashantv @kriskowal @breerly