### PR TITLE
Fix cover.sh: in() not present in older jq versions

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -39,7 +39,7 @@ for pkg in "$@"; do
 		| map
 			( select(startswith("'"$ROOT_PKG"'"))
 			| select(contains("/vendor/") | not)
-			| select(in({'"$filter"'}) | not)
+			| select({'"$filter"'}[.] | not)
 			)
 		| join(",")
 	')


### PR DESCRIPTION
The version of jq on our Travis containers doesn't support the `in` function.
This changes it to use a simple map lookup.