### PR TITLE
plugin: Generate code from plugins

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/thriftrw/thriftrw-go/compile"
+	"github.com/thriftrw/thriftrw-go/internal"
 	"github.com/thriftrw/thriftrw-go/internal/plugin"
 )
 
@@ -81,18 +82,61 @@ func Generate(m *compile.Module, o *Options) error {
 		ThriftRoot:   o.ThriftRoot,
 	}
 
-	if o.NoRecurse {
-		return generateModule(m, importer, o)
-	}
+	// Mapping of files relative to OutputDir to their contents.
+	files := make(map[string][]byte)
+	genBuilder := newGenerateServiceBuilder(importer)
 
-	return m.Walk(func(m *compile.Module) error {
-		if err := generateModule(m, importer, o); err != nil {
+	generate := func(m *compile.Module) error {
+		moduleFiles, err := generateModule(m, importer, genBuilder, o)
+		if err != nil {
+			return generateError{Name: m.ThriftPath, Reason: err}
+		}
+		if err := mergeFiles(files, moduleFiles); err != nil {
 			return generateError{Name: m.ThriftPath, Reason: err}
 		}
 		return nil
-	})
+	}
 
-	// TODO(abg): Generate code from opts.Plugin
+	if o.NoRecurse {
+		if err := generate(m); err != nil {
+			return err
+		}
+	} else {
+		if err := m.Walk(generate); err != nil {
+			return err
+		}
+	}
+
+	plug := o.Plugin
+	if plug == nil {
+		plug = plugin.EmptyHandle
+	}
+
+	if sgen := plug.ServiceGenerator(); sgen != nil {
+		res, err := sgen.Generate(genBuilder.Build())
+		if err != nil {
+			return err
+		}
+
+		if err := mergeFiles(files, res.Files); err != nil {
+			return err
+		}
+	}
+
+	for relPath, contents := range files {
+		fullPath := filepath.Join(o.OutputDir, relPath)
+		directory := filepath.Dir(fullPath)
+
+		if err := os.MkdirAll(directory, 0755); err != nil {
+			return fmt.Errorf("could not create directory %q: %v", directory, err)
+		}
+
+		if err := ioutil.WriteFile(fullPath, contents, 0644); err != nil {
+			return fmt.Errorf("failed to write %q: %v", fullPath, err)
+		}
+	}
+
+	return nil
 }
 
 // TODO(abg): Make some sort of public interface out of the Importer
@@ -129,10 +173,21 @@ func (i thriftPackageImporter) ServicePackage(file, name string) (string, error)
 	return filepath.Join(topPackage, "service", strings.ToLower(name)), nil
 }
 
