### PR TITLE
plugin: Don't require unique names

### DIFF
--- a/internal/plugin/flag.go
+++ b/internal/plugin/flag.go
@@ -106,7 +106,7 @@ type Flags []Flag
 func (fs Flags) Handle() (MultiHandle, error) {
 	var (
 		lock  sync.Mutex
-		multi = make(MultiHandle)
+		multi MultiHandle
 	)
 
 	err := concurrent.Range(fs, func(_ int, f Flag) error {
@@ -118,14 +118,7 @@ func (fs Flags) Handle() (MultiHandle, error) {
 		lock.Lock()
 		defer lock.Unlock()
 
-		// TODO(abg): We could stop keying off the name and allow the same
-		// plugin to be specified multiple times with different arguments.
-		if _, conflict := multi[f.Name]; conflict {
-			h.Close()
-			return fmt.Errorf("plugin conflict: plugin %q is specified multiple times", f.Name)
-		}
-
-		multi[f.Name] = h
+		multi = append(multi, h)
 		return nil
 	})
 

--- a/internal/plugin/flag_test.go
+++ b/internal/plugin/flag_test.go
@@ -189,23 +189,6 @@ func TestFlagsHandle(t *testing.T) {
 			plugs: []plug{},
 		},
 		{
-			desc: "duplicate plugin",
-			plugs: []plug{
-				{
-					name: "empty",
-					path: testdata(t, "thriftrw-plugin-empty"),
-				},
-				{
-					name: "empty",
-					path: testdata(t, "thriftrw-plugin-empty"),
-					args: []string{"extra", "args"},
-				},
-			},
-			wantErrors: []string{
-				`plugin conflict: plugin "empty" is specified multiple times`,
-			},
-		},
-		{
 			desc: "all success",
 			plugs: []plug{
 				{

--- a/internal/plugin/gen.sh
+++ b/internal/plugin/gen.sh
@@ -17,7 +17,7 @@ set -x
 #   go install github.com/thriftrw/thriftrw-go/vendor/github.com/golang/mock/mockgen
 
 PACKAGE=github.com/thriftrw/thriftrw-go/internal/plugin
-INTERFACES=Handle
+INTERFACES=Handle,ServiceGenerator
 DESTINATION=handletest/mock.go
 PACKAGENAME=handletest
 

--- a/internal/plugin/handle.go
+++ b/internal/plugin/handle.go
@@ -30,10 +30,21 @@ import (
 type Handle interface {
 	io.Closer
 
+	// Name is the name of this plugin.
+	Name() string
+
 	// ServiceGenerator returns a ServiceGenerator for this plugin or nil if
 	// this plugin does not implement that feature.
 	//
 	// Note that the ServiceGenerator is valid only as long as Close is not
 	// called on the Handle.
-	ServiceGenerator() api.ServiceGenerator
+	ServiceGenerator() ServiceGenerator
+}
+
+// ServiceGenerator generates files for Thrift services.
+type ServiceGenerator interface {
+	api.ServiceGenerator
+
+	// Handle returns the Handle that owns this ServiceGenerator.
+	Handle() Handle
 }

--- a/internal/plugin/handletest/mock.go
+++ b/internal/plugin/handletest/mock.go
@@ -19,12 +19,13 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-// Source: github.com/thriftrw/thriftrw-go/internal/plugin (interfaces: Handle)
+// Source: github.com/thriftrw/thriftrw-go/internal/plugin (interfaces: Handle,ServiceGenerator)
 
 package handletest
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	plugin "github.com/thriftrw/thriftrw-go/internal/plugin"
 	api "github.com/thriftrw/thriftrw-go/plugin/api"
 )
 
@@ -59,12 +60,64 @@ func (_mr *_MockHandleRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockHandle) ServiceGenerator() api.ServiceGenerator {
+func (_m *MockHandle) Name() string {
+	ret := _m.ctrl.Call(_m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockHandleRecorder) Name() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Name")
+}
+
+func (_m *MockHandle) ServiceGenerator() plugin.ServiceGenerator {
 	ret := _m.ctrl.Call(_m, "ServiceGenerator")
-	ret0, _ := ret[0].(api.ServiceGenerator)
+	ret0, _ := ret[0].(plugin.ServiceGenerator)
 	return ret0
 }
 
 func (_mr *_MockHandleRecorder) ServiceGenerator() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ServiceGenerator")
+}
+
+// Mock of ServiceGenerator interface
+type MockServiceGenerator struct {
+	ctrl     *gomock.Controller
+	recorder *_MockServiceGeneratorRecorder
+}
+
+// Recorder for MockServiceGenerator (not exported)
+type _MockServiceGeneratorRecorder struct {
+	mock *MockServiceGenerator
+}
+
+func NewMockServiceGenerator(ctrl *gomock.Controller) *MockServiceGenerator {
+	mock := &MockServiceGenerator{ctrl: ctrl}
+	mock.recorder = &_MockServiceGeneratorRecorder{mock}
+	return mock
+}
+
+func (_m *MockServiceGenerator) EXPECT() *_MockServiceGeneratorRecorder {
+	return _m.recorder
+}
+
+func (_m *MockServiceGenerator) Generate(_param0 *api.GenerateServiceRequest) (*api.GenerateServiceResponse, error) {
+	ret := _m.ctrl.Call(_m, "Generate", _param0)
+	ret0, _ := ret[0].(*api.GenerateServiceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockServiceGeneratorRecorder) Generate(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Generate", arg0)
+}
+
+func (_m *MockServiceGenerator) Handle() plugin.Handle {
+	ret := _m.ctrl.Call(_m, "Handle")
+	ret0, _ := ret[0].(plugin.Handle)
+	return ret0
+}
+
+func (_mr *_MockServiceGeneratorRecorder) Handle() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Handle")
 }

--- a/internal/plugin/multi.go
+++ b/internal/plugin/multi.go
@@ -22,6 +22,7 @@ package plugin
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/thriftrw/thriftrw-go/internal/concurrent"
@@ -29,38 +30,50 @@ import (
 )
 
 // MultiHandle wraps a collection of handles into a single handle.
-type MultiHandle map[string]Handle
+type MultiHandle []Handle
+
+// Name is the combined name of this plugin
+func (mh MultiHandle) Name() string {
+	names := make([]string, 0, len(mh))
+	for _, h := range mh {
+		names = append(names, h.Name())
+	}
+	return fmt.Sprintf("MultiHandle{%v}", strings.Join(names, ", "))
+}
 
 // Close closes all Handles associated with this MultiHandle.
 func (mh MultiHandle) Close() error {
-	return concurrent.Range(mh, func(name string, h Handle) error {
-		if err := h.Close(); err != nil {
-			return fmt.Errorf("plugin %q failed to close: %v", name, err)
-		}
-		return nil
+	return concurrent.Range(mh, func(_ int, h Handle) error {
+		return h.Close()
 	})
 }
 
 // ServiceGenerator returns a ServiceGenerator which calls into the
 // ServiceGenerators of all plugins associated with this MultiHandle and
 // consolidates their results.
-func (mh MultiHandle) ServiceGenerator() api.ServiceGenerator {
-	msg := make(MultiServiceGenerator, len(mh))
-	for name, h := range mh {
+func (mh MultiHandle) ServiceGenerator() ServiceGenerator {
+	msg := make(MultiServiceGenerator, 0, len(mh))
+	for _, h := range mh {
 		sg := h.ServiceGenerator()
 		if sg != nil {
-			msg[name] = sg
+			msg = append(msg, sg)
 		}
-	}
-	if len(msg) == 0 {
-		return nil
 	}
 	return msg
 }
 
 // MultiServiceGenerator wraps a collection of ServiceGenerators into a single
 // ServiceGenerator.
-type MultiServiceGenerator map[string]api.ServiceGenerator
+type MultiServiceGenerator []ServiceGenerator
+
+// Handle returns a reference to the Handle that owns this ServiceGenerator.
+func (msg MultiServiceGenerator) Handle() Handle {
+	mh := make(MultiHandle, len(msg))
+	for i, sg := range msg {
+		mh[i] = sg.Handle()
+	}
+	return mh
+}
 
 // Generate calls all the service generators associated with this plugin and
 // consolidates their output.
@@ -73,22 +86,23 @@ func (msg MultiServiceGenerator) Generate(req *api.GenerateServiceRequest) (*api
 		usedPaths = make(map[string]string) // path -> plugin name
 	)
 
-	err := concurrent.Range(msg, func(name string, sg api.ServiceGenerator) error {
+	err := concurrent.Range(msg, func(_ int, sg ServiceGenerator) error {
 		res, err := sg.Generate(req)
 		if err != nil {
-			return fmt.Errorf("plugin %q failed to generate service code: %v", name, err)
+			return err
 		}
 
 		lock.Lock()
 		defer lock.Unlock()
 
+		pluginName := sg.Handle().Name()
 		for path, contents := range res.Files {
 			if takenBy, taken := usedPaths[path]; taken {
 				return fmt.Errorf("plugin conflict: cannot write file %q for plugin %q: "+
-					"plugin %q already wrote to that file", path, name, takenBy)
+					"plugin %q already wrote to that file", path, pluginName, takenBy)
 			}
 
-			usedPaths[path] = name
+			usedPaths[path] = pluginName
 			files[path] = contents
 		}
 

--- a/internal/plugin/multi.go
+++ b/internal/plugin/multi.go
@@ -54,8 +54,7 @@ func (mh MultiHandle) Close() error {
 func (mh MultiHandle) ServiceGenerator() ServiceGenerator {
 	msg := make(MultiServiceGenerator, 0, len(mh))
 	for _, h := range mh {
-		sg := h.ServiceGenerator()
-		if sg != nil {
+		if sg := h.ServiceGenerator(); sg != nil {
 			msg = append(msg, sg)
 		}
 	}

--- a/internal/plugin/transport_test.go
+++ b/internal/plugin/transport_test.go
@@ -328,7 +328,8 @@ func TestServiceGeneratorGenerate(t *testing.T) {
 		{
 			desc:          "call error",
 			generateError: errors.New("great sadness"),
-			wantError:     "TApplicationException{Message: great sadness, Type: InternalError}",
+			wantError: `plugin "foo" failed to generate service code: ` +
+				"TApplicationException{Message: great sadness, Type: InternalError}",
 		},
 	}
 


### PR DESCRIPTION
This changes MultiHandle and MultiServiceGenerator to stop keying off of the
plugin name. An advantage of this is that plugin names are no longer required
to be unique so we don't have to worry about builtin plugins conflicting with
user plugins. Additionally, this also makes parameterized plugins possible.
That is, you could now have a plugin which generates significantly different
code based on its command line arguments and have it used twice in the same
thriftrw invocation:

    -p 'myplugin --generateA' -p 'myplugin --generateB'

CC @prashantv @breerly @kriskowal