### PR TITLE
Revamp README for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-[![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+# thriftrw-go [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
-  [ci-img]: https://travis-ci.org/thriftrw/thriftrw-go.svg?branch=master
-  [cov-img]: https://coveralls.io/repos/github/thriftrw/thriftrw-go/badge.svg?branch=master
-  [ci]: https://travis-ci.org/thriftrw/thriftrw-go
-  [cov]: https://coveralls.io/github/thriftrw/thriftrw-go?branch=master
+A Thrift encoding code generator and library for Go.
 
-`thriftrw` is a Thrift encoding code generator and library for Go.
+## Installation
 
-**This project is currently WIP and not ready for use. Do not use it until this notice goes away.**
+`go get -u github.com/thriftrw/thriftrw-go`
 
-Related Projects
-================
+## Development Status: Alpha
 
--   [thriftrw-python]
--   [thriftrw-node]
+Ready for adventurous users and early adopters, but there will likely be a few
+breaking changes and features required before releasing version 1.0.
 
-  [thriftrw-python]: https://github.com/thriftrw/thriftrw-python
-  [thriftrw-node]: https://github.com/thriftrw/thriftrw-node
+[doc-img]: https://godoc.org/github.com/thriftrw/thriftrw-go?status.svg
+[doc]: https://godoc.org/github.com/thriftrw/thriftrw-go
+[ci-img]: https://travis-ci.org/thriftrw/thriftrw-go.svg?branch=master
+[cov-img]: https://coveralls.io/repos/github/thriftrw/thriftrw-go/badge.svg?branch=master
+[ci]: https://travis-ci.org/thriftrw/thriftrw-go
+[cov]: https://coveralls.io/github/thriftrw/thriftrw-go?branch=master


### PR DESCRIPTION
Switching thriftrw over to the release process used in tchannel-go. Once this merges into `dev` I'm going to cut `v0.1.0` so that yarpc can pin to it.

@abhinav @kriskowal @prashantv 