-// generates code for only the given module, assuming that code for included
-// modules has already been generated.
-func generateModule(m *compile.Module, i thriftPackageImporter, o *Options) error {
-	outDir := o.OutputDir
+func mergeFiles(dest, src map[string][]byte) error {
+	var errors []error
+	for path, contents := range src {
+		if _, ok := dest[path]; ok {
+			errors = append(errors, fmt.Errorf("file generation conflict: "+
+				"multiple sources are trying to write to %q", path))
+		}
+		dest[path] = contents
+	}
+	return internal.MultiError(errors)
+}
+
+// generateModule returns a mapping from filename to file contents of files
+// that should be generated relative to o.OutputDir.
+func generateModule(m *compile.Module, i thriftPackageImporter, builder *generateServiceBuilder, o *Options) (map[string][]byte, error) {
 	// packageRelPath is the path relative to outputDir into which we'll be
 	// writing the package for this Thrift file. For $thriftRoot/foo/bar.thrift,
 	// packageRelPath is foo/bar, and packageDir is $outputDir/foo/bar. All
@@ -140,7 +195,7 @@ func generateModule(m *compile.Module, i thriftPackageImporter, o *Options) erro
 	// package will be importable via $importPrefix/foo/bar.
 	packageRelPath, err := i.RelativePackage(m.ThriftPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// TODO(abg): Prefer top-level package name from `namespace go` directive.
@@ -150,33 +205,31 @@ func generateModule(m *compile.Module, i thriftPackageImporter, o *Options) erro
 	// for this Thrift file.
 	importPath, err := i.Package(m.ThriftPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// packageOutDir is the directory whithin which all files and folders for
-	// this Thrift file will be written.
-	packageOutDir := filepath.Join(outDir, packageRelPath)
-
-	// Mapping of file names relative to $packageOutDir and their contents.
-	files := make(map[string]*bytes.Buffer)
+	// Mapping of file names relative to packageRelPath to their contents.
+	// Note that we need to return a mapping relative to o.OutputDir so we
+	// will prepend $packageRelPath/ to all these paths.
+	files := make(map[string][]byte)
 
 	if len(m.Constants) > 0 {
 		g := NewGenerator(i, importPath, packageName)
 
 		for _, constantName := range sortStringKeys(m.Constants) {
 			if err := Constant(g, m.Constants[constantName]); err != nil {
-				return err
+				return nil, err
 			}
 		}
 
 		buff := new(bytes.Buffer)
 		if err := g.Write(buff, token.NewFileSet()); err != nil {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"could not generate constants for %q: %v", m.ThriftPath, err)
 		}
 
 		// TODO(abg): Verify no file collisions
-		files["constants.go"] = buff
+		files["constants.go"] = buff.Bytes()
 	}
 
 	if len(m.Types) > 0 {
@@ -184,71 +237,69 @@ func generateModule(m *compile.Module, i thriftPackageImporter, o *Options) erro
 
 		for _, typeName := range sortStringKeys(m.Types) {
 			if err := TypeDefinition(g, m.Types[typeName]); err != nil {
-				return err
+				return nil, err
 			}
 		}
 
 		buff := new(bytes.Buffer)
 		if err := g.Write(buff, token.NewFileSet()); err != nil {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"could not generate types for %q: %v", m.ThriftPath, err)
 		}
 
 		// TODO(abg): Verify no file collisions
-		files["types.go"] = buff
+		files["types.go"] = buff.Bytes()
 	}
 
 	if len(m.Services) > 0 {
 		for _, serviceName := range sortStringKeys(m.Services) {
 			service := m.Services[serviceName]
+
+			// If we called generateModule on something, that's a root
+			// service. We need plugins to generate code for them.
+			if _, err := builder.AddRootService(service); err != nil {
+				return nil, err
+			}
+
 			importPath, err := i.ServicePackage(service.ThriftFile(), service.Name)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			packageName := filepath.Base(importPath)
-
-			// TODO inherited service functions
 
 			g := NewGenerator(i, importPath, packageName)
 			serviceFiles, err := Service(g, service)
 			if err != nil {
-				return fmt.Errorf(
+				return nil, fmt.Errorf(
 					"could not generate code for service %q: %v",
 					serviceName, err)
 			}
 
 			for name, buff := range serviceFiles {
 				filename := filepath.Join("service", packageName, name)
-				files[filename] = buff
+				files[filename] = buff.Bytes()
 			}
 
+			// TODO(abg): Delete this once the YARPC plugin is landed.
 			if o.YARPC {
 				yarpcFiles, err := YARPC(i, service)
 				if err != nil {
-					return fmt.Errorf(
+					return nil, fmt.Errorf(
 						"could not generate YARPC code for service %q: %v",
 						serviceName, err)
 				}
 
 				for name, buff := range yarpcFiles {
 					filename := filepath.Join("yarpc", name)
-					files[filename] = buff
+					files[filename] = buff.Bytes()
 				}
 			}
 		}
 	}
 
-	for relPath, contents := range files {
-		fullPath := filepath.Join(packageOutDir, relPath)
-		directory := filepath.Dir(fullPath)
-
-		if err := os.MkdirAll(directory, 0755); err != nil {
-			return fmt.Errorf("could not create directory %q: %v", directory, err)
-		}
-
-		if err := ioutil.WriteFile(fullPath, contents.Bytes(), 0644); err != nil {
-			return fmt.Errorf("failed to write %q: %v", fullPath, err)
-		}
+	newFiles := make(map[string][]byte, len(files))
+	for path, contents := range files {
+		newFiles[filepath.Join(packageRelPath, path)] = contents
 	}
-	return nil
+	return newFiles, nil
 }

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -21,15 +21,31 @@
 package gen
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/thriftrw/thriftrw-go/compile"
+	"github.com/thriftrw/thriftrw-go/internal/plugin"
+	"github.com/thriftrw/thriftrw-go/internal/plugin/handletest"
+	"github.com/thriftrw/thriftrw-go/plugin/api"
+	"github.com/thriftrw/thriftrw-go/plugin/plugintest"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func testdata(t *testing.T, paths ...string) string {
+	cwd, err := os.Getwd()
+	require.NoError(t, err, "could not determine CWD")
+
+	args := []string{cwd, "testdata"}
+	args = append(args, paths...)
+	return filepath.Join(args...)
+}
 
 func TestGenerateWithRelativePaths(t *testing.T) {
 	outputDir, err := ioutil.TempDir("", "thriftrw-generate-test")
@@ -60,6 +76,174 @@ func TestGenerateWithRelativePaths(t *testing.T) {
 		if assert.Error(t, err, "expected code generation with %v to fail", opt) {
 			assert.Contains(t, err.Error(), "must be an absolute path")
 		}
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	var (
+		ts compile.TypeSpec = &compile.TypedefSpec{
+			Name:   "Timestamp",
+			File:   testdata(t, "thrift/common/bar.thrift"),
+			Target: compile.I64Spec,
+		}
+		ts2 compile.TypeSpec = &compile.TypedefSpec{
+			Name:   "Timestamp",
+			File:   testdata(t, "thrift/foo.thrift"),
+			Target: ts,
+		}
+	)
+
+	ts2, err := ts2.Link(compile.EmptyScope("bar"))
+	require.NoError(t, err)
+
+	ts, err = ts.Link(compile.EmptyScope("bar"))
+	require.NoError(t, err)
+
+	module := &compile.Module{
+		Name:       "foo",
+		ThriftPath: testdata(t, "thrift/foo.thrift"),
+		Includes: map[string]*compile.IncludedModule{
+			"bar": {
+				Name: "bar",
+				Module: &compile.Module{
+					Name:       "bar",
+					ThriftPath: testdata(t, "thrift/common/bar.thrift"),
+					Types:      map[string]compile.TypeSpec{"Timestamp": ts},
+				},
+			},
+		},
+		Types: map[string]compile.TypeSpec{"Timestamp": ts2},
+	}
+
+	tests := []struct {
+		desc      string
+		noRecurse bool
+		getPlugin func(*gomock.Controller) plugin.Handle
+
+		wantFiles []string
+		wantError string
+	}{
+		{
+			desc:      "nil plugin; no recurse",
+			noRecurse: true,
+			wantFiles: []string{"foo/types.go"},
+		},
+		{
+			desc: "nil plugin; recurse",
+			wantFiles: []string{
+				"foo/types.go",
+				"common/bar/types.go",
+			},
+		},
+		{
+			desc: "no service generator",
+			getPlugin: func(mockCtrl *gomock.Controller) plugin.Handle {
+				handle := handletest.NewMockHandle(mockCtrl)
+				handle.EXPECT().ServiceGenerator().Return(nil)
+				return handle
+			},
+			wantFiles: []string{
+				"foo/types.go",
+				"common/bar/types.go",
+			},
+		},
+		{
+			desc: "empty plugin",
+			getPlugin: func(mockCtrl *gomock.Controller) plugin.Handle {
+				return plugin.EmptyHandle
+			},
+			wantFiles: []string{
+				"foo/types.go",
+				"common/bar/types.go",
+			},
+		},
+		{
+			desc: "ServiceGenerator plugin",
+			getPlugin: func(mockCtrl *gomock.Controller) plugin.Handle {
+				sgen := plugintest.NewMockServiceGenerator(mockCtrl)
+				sgen.EXPECT().Generate(gomock.Any()).
+					Return(&api.GenerateServiceResponse{
+						Files: map[string][]byte{
+							"foo.txt":    []byte("hello world\n"),
+							"bar/baz.go": []byte("package bar\n"),
+						},
+					}, nil)
+
+				handle := handletest.NewMockHandle(mockCtrl)
+				handle.EXPECT().ServiceGenerator().Return(sgen)
+				return handle
+			},
+			wantFiles: []string{
+				"foo/types.go",
+				"common/bar/types.go",
+				"foo.txt",
+				"bar/baz.go",
+			},
+		},
+		{
+			desc: "ServiceGenerator plugin conflict",
+			getPlugin: func(mockCtrl *gomock.Controller) plugin.Handle {
+				sgen := plugintest.NewMockServiceGenerator(mockCtrl)
+				sgen.EXPECT().Generate(gomock.Any()).
+					Return(&api.GenerateServiceResponse{
+						Files: map[string][]byte{
+							"common/bar/types.go": []byte("hulk smash"),
+						},
+					}, nil)
+
+				handle := handletest.NewMockHandle(mockCtrl)
+				handle.EXPECT().ServiceGenerator().Return(sgen)
+				return handle
+			},
+			wantError: `file generation conflict: multiple sources are trying to write to "common/bar/types.go"`,
+		},
+		{
+			desc: "ServiceGenerator plugin error",
+			getPlugin: func(mockCtrl *gomock.Controller) plugin.Handle {
+				sgen := plugintest.NewMockServiceGenerator(mockCtrl)
+				sgen.EXPECT().Generate(gomock.Any()).Return(nil, errors.New("great sadness"))
+
+				handle := handletest.NewMockHandle(mockCtrl)
+				handle.EXPECT().ServiceGenerator().Return(sgen)
+				return handle
+			},
+			wantError: `great sadness`,
+		},
+	}
+
+	for _, tt := range tests {
+		func() {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			outputDir, err := ioutil.TempDir(os.TempDir(), "test-generate-recurse")
+			require.NoError(t, err)
+			defer os.RemoveAll(outputDir)
+
+			var p plugin.Handle
+			if tt.getPlugin != nil {
+				p = tt.getPlugin(mockCtrl)
+			}
+
+			err = Generate(module, &Options{
+				OutputDir:     outputDir,
+				PackagePrefix: "github.com/thriftrw/thriftrw-go/gen/testdata",
+				ThriftRoot:    testdata(t, "thrift"),
+				Plugin:        p,
+				NoRecurse:     tt.noRecurse,
+			})
+			if tt.wantError != "" {
+				assert.Contains(t, err.Error(), tt.wantError)
+				return
+			}
+
+			if assert.NoError(t, err, tt.desc) {
+				for _, f := range tt.wantFiles {
+					_, err = os.Stat(filepath.Join(outputDir, f))
+					assert.NoError(t, err, tt.desc)
+				}
+			}
+		}()
 	}
 }
 

--- a/gen/plugin.go
+++ b/gen/plugin.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gen
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/thriftrw/thriftrw-go/compile"
+	"github.com/thriftrw/thriftrw-go/plugin/api"
+)
+
+type serviceName string
+
+type generateServiceBuilder struct {
+	api.GenerateServiceRequest
+
+	importer thriftPackageImporter
+
+	nextModuleID  api.ModuleID
+	nextServiceID api.ServiceID
+
+	// ThriftFile -> Module ID
+	moduleIDs map[string]api.ModuleID
+
+	// ThriftFile -> Service name -> Service ID
+	serviceIDs map[string]map[serviceName]api.ServiceID
+
+	// To ensure there are no duplicates
+	rootServices map[api.ServiceID]struct{}
+}
+
+func newGenerateServiceBuilder(i thriftPackageImporter) *generateServiceBuilder {
+	return &generateServiceBuilder{
+		GenerateServiceRequest: api.GenerateServiceRequest{
+			RootServices: make([]api.ServiceID, 0, 10),
+			Services:     make(map[api.ServiceID]*api.Service),
+			Modules:      make(map[api.ModuleID]*api.Module),
+		},
+		importer:      i,
+		nextModuleID:  1,
+		nextServiceID: 1,
+		moduleIDs:     make(map[string]api.ModuleID),
+		serviceIDs:    make(map[string]map[serviceName]api.ServiceID),
+		rootServices:  make(map[api.ServiceID]struct{}),
+	}
+}
+
+func (g *generateServiceBuilder) Build() *api.GenerateServiceRequest {
+	return &g.GenerateServiceRequest
+}
+
+// AddRootService adds a service as a root service to this request.
+func (g *generateServiceBuilder) AddRootService(spec *compile.ServiceSpec) (api.ServiceID, error) {
+	id, err := g.addService(spec)
+	if err != nil {
+		return id, err
+	}
+
+	if _, alreadyAdded := g.rootServices[id]; !alreadyAdded {
+		g.RootServices = append(g.RootServices, id)
+		g.rootServices[id] = struct{}{}
+	}
+
+	return id, err
+}
+
+// addModule adds the module for the given Thrift file to the request.
+func (g *generateServiceBuilder) addModule(thriftPath string) (api.ModuleID, error) {
+	if id, ok := g.moduleIDs[thriftPath]; ok {
+		return id, nil
+	}
+
+	id := g.nextModuleID
+	g.nextModuleID++
+	g.moduleIDs[thriftPath] = id
+
+	importPath, err := g.importer.Package(thriftPath)
+	if err != nil {
+		return 0, err
+	}
+
+	dir, err := g.importer.RelativePackage(thriftPath)
+	if err != nil {
+		return 0, err
+	}
+
+	g.Modules[id] = &api.Module{
+		Package:   importPath,
+		Directory: dir,
+	}
+	return id, nil
+}
+
+func (g *generateServiceBuilder) addService(spec *compile.ServiceSpec) (api.ServiceID, error) {
+	if moduleServices, ok := g.serviceIDs[spec.ThriftFile()]; ok {
+		if id, ok := moduleServices[serviceName(spec.Name)]; ok {
+			return id, nil
+		}
+	} else {
+		g.serviceIDs[spec.ThriftFile()] = make(map[serviceName]api.ServiceID)
+	}
+
+	var parentID *api.ServiceID
+	if spec.Parent != nil {
+		parent, err := g.addService(spec.Parent)
+		if err != nil {
+			return 0, err
+		}
+		parentID = &parent
+	}
+
+	serviceID := g.nextServiceID
+	g.nextServiceID++
+	g.serviceIDs[spec.ThriftFile()][serviceName(spec.Name)] = serviceID
+
+	moduleID, err := g.addModule(spec.ThriftFile())
+	if err != nil {
+		return 0, err
+	}
+
+	// kv.thrift (service Foo) => .../kv/service/foo
+	importPath, err := g.importer.ServicePackage(spec.ThriftFile(), spec.Name)
+	if err != nil {
+		return 0, err
+	}
+
+	// kv.thrift => kv/
+	dir, err := g.importer.RelativePackage(spec.ThriftFile())
+	if err != nil {
+		return 0, err
+	}
+
+	// kv.thrift => kv/service/foo/
+	dir = filepath.Join(dir, "service", filepath.Base(importPath))
+
+	functions := make([]*api.Function, 0, len(spec.Functions))
+	for _, functionName := range sortStringKeys(spec.Functions) {
+		function, err := g.buildFunction(spec.Functions[functionName])
+		if err != nil {
+			return 0, err
+		}
+		functions = append(functions, function)
+	}
+
+	g.Services[serviceID] = &api.Service{
+		Name:      spec.Name,
+		Package:   importPath,
+		Directory: dir,
+		ParentID:  parentID,
+		Functions: functions,
+		ModuleID:  moduleID,
+	}
+	return serviceID, nil
+}
+
+func (g *generateServiceBuilder) buildFunction(spec *compile.FunctionSpec) (*api.Function, error) {
+	args, err := g.buildFieldGroup(compile.FieldGroup(spec.ArgsSpec))
+	if err != nil {
+		return nil, err
+	}
+
+	function := &api.Function{
+		Name:       goCase(spec.Name),
+		ThriftName: spec.Name,
+		Arguments:  args,
+	}
+
+	if spec.ResultSpec != nil {
+		var err error
+		result := spec.ResultSpec
+		if result.ReturnType != nil {
+			function.ReturnType, err = g.buildType(result.ReturnType, true)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if len(result.Exceptions) > 0 {
+			function.Exceptions, err = g.buildFieldGroup(result.Exceptions)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return function, nil
+}
+
+func (g *generateServiceBuilder) buildFieldGroup(fs compile.FieldGroup) ([]*api.Argument, error) {
+	args := make([]*api.Argument, 0, len(fs))
+	for _, f := range fs {
+		t, err := g.buildType(f.Type, f.Required)
+		if err != nil {
+			return nil, err
+		}
+
+		args = append(args, &api.Argument{
+			Name: goCase(f.Name),
+			Type: t,
+		})
+	}
+	return args, nil
+}
+
+func (g *generateServiceBuilder) buildType(spec compile.TypeSpec, required bool) (*api.Type, error) {
+	simpleType := func(t api.SimpleType) *api.SimpleType { return &t }
+
+	var t *api.Type
+	switch spec {
+	case compile.BoolSpec:
+		t = &api.Type{SimpleType: simpleType(api.SimpleTypeBool)}
+	case compile.I8Spec:
+		t = &api.Type{SimpleType: simpleType(api.SimpleTypeInt8)}
+	case compile.I16Spec:
+		t = &api.Type{SimpleType: simpleType(api.SimpleTypeInt16)}
+	case compile.I32Spec:
+		t = &api.Type{SimpleType: simpleType(api.SimpleTypeInt32)}
+	case compile.I64Spec:
+		t = &api.Type{SimpleType: simpleType(api.SimpleTypeInt64)}
+	case compile.DoubleSpec:
+		t = &api.Type{SimpleType: simpleType(api.SimpleTypeFloat64)}
+	case compile.StringSpec:
+		t = &api.Type{SimpleType: simpleType(api.SimpleTypeString)}
+	case compile.BinarySpec:
+		// Don't need to wrap into a ptr
+		return &api.Type{SliceType: &api.Type{SimpleType: simpleType(api.SimpleTypeByte)}}, nil
+	}
+
+	if t != nil {
+		if !required {
+			t = &api.Type{PointerType: t}
+		}
+		return t, nil
+	}
+
+	switch s := spec.(type) {
+	case *compile.MapSpec:
+		k, err := g.buildType(s.KeySpec, true)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := g.buildType(s.ValueSpec, true)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isHashable(s.KeySpec) {
+			return &api.Type{KeyValueSliceType: &api.TypePair{Left: k, Right: v}}, nil
+		}
+
+		return &api.Type{MapType: &api.TypePair{Left: k, Right: v}}, nil
+
+	case *compile.ListSpec:
+		v, err := g.buildType(s.ValueSpec, true)
+		if err != nil {
+			return nil, err
+		}
+
+		return &api.Type{SliceType: v}, nil
+
+	case *compile.SetSpec:
+		v, err := g.buildType(s.ValueSpec, true)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isHashable(s.ValueSpec) {
+			return &api.Type{SliceType: v}, nil
+		}
+
+		return &api.Type{MapType: &api.TypePair{
+			Left:  v,
+			Right: &api.Type{SimpleType: simpleType(api.SimpleTypeStructEmpty)},
+		}}, nil
+
+	case *compile.EnumSpec:
+		importPath, err := g.importer.Package(s.ThriftFile())
+		if err != nil {
+			return nil, err
+		}
+
+		t = &api.Type{
+			ReferenceType: &api.TypeReference{
+				Name:    goCase(s.Name),
+				Package: importPath,
+			},
+		}
+		if !required {
+			t = &api.Type{PointerType: t}
+		}
+		return t, nil
+
+	case *compile.StructSpec:
+		importPath, err := g.importer.Package(s.ThriftFile())
+		if err != nil {
+			return nil, err
+		}
+
+		return &api.Type{
+			PointerType: &api.Type{
+				ReferenceType: &api.TypeReference{
+					Name:    goCase(s.Name),
+					Package: importPath,
+				},
+			},
+		}, nil
+
+	case *compile.TypedefSpec:
+		importPath, err := g.importer.Package(s.ThriftFile())
+		if err != nil {
+			return nil, err
+		}
+
+		t = &api.Type{
+			ReferenceType: &api.TypeReference{
+				Name:    goCase(s.Name),
+				Package: importPath,
+			},
+		}
+
+		if !required && !isReferenceType(spec) {
+			t = &api.Type{PointerType: t}
+		}
+
+		return t, nil
+	default:
+		panic(fmt.Sprintf("Unknown type (%T) %v", spec, spec))
+	}
+}

--- a/gen/plugin_test.go
+++ b/gen/plugin_test.go
@@ -1,0 +1,558 @@
+package gen
+
+import (
+	"testing"
+
+	"github.com/thriftrw/thriftrw-go/ast"
+	"github.com/thriftrw/thriftrw-go/compile"
+	"github.com/thriftrw/thriftrw-go/plugin/api"
+	"github.com/thriftrw/thriftrw-go/ptr"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddRootService(t *testing.T) {
+	tests := []struct {
+		desc string
+		spec *compile.ServiceSpec
+		want *api.GenerateServiceRequest
+	}{
+		{
+			desc: "empty service",
+			spec: &compile.ServiceSpec{
+				Name: "EmptyService",
+				File: "idl/empty.thrift",
+			},
+			want: &api.GenerateServiceRequest{
+				RootServices: []api.ServiceID{1},
+				Services: map[api.ServiceID]*api.Service{
+					1: {
+						Name:      "EmptyService",
+						Package:   "github.com/thriftrw/thriftrw-go/gen/testdata/empty/service/emptyservice",
+						Directory: "empty/service/emptyservice",
+						Functions: []*api.Function{}, // must be non-nil
+						ModuleID:  1,
+					},
+				},
+				Modules: map[api.ModuleID]*api.Module{
+					1: {
+						Package:   "github.com/thriftrw/thriftrw-go/gen/testdata/empty",
+						Directory: "empty",
+					},
+				},
+			},
+		},
+		{
+			desc: "service with a parent",
+			spec: &compile.ServiceSpec{
+				Name: "KeyValue",
+				File: "idl/kv.thrift",
+				Parent: &compile.ServiceSpec{
+					Name: "AbstractService",
+					File: "idl/common/abstract.thrift",
+				},
+			},
+			want: &api.GenerateServiceRequest{
+				RootServices: []api.ServiceID{2},
+				Services: map[api.ServiceID]*api.Service{
+					1: {
+						Name:      "AbstractService",
+						Package:   "github.com/thriftrw/thriftrw-go/gen/testdata/common/abstract/service/abstractservice",
+						Directory: "common/abstract/service/abstractservice",
+						Functions: []*api.Function{}, // must be non-nil
+						ModuleID:  1,
+					},
+					2: {
+						Name:      "KeyValue",
+						Package:   "github.com/thriftrw/thriftrw-go/gen/testdata/kv/service/keyvalue",
+						Directory: "kv/service/keyvalue",
+						ParentID:  (*api.ServiceID)(ptr.Int32(1)),
+						Functions: []*api.Function{}, // must be non-nil
+						ModuleID:  2,
+					},
+				},
+				Modules: map[api.ModuleID]*api.Module{
+					1: {
+						Package:   "github.com/thriftrw/thriftrw-go/gen/testdata/common/abstract",
+						Directory: "common/abstract",
+					},
+					2: {
+						Package:   "github.com/thriftrw/thriftrw-go/gen/testdata/kv",
+						Directory: "kv",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		spec := tt.spec
+		err := spec.Link(compile.EmptyScope("foo"))
+		if !assert.NoError(t, err, "%v: invalid test: scope must link", tt.desc) {
+			continue
+		}
+
+		importer := thriftPackageImporter{
+			ImportPrefix: "github.com/thriftrw/thriftrw-go/gen/testdata",
+			ThriftRoot:   "idl",
+		}
+
+		g := newGenerateServiceBuilder(importer)
+		if _, err := g.AddRootService(spec); assert.NoError(t, err, tt.desc) {
+			assert.Equal(t, tt.want, g.Build(), tt.desc)
+		}
+	}
+}
+
+func TestBuildFunction(t *testing.T) {
+	tests := []struct {
+		desc string
+		spec *compile.FunctionSpec
+		want *api.Function
+	}{
+		{
+			desc: "returns and throws",
+			spec: &compile.FunctionSpec{
+				Name: "getValue",
+				ArgsSpec: compile.ArgsSpec{
+					{
+						ID:   1,
+						Name: "key",
+						Type: compile.StringSpec,
+					},
+				},
+				ResultSpec: &compile.ResultSpec{
+					ReturnType: compile.BinarySpec,
+					Exceptions: compile.FieldGroup{
+						{
+							ID:   1,
+							Name: "doesNotExist",
+							Type: &compile.StructSpec{
+								Name: "KeyDoesNotExist",
+								File: "idl/keyvalue.thrift",
+								Type: ast.ExceptionType,
+								Fields: compile.FieldGroup{
+									{
+										ID:   1,
+										Name: "message",
+										Type: compile.StringSpec,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &api.Function{
+				Name:       "GetValue",
+				ThriftName: "getValue",
+				Arguments: []*api.Argument{
+					{
+						Name: "Key",
+						Type: &api.Type{PointerType: &api.Type{SimpleType: simpleType(api.SimpleTypeString)}},
+					},
+				},
+				ReturnType: &api.Type{SliceType: &api.Type{SimpleType: simpleType(api.SimpleTypeByte)}},
+				Exceptions: []*api.Argument{
+					{
+						Name: "DoesNotExist",
+						Type: &api.Type{
+							PointerType: &api.Type{
+								ReferenceType: &api.TypeReference{
+									Name:    "KeyDoesNotExist",
+									Package: "github.com/thriftrw/thriftrw-go/gen/testdata/keyvalue",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "no return, no throw",
+			spec: &compile.FunctionSpec{
+				Name: "setValue",
+				ArgsSpec: compile.ArgsSpec{
+					{
+						ID:   1,
+						Name: "key",
+						Type: compile.StringSpec,
+					},
+					{
+						ID:   2,
+						Name: "value",
+						Type: compile.BinarySpec,
+					},
+				},
+				ResultSpec: &compile.ResultSpec{},
+			},
+			want: &api.Function{
+				Name:       "SetValue",
+				ThriftName: "setValue",
+				Arguments: []*api.Argument{
+					{
+						Name: "Key",
+						Type: &api.Type{PointerType: &api.Type{SimpleType: simpleType(api.SimpleTypeString)}},
+					},
+					{
+						Name: "Value",
+						Type: &api.Type{SliceType: &api.Type{SimpleType: simpleType(api.SimpleTypeByte)}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		spec := tt.spec
+		err := spec.Link(compile.EmptyScope("foo"))
+		if !assert.NoError(t, err, "%v: invalid test: scope must link", tt.desc) {
+			continue
+		}
+
+		importer := thriftPackageImporter{
+			ImportPrefix: "github.com/thriftrw/thriftrw-go/gen/testdata",
+			ThriftRoot:   "idl",
+		}
+
+		g := newGenerateServiceBuilder(importer)
+		got, err := g.buildFunction(spec)
+		if assert.NoError(t, err, tt.desc) {
+			assert.Equal(t, tt.want, got, tt.desc)
+		}
+	}
+}
+
+func TestBuildType(t *testing.T) {
+	tests := []struct {
+		desc     string
+		spec     compile.TypeSpec
+		required bool
+
+		want *api.Type
+	}{
+		// required primitives
+		{
+			desc:     "bool",
+			spec:     compile.BoolSpec,
+			required: true,
+			want:     &api.Type{SimpleType: simpleType(api.SimpleTypeBool)},
+		},
+		{
+			desc:     "int8",
+			spec:     compile.I8Spec,
+			required: true,
+			want:     &api.Type{SimpleType: simpleType(api.SimpleTypeInt8)},
+		},
+		{
+			desc:     "int16",
+			spec:     compile.I16Spec,
+			required: true,
+			want:     &api.Type{SimpleType: simpleType(api.SimpleTypeInt16)},
+		},
+		{
+			desc:     "int32",
+			spec:     compile.I32Spec,
+			required: true,
+			want:     &api.Type{SimpleType: simpleType(api.SimpleTypeInt32)},
+		},
+		{
+			desc:     "int64",
+			spec:     compile.I64Spec,
+			required: true,
+			want:     &api.Type{SimpleType: simpleType(api.SimpleTypeInt64)},
+		},
+		{
+			desc:     "float64",
+			spec:     compile.DoubleSpec,
+			required: true,
+			want:     &api.Type{SimpleType: simpleType(api.SimpleTypeFloat64)},
+		},
+		{
+			desc:     "string",
+			spec:     compile.StringSpec,
+			required: true,
+			want:     &api.Type{SimpleType: simpleType(api.SimpleTypeString)},
+		},
+		{
+			desc:     "[]byte",
+			spec:     compile.BinarySpec,
+			required: true,
+			want:     &api.Type{SliceType: &api.Type{SimpleType: simpleType(api.SimpleTypeByte)}},
+		},
+
+		// optional primitives
+		{
+			desc: "*bool",
+			spec: compile.BoolSpec,
+			want: &api.Type{PointerType: &api.Type{SimpleType: simpleType(api.SimpleTypeBool)}},
+		},
+		{
+			desc: "*int8",
+			spec: compile.I8Spec,
+			want: &api.Type{PointerType: &api.Type{SimpleType: simpleType(api.SimpleTypeInt8)}},
+		},
+		{
+			desc: "*int16",
+			spec: compile.I16Spec,
+			want: &api.Type{PointerType: &api.Type{SimpleType: simpleType(api.SimpleTypeInt16)}},
+		},
+		{
+			desc: "*int32",
+			spec: compile.I32Spec,
+			want: &api.Type{PointerType: &api.Type{SimpleType: simpleType(api.SimpleTypeInt32)}},
+		},
+		{
+			desc: "*int64",
+			spec: compile.I64Spec,
+			want: &api.Type{PointerType: &api.Type{SimpleType: simpleType(api.SimpleTypeInt64)}},
+		},
+		{
+			desc: "*float64",
+			spec: compile.DoubleSpec,
+			want: &api.Type{PointerType: &api.Type{SimpleType: simpleType(api.SimpleTypeFloat64)}},
+		},
+		{
+			desc: "*string",
+			spec: compile.StringSpec,
+			want: &api.Type{PointerType: &api.Type{SimpleType: simpleType(api.SimpleTypeString)}},
+		},
+		{
+			desc: "[]byte",
+			spec: compile.BinarySpec,
+			want: &api.Type{SliceType: &api.Type{SimpleType: simpleType(api.SimpleTypeByte)}},
+		},
+
+		// containers
+		{
+			// hashable map key
+			desc: "map[string]int32",
+			spec: &compile.MapSpec{
+				KeySpec:   compile.StringSpec,
+				ValueSpec: compile.I32Spec,
+			},
+			want: &api.Type{MapType: &api.TypePair{
+				Left:  &api.Type{SimpleType: simpleType(api.SimpleTypeString)},
+				Right: &api.Type{SimpleType: simpleType(api.SimpleTypeInt32)},
+			}},
+		},
+		{
+			// unhashable map key
+			desc: "[]struct{Key []byte; Value int32}",
+			spec: &compile.MapSpec{
+				KeySpec:   compile.BinarySpec,
+				ValueSpec: compile.I32Spec,
+			},
+			want: &api.Type{KeyValueSliceType: &api.TypePair{
+				Left: &api.Type{
+					SliceType: &api.Type{SimpleType: simpleType(api.SimpleTypeByte)},
+				},
+				Right: &api.Type{SimpleType: simpleType(api.SimpleTypeInt32)},
+			}},
+		},
+		{
+			// hashable set item
+			desc: "map[float64]struct{}",
+			spec: &compile.SetSpec{ValueSpec: compile.DoubleSpec},
+			want: &api.Type{MapType: &api.TypePair{
+				Left:  &api.Type{SimpleType: simpleType(api.SimpleTypeFloat64)},
+				Right: &api.Type{SimpleType: simpleType(api.SimpleTypeStructEmpty)},
+			}},
+		},
+		{
+			// unhashable set item
+			desc: "[]*foo.Foo",
+			spec: &compile.SetSpec{
+				ValueSpec: &compile.StructSpec{
+					Name: "Foo",
+					File: "idl/foo.thrift",
+					Type: ast.StructType,
+					Fields: compile.FieldGroup{
+						{
+							ID:       1,
+							Name:     "value",
+							Type:     compile.StringSpec,
+							Required: true,
+						},
+					},
+				},
+			},
+			want: &api.Type{
+				SliceType: &api.Type{
+					PointerType: &api.Type{
+						ReferenceType: &api.TypeReference{
+							Name:    "Foo",
+							Package: "github.com/thriftrw/thriftrw-go/gen/testdata/foo",
+						},
+					},
+				},
+			},
+		},
+		{
+			// list
+			desc: "[]map[string][]byte",
+			spec: &compile.ListSpec{
+				ValueSpec: &compile.MapSpec{
+					KeySpec:   compile.StringSpec,
+					ValueSpec: compile.BinarySpec,
+				},
+			},
+			want: &api.Type{
+				SliceType: &api.Type{
+					MapType: &api.TypePair{
+						Left: &api.Type{SimpleType: simpleType(api.SimpleTypeString)},
+						Right: &api.Type{
+							SliceType: &api.Type{SimpleType: simpleType(api.SimpleTypeByte)},
+						},
+					},
+				},
+			},
+		},
+		{
+			// required enum
+			desc: "required enum",
+			spec: &compile.EnumSpec{
+				Name: "Foo",
+				File: "idl/bar.thrift",
+				Items: []compile.EnumItem{
+					{Name: "A", Value: 0},
+					{Name: "B", Value: 2},
+				},
+			},
+			required: true,
+			want: &api.Type{
+				ReferenceType: &api.TypeReference{
+					Name:    "Foo",
+					Package: "github.com/thriftrw/thriftrw-go/gen/testdata/bar",
+				},
+			},
+		},
+		{
+			// optional enum
+			desc: "optional enum",
+			spec: &compile.EnumSpec{
+				Name: "Foo",
+				File: "idl/bar.thrift",
+				Items: []compile.EnumItem{
+					{Name: "A", Value: 0},
+					{Name: "B", Value: 2},
+				},
+			},
+			want: &api.Type{
+				PointerType: &api.Type{
+					ReferenceType: &api.TypeReference{
+						Name:    "Foo",
+						Package: "github.com/thriftrw/thriftrw-go/gen/testdata/bar",
+					},
+				},
+			},
+		},
+		{
+			// struct
+			desc: "struct",
+			spec: &compile.StructSpec{
+				Name: "Foo",
+				File: "idl/foo.thrift",
+				Type: ast.StructType,
+				Fields: compile.FieldGroup{
+					{
+						ID:       1,
+						Name:     "value",
+						Type:     compile.StringSpec,
+						Required: true,
+					},
+				},
+			},
+			want: &api.Type{
+				PointerType: &api.Type{
+					ReferenceType: &api.TypeReference{
+						Name:    "Foo",
+						Package: "github.com/thriftrw/thriftrw-go/gen/testdata/foo",
+					},
+				},
+			},
+		},
+		{
+			desc: "required typedef with a primitive",
+			spec: &compile.TypedefSpec{
+				Name:   "Foo",
+				File:   "idl/foo/bar.thrift",
+				Target: compile.I64Spec,
+			},
+			required: true,
+			want: &api.Type{
+				ReferenceType: &api.TypeReference{
+					Name:    "Foo",
+					Package: "github.com/thriftrw/thriftrw-go/gen/testdata/foo/bar",
+				},
+			},
+		},
+		{
+			desc: "optional typedef with a primitive",
+			spec: &compile.TypedefSpec{
+				Name:   "Foo",
+				File:   "idl/foo/bar.thrift",
+				Target: compile.I64Spec,
+			},
+			want: &api.Type{
+				PointerType: &api.Type{
+					ReferenceType: &api.TypeReference{
+						Name:    "Foo",
+						Package: "github.com/thriftrw/thriftrw-go/gen/testdata/foo/bar",
+					},
+				},
+			},
+		},
+		{
+			desc: "required typedef with non-primitive",
+			spec: &compile.TypedefSpec{
+				Name:   "Foo",
+				File:   "idl/foo/bar.thrift",
+				Target: compile.BinarySpec,
+			},
+			required: true,
+			want: &api.Type{
+				ReferenceType: &api.TypeReference{
+					Name:    "Foo",
+					Package: "github.com/thriftrw/thriftrw-go/gen/testdata/foo/bar",
+				},
+			},
+		},
+		{
+			desc: "optional typedef with non-primitive",
+			spec: &compile.TypedefSpec{
+				Name:   "Foo",
+				File:   "idl/foo/bar.thrift",
+				Target: &compile.ListSpec{ValueSpec: compile.StringSpec},
+			},
+			want: &api.Type{
+				ReferenceType: &api.TypeReference{
+					Name:    "Foo",
+					Package: "github.com/thriftrw/thriftrw-go/gen/testdata/foo/bar",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		spec, err := tt.spec.Link(compile.EmptyScope("foo"))
+		if !assert.NoError(t, err, "%v: invalid test: scope must link", tt.desc) {
+			continue
+		}
+
+		importer := thriftPackageImporter{
+			ImportPrefix: "github.com/thriftrw/thriftrw-go/gen/testdata",
+			ThriftRoot:   "idl",
+		}
+
+		g := newGenerateServiceBuilder(importer)
+		got, err := g.buildType(spec, tt.required)
+		if assert.NoError(t, err, tt.desc) {
+			assert.Equal(t, tt.want, got, tt.desc)
+		}
+	}
+}
+
+func simpleType(s api.SimpleType) *api.SimpleType {
+	return &s
+}

--- a/internal/plugin/empty.go
+++ b/internal/plugin/empty.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package plugin
+
+import "github.com/thriftrw/thriftrw-go/plugin/api"
+
+// EmptyHandle is a no-op Handle that does not do anything.
+var EmptyHandle Handle = emptyHandle{}
+
+type emptyHandle struct{}
+
+func (emptyHandle) Close() error {
+	return nil
+}
+
+func (emptyHandle) ServiceGenerator() api.ServiceGenerator {
+	return EmptyServiceGenerator
+}
+
+// EmptyServiceGenerator is a no-op service generator that does not generate
+// any new files.
+var EmptyServiceGenerator api.ServiceGenerator = emptyServiceGenerator{}
+
+type emptyServiceGenerator struct{}
+
+func (emptyServiceGenerator) Generate(Request *api.GenerateServiceRequest) (*api.GenerateServiceResponse, error) {
+	return &api.GenerateServiceResponse{Files: make(map[string][]byte)}, nil
+}

--- a/plugin/api.thrift
+++ b/plugin/api.thrift
@@ -31,6 +31,8 @@ struct TypeReference {
      * Import path for the package defining this type.
      */
     2: required string package
+
+    // TODO(abg): Should this just be using ModuleID instead of a package?
 }
 
 /**


### PR DESCRIPTION
This integrates plugins into the code generator and starts actually generating
code. With this change, the plugin system is actually fully functional.

Note that we're not dropping support for the `--yarpc` flag until YARPC has cut
a release with the YARPC plugin.

@prashantv @breerly @kriskowal