### PR TITLE
plugin/server: Fix Stop() race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 
 .PHONY: test
 test: build
-	go test $(PACKAGES)
+	go test -race $(PACKAGES)
 
 .PHONY: cover
 cover:


### PR DESCRIPTION
Calling `Stop` on the server was not closing the reader/writer so the loop was
stuck waiting for the next request. This changes it to close the reader and
let the writer be closed automatically when the loop exits.

Errors while reading are ignored if the server has already been closed.