### PR TITLE
plugins: Parse command line arguments

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/thriftrw/thriftrw-go/compile"
+	"github.com/thriftrw/thriftrw-go/internal/plugin"
 )
 
 // Options controls how code gets generated.
@@ -56,6 +57,9 @@ type Options struct {
 	// NoRecurse determines whether code should be generated for included Thrift
 	// files as well. If true, code gets generated only for the first module.
 	NoRecurse bool
+
+	// Code generation plugin
+	Plugin plugin.Handle
 }
 
 // Generate generates code based on the given options.
@@ -87,6 +91,8 @@ func Generate(m *compile.Module, o *Options) error {
 		}
 		return nil
 	})
+
+	// TODO(abg): Generate code from opts.Plugin
 }
 
 // TODO(abg): Make some sort of public interface out of the Importer

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,14 @@
-hash: 325f10fea77188e5dbef900a3452d12b6fbccea67143fb2b1e437482daec838e
-updated: 2016-08-26T16:56:31.778461579-07:00
+hash: 9916ba39872b835d00fed77e42ba4fe85d64c0892501f60f3452ff19840ed369
+updated: 2016-08-29T10:57:58.892748056-07:00
 imports:
+- name: github.com/anmitsu/go-shlex
+  version: 53a3d8a8a362cca54fd6825caf2216aa6d8139fc
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
 - name: github.com/jessevdk/go-flags
-  version: 01a6b3ff72f9b826af6791c3b87368c7791b5376
+  version: a8cab0163d48558ffd77076c9c99388529766f63
 - name: github.com/kr/pretty
   version: 737b74a46c4bf788349f72cb256fed10aea4d0ac
 - name: github.com/kr/text

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,3 +11,4 @@ import:
   subpackages:
   - go/ast/astutil
 - package: github.com/jessevdk/go-flags
+- package: github.com/anmitsu/go-shlex

--- a/internal/error.go
+++ b/internal/error.go
@@ -43,7 +43,7 @@ func indentTail(spaces int, s string) string {
 	return strings.Join(lines, "\n")
 }
 
-// MultiError combines a list of errors into one.
+// MultiError combines a list of errors into one. The list MUST NOT contain nil.
 //
 // Returns nil if the error list is empty.
 func MultiError(errors []error) error {
@@ -65,4 +65,33 @@ func MultiError(errors []error) error {
 	}
 
 	return multiError(newErrors)
+}
+
+// CombineErrors combines the given collection of errors together. nil values
+// will be ignored.
+//
+// The intention for this is to help chain togeter errors from multiple failing
+// operations.
+//
+// 	CombineErrors(
+// 		reader.Close(),
+// 		writer.Close(),
+// 	)
+//
+// This may also be used like so,
+//
+// 	err := reader.Close()
+// 	err = internal.CombineErrors(err, writer.Close())
+// 	if someCondition {
+// 		err = internal.CombineErrors(err, transport.Close())
+// 	}
+func CombineErrors(errors ...error) error {
+	newErrors := errors[:0] // zero-alloc filtering
+	for _, err := range errors {
+		if err != nil {
+			newErrors = append(newErrors, err)
+		}
+	}
+
+	return MultiError(newErrors)
 }

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -83,3 +83,29 @@ func TestMultiError(t *testing.T) {
 		}
 	}
 }
+
+func TestCombineErrors(t *testing.T) {
+	tests := []struct {
+		give []error
+		want error
+	}{
+		{
+			give: []error{
+				errors.New("foo"),
+				nil,
+				multiError{
+					errors.New("bar"),
+				},
+				nil,
+			},
+			want: multiError{
+				errors.New("foo"),
+				errors.New("bar"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, CombineErrors(tt.give...))
+	}
+}

--- a/internal/plugin/flag.go
+++ b/internal/plugin/flag.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/thriftrw/thriftrw-go/internal"
+	"github.com/thriftrw/thriftrw-go/internal/concurrent"
+	"github.com/thriftrw/thriftrw-go/internal/process"
+
+	"github.com/anmitsu/go-shlex"
+)
+
+const _pluginExecPrefix = "thriftrw-plugin-"
+
+// Flag defines an external plugin specification passed over the command line.
+//
+// Plugin specifications received over the command line are simply plugin
+// names followed by arguments for the plugin.
+//
+// An executable with the name thriftrw-plugin-$name is expected on the $PATH.
+// Remaining arguments are passed to the program. For example,
+//
+// 	-p "foo -a --bc"
+//
+// Will pass the arguments "-a --bc" to the executable "thriftrw-plugin-foo".
+type Flag struct {
+	Name    string    // Name of the plugin
+	Command *exec.Cmd // Command specification
+}
+
+// Handle gets a Handle to this plugin specification.
+//
+// The returned handle MUST be closed by the caller if error was nil.
+func (f *Flag) Handle() (Handle, error) {
+	transport, err := process.NewClient(f.Command)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open plugin %q: %v", f.Name, err)
+	}
+
+	handle, err := NewTransportHandle(f.Name, transport)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open plugin %q: %v", f.Name, err)
+	}
+
+	return handle, nil
+}
+
+// UnmarshalFlag parses a string specification of a plugin.
+func (f *Flag) UnmarshalFlag(value string) error {
+	tokens, err := shlex.Split(value, true)
+	if err != nil {
+		return fmt.Errorf("invalid plugin %q: %v", value, err)
+	}
+
+	if len(tokens) < 1 {
+		return fmt.Errorf("invalid plugin %q: please provide a name", value)
+	}
+
+	f.Name = tokens[0]
+	exe := _pluginExecPrefix + f.Name
+	path, err := exec.LookPath(exe)
+	if err != nil {
+		return fmt.Errorf("invalid plugin %q: could not find executable %q: %v", value, exe, err)
+	}
+
+	cmd := exec.Command(path, tokens[1:]...)
+	cmd.Stderr = os.Stderr // connect stderr so that plugins can log
+
+	f.Command = cmd
+	return nil
+}
+
+// Flags is a collection of ThriftRW external plugin specifications.
+type Flags []Flag
+
+// Handle gets a MultiHandle to all the plugins in this list or nil if the
+// list is empty.
+//
+// The returned handle MUST be closed by the caller if error was nil.
+func (fs Flags) Handle() (MultiHandle, error) {
+	if len(fs) == 0 {
+		return nil, nil
+	}
+
+	var (
+		lock  sync.Mutex
+		multi = make(MultiHandle)
+	)
+
+	err := concurrent.Range(fs, func(_ int, f Flag) error {
+		h, err := f.Handle()
+		if err != nil {
+			return err
+		}
+
+		lock.Lock()
+		defer lock.Unlock()
+
+		// TODO(abg): We could stop keying off the name and allow the same
+		// plugin to be specified multiple times with different arguments.
+		if _, conflict := multi[f.Name]; conflict {
+			h.Close()
+			return fmt.Errorf("plugin conflict: plugin %q is specified multiple times", f.Name)
+		}
+
+		multi[f.Name] = h
+		return nil
+	})
+
+	if err == nil {
+		return multi, nil
+	}
+
+	errors := []error{err}
+	if err := multi.Close(); err != nil {
+		errors = append(errors, err)
+	}
+
+	return nil, internal.MultiError(errors)
+}

--- a/internal/plugin/flag_test.go
+++ b/internal/plugin/flag_test.go
@@ -1,0 +1,286 @@
+package plugin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testdata(t *testing.T, paths ...string) string {
+	cwd, err := os.Getwd()
+	require.NoError(t, err, "could not determine CWD")
+
+	args := []string{cwd, "testdata"}
+	args = append(args, paths...)
+	return filepath.Join(args...)
+}
+
+func prependToPath(p string) func() {
+	oldPath := os.Getenv("PATH")
+	newPath := p + string(os.PathListSeparator) + oldPath
+
+	os.Setenv("PATH", newPath)
+	return func() { os.Setenv("PATH", oldPath) }
+}
+
+func TestUnmarshalFlag(t *testing.T) {
+	done := prependToPath(testdata(t))
+	defer done()
+
+	tests := []struct {
+		giveValue string
+
+		wantName string
+		wantPath string
+		wantArgs []string
+
+		wantErrorPrefix string
+	}{
+		{
+			giveValue:       "",
+			wantErrorPrefix: `invalid plugin "": please provide a name`,
+		},
+		{
+			giveValue:       `foo '`,
+			wantErrorPrefix: `invalid plugin "foo '": No closing quotation`,
+		},
+		{
+			giveValue:       "unknown-plugin",
+			wantErrorPrefix: `invalid plugin "unknown-plugin": could not find executable "thriftrw-plugin-unknown-plugin":`,
+		},
+		{
+			giveValue: "empty",
+			wantName:  "empty",
+			wantPath:  testdata(t, "thriftrw-plugin-empty"),
+		},
+		{
+			giveValue: "handshake-failed",
+			wantName:  "handshake-failed",
+			wantPath:  testdata(t, "thriftrw-plugin-handshake-failed"),
+		},
+		{
+			giveValue: "handshake-failed --bar baz",
+			wantName:  "handshake-failed",
+			wantPath:  testdata(t, "thriftrw-plugin-handshake-failed"),
+			wantArgs:  []string{"--bar", "baz"},
+		},
+		{
+			giveValue: `handshake-failed bar\ baz`,
+			wantName:  "handshake-failed",
+			wantPath:  testdata(t, "thriftrw-plugin-handshake-failed"),
+			wantArgs:  []string{"bar baz"},
+		},
+		{
+			giveValue: `handshake-failed bar="baz qux"`,
+			wantName:  "handshake-failed",
+			wantPath:  testdata(t, "thriftrw-plugin-handshake-failed"),
+			wantArgs:  []string{"bar=baz qux"},
+		},
+	}
+
+	for _, tt := range tests {
+		var f Flag
+		err := f.UnmarshalFlag(tt.giveValue)
+		if tt.wantErrorPrefix != "" {
+			if assert.Error(t, err, "expected error for %q", tt.giveValue) {
+				assert.True(t,
+					strings.HasPrefix(err.Error(), tt.wantErrorPrefix),
+					"expected prefix %q on error message %q for %q",
+					tt.wantErrorPrefix, err.Error(), tt.giveValue,
+				)
+			}
+		} else {
+			if assert.NoError(t, err, "expected no error for %q", tt.giveValue) {
+				assert.Equal(t, tt.wantName, f.Name, "name for %q does not match", tt.giveValue)
+				assert.Equal(t, tt.wantPath, f.Command.Path, "path for %q does not match", tt.giveValue)
+
+				// We check args[1:] because args[0] is always path.
+				if len(tt.wantArgs) == 0 {
+					assert.Empty(t, f.Command.Args[1:], "args for %q do not match", tt.giveValue)
+				} else {
+					assert.Equal(t, tt.wantArgs, f.Command.Args[1:], "args for %q do not match", tt.giveValue)
+				}
+			}
+		}
+	}
+}
+
+func TestFlagHandle(t *testing.T) {
+	tests := []struct {
+		desc string
+		name string
+		path string
+		args []string
+
+		wantErrors []string
+	}{
+		{
+			desc: "working plugin",
+			name: "empty",
+			path: testdata(t, "thriftrw-plugin-empty"),
+		},
+		{
+			desc: "handshake failed",
+			name: "handshake-failed",
+			path: testdata(t, "thriftrw-plugin-handshake-failed"),
+			wantErrors: []string{
+				`failed to open plugin "handshake-failed":`,
+				`handshake with plugin "handshake-failed" failed:`,
+			},
+		},
+		{
+			desc:       "non existent path",
+			name:       "bar",
+			path:       testdata(t, "thriftrw-plugin-bar"),
+			wantErrors: []string{`failed to open plugin "bar":`, "no such file or directory"},
+		},
+	}
+
+	for _, tt := range tests {
+		f := Flag{
+			Name:    tt.name,
+			Command: exec.Command(tt.path, tt.args...),
+		}
+		h, err := f.Handle()
+
+		if len(tt.wantErrors) > 0 {
+			if !assert.Error(t, err, "%v: expected error", tt.desc) {
+				continue
+			}
+
+			for _, msg := range tt.wantErrors {
+				assert.Contains(t, err.Error(), msg, "%v: error message mismatch", tt.desc)
+			}
+		} else {
+			if assert.NoError(t, err, "%v: expected no error", tt.desc) {
+				assert.NoError(t, h.Close(), "%v: failed to close", tt.desc)
+			}
+		}
+	}
+}
+
+func TestFlagsHandle(t *testing.T) {
+	type plug struct {
+		name string
+		path string
+		args []string
+	}
+
+	tests := []struct {
+		desc  string
+		plugs []plug
+
+		wantNil    bool // both, handle and err must be nil
+		wantErrors []string
+	}{
+		{
+			desc:    "no plugins",
+			wantNil: true,
+		},
+		{
+			desc:    "empty plugins",
+			plugs:   []plug{},
+			wantNil: true,
+		},
+		{
+			desc: "duplicate plugin",
+			plugs: []plug{
+				{
+					name: "empty",
+					path: testdata(t, "thriftrw-plugin-empty"),
+				},
+				{
+					name: "empty",
+					path: testdata(t, "thriftrw-plugin-empty"),
+					args: []string{"extra", "args"},
+				},
+			},
+			wantErrors: []string{
+				`plugin conflict: plugin "empty" is specified multiple times`,
+			},
+		},
+		{
+			desc: "all success",
+			plugs: []plug{
+				{
+					name: "empty",
+					path: testdata(t, "thriftrw-plugin-empty"),
+				},
+				{
+					name: "another-empty",
+					path: testdata(t, "thriftrw-plugin-another-empty"),
+				},
+			},
+		},
+		{
+			desc: "all fail",
+			plugs: []plug{
+				{
+					name: "handshake-failed",
+					path: testdata(t, "thriftrw-plugin-handshake-failed"),
+				},
+				{
+					name: "another-handshake-failed",
+					path: testdata(t, "thriftrw-plugin-another-handshake-failed"),
+				},
+			},
+			wantErrors: []string{
+				`failed to open plugin "handshake-failed": handshake with plugin "handshake-failed" failed:`,
+				`failed to open plugin "another-handshake-failed": handshake with plugin "another-handshake-failed" failed:`,
+			},
+		},
+		{
+			desc: "partial failure",
+			plugs: []plug{
+				{
+					name: "handshake-failed",
+					path: testdata(t, "thriftrw-plugin-handshake-failed"),
+				},
+				{
+					name: "empty",
+					path: testdata(t, "thriftrw-plugin-empty"),
+				},
+			},
+			wantErrors: []string{
+				`failed to open plugin "handshake-failed": handshake with plugin "handshake-failed" failed:`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		var flags Flags
+		for _, p := range tt.plugs {
+			flags = append(flags, Flag{
+				Name:    p.name,
+				Command: exec.Command(p.path, p.args...),
+			})
+		}
+
+		h, err := flags.Handle()
+
+		if tt.wantNil {
+			assert.Nil(t, h, "%v: expected nil handle", tt.desc)
+			assert.Nil(t, err, "%v: expected nil error", tt.desc)
+			continue
+		}
+
+		if len(tt.wantErrors) > 0 {
+			if !assert.Error(t, err, "%v: expected error", tt.desc) {
+				continue
+			}
+
+			for _, msg := range tt.wantErrors {
+				assert.Contains(t, err.Error(), msg, "%v: error message mismatch", tt.desc)
+			}
+		} else {
+			if assert.NoError(t, err, "%v: expected no error", tt.desc) {
+				assert.NoError(t, h.Close(), "%v: failed to close", tt.desc)
+			}
+		}
+	}
+}

--- a/internal/plugin/multi_test.go
+++ b/internal/plugin/multi_test.go
@@ -30,6 +30,16 @@ func TestMultiHandleClose(t *testing.T) {
 	assert.NoError(t, mh.Close())
 }
 
+func TestMultiHandleCloseNil(t *testing.T) {
+	var mh MultiHandle
+	assert.NoError(t, mh.Close())
+}
+
+func TestMultiHandleServiceGeneratorNil(t *testing.T) {
+	var mh MultiHandle
+	mh.ServiceGenerator() // should not panic
+}
+
 func TestMultiHandleCloseError(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -242,4 +252,10 @@ func TestMultiServiceGeneratorGenerate(t *testing.T) {
 			}
 		}()
 	}
+}
+
+func TestMultiServiceGeneratorGenerateNil(t *testing.T) {
+	var msg MultiServiceGenerator
+	_, err := msg.Generate(&api.GenerateServiceRequest{})
+	assert.NoError(t, err)
 }

--- a/internal/plugin/testdata/another-empty-plugin.go
+++ b/internal/plugin/testdata/another-empty-plugin.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/thriftrw/thriftrw-go/plugin"
+
+// A valid plugin that does not do anything.
+
+func main() {
+	plugin.Main(&plugin.Plugin{Name: "another-empty"})
+}

--- a/internal/plugin/testdata/empty-plugin.go
+++ b/internal/plugin/testdata/empty-plugin.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/thriftrw/thriftrw-go/plugin"
+
+// A valid plugin that does not do anything.
+
+func main() {
+	plugin.Main(&plugin.Plugin{Name: "empty"})
+}

--- a/internal/plugin/testdata/thriftrw-plugin-another-empty
+++ b/internal/plugin/testdata/thriftrw-plugin-another-empty
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+DIR=$(dirname "$0")
+go run "$DIR/another-empty-plugin.go" "$@"

--- a/internal/plugin/testdata/thriftrw-plugin-another-handshake-failed
+++ b/internal/plugin/testdata/thriftrw-plugin-another-handshake-failed
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Empty executable that will always fail handshake

--- a/internal/plugin/testdata/thriftrw-plugin-empty
+++ b/internal/plugin/testdata/thriftrw-plugin-empty
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+DIR=$(dirname "$0")
+go run "$DIR/empty-plugin.go" "$@"

--- a/internal/plugin/testdata/thriftrw-plugin-handshake-failed
+++ b/internal/plugin/testdata/thriftrw-plugin-handshake-failed
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# Empty executable that will always fail handshake

--- a/internal/plugin/transport.go
+++ b/internal/plugin/transport.go
@@ -94,18 +94,11 @@ func (h *transportHandle) Close() error {
 		return nil // already closed
 	}
 
-	var errors []error
-	if err := h.Client.Goodbye(); err != nil {
-		errors = append(errors, err)
-	}
-
+	err := h.Client.Goodbye()
 	if closer, ok := h.Transport.(io.Closer); ok {
-		if err := closer.Close(); err != nil {
-			errors = append(errors, err)
-		}
+		err = internal.CombineErrors(err, closer.Close())
 	}
-
-	return internal.MultiError(errors)
+	return err
 }
 
 func (h *transportHandle) ServiceGenerator() api.ServiceGenerator {

--- a/main.go
+++ b/main.go
@@ -115,10 +115,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	if pluginHandle != nil {
-		defer pluginHandle.Close()
-	}
+	defer pluginHandle.Close()
 
 	generatorOptions := gen.Options{
 		OutputDir:     opts.OutputDirectory,

--- a/main.go
+++ b/main.go
@@ -28,9 +28,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	flags "github.com/jessevdk/go-flags"
 	"github.com/thriftrw/thriftrw-go/compile"
 	"github.com/thriftrw/thriftrw-go/gen"
+	"github.com/thriftrw/thriftrw-go/internal/plugin"
+
+	"github.com/jessevdk/go-flags"
 )
 
 type options struct {
@@ -42,7 +44,12 @@ type options struct {
 	NoRecurse bool `long:"no-recurse" description:"Don't generate code for included Thrift files."`
 	YARPC     bool `long:"yarpc" description:"Generate code for YARPC. Defaults to false."`
 
-	// TODO(abg): Detailed help with examples of --thrift-root and --pkg-prefix
+	// TODO(abg): Drop --yarpc flag
+
+	Plugins plugin.Flags `long:"plugin" short:"p" value-name:"PLUGIN" description:"Code generation plugin for ThriftRW. This option may be provided multiple times to apply multiple plugins."`
+
+	// TODO(abg): Detailed help with examples of --thrift-root, --pkg-prefix,
+	// and --plugin
 }
 
 func main() {
@@ -104,14 +111,23 @@ func main() {
 		}
 	}
 
+	pluginHandle, err := opts.Plugins.Handle()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if pluginHandle != nil {
+		defer pluginHandle.Close()
+	}
+
 	generatorOptions := gen.Options{
 		OutputDir:     opts.OutputDirectory,
 		PackagePrefix: opts.PackagePrefix,
 		ThriftRoot:    opts.ThriftRoot,
 		NoRecurse:     opts.NoRecurse,
 		YARPC:         opts.YARPC,
+		Plugin:        pluginHandle,
 	}
-
 	if err := gen.Generate(module, &generatorOptions); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This adds support for parsing plugin arguments over the command line. It does
not actually integrate into the code generator yet.

Plugins are specified over the command line using the "-p" or "--plugin"
options. The value is in the form,

    NAME [ARGS ...]

Where `NAME` is the name of the plugin and `ARGS` is zero or more arguments to
pass to the plugin.

An executable with the name `thriftrw-plugin-${NAME}` is expected to be
available on `$PATH` to call the plugin. `ARGS` are passed to the plugin
executable.

For example,

    -p yarpc -p 'accessors --no-setters'

Will call,

-   `thrifrw-plugin-yarpc`
-   `thriftrw-plugin-accessors --no-setters`

Currently, a plugin can only be called once in a single invocation of
ThriftRW. That is, the following is currently unsupported:

    -p "foo --someflag" -p "foo --anotherflag"

CC @prashantv @breerly @kriskowal