### PR TITLE
naming: Handle unknown abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ v0.2.0 (unreleased)
     Initially, only the generated code for `service` declarations is
     customizable. Check the documentation for more details.
 
+-   Breaking: Fixed a bug where all-caps attributes that are not known
+    abbreviations were changed to PascalCase.
+
 
 v0.1.0 (2016-08-31)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ v0.2.0 (unreleased)
 -   Breaking: Fixed a bug where all-caps attributes that are not known
     abbreviations were changed to PascalCase.
 
+-   Breaking: The `String()` method for `enum` types now returns the name of
+    the item as specified in the Thrift file.
+
 
 v0.1.0 (2016-08-31)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ v0.2.0 (unreleased)
     ThriftRW now provides a plugin system to allow customizing code generation.
     Initially, only the generated code for `service` declarations is
     customizable. Check the documentation for more details.
-
 -   Breaking: Fixed a bug where all-caps attributes that are not known
     abbreviations were changed to PascalCase.
-
 -   Breaking: The `String()` method for `enum` types now returns the name of
     the item as specified in the Thrift file.
 

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -68,7 +68,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		<if .Spec.Items>
 			const (
 			<range .Spec.Items>
-				<$enumName><goCase .Name> <$enumName> = <.Value>
+				<enumItemName $enumName .Name> <$enumName> = <.Value>
 			<end>
 			)
 		<end>
@@ -90,7 +90,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 				switch <$w> {
 				<range .UniqueItems>
 					case <.Value>:
-						return "<goCase .Name>"
+						return "<.Name>"
 				<end>
 				}
 			<end>
@@ -103,7 +103,9 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		}{
 			Spec:        spec,
 			UniqueItems: items,
-		})
+		},
+		TemplateFunc("enumItemName", enumItemName),
+	)
 
 	return wrapGenerateError(spec.Name, err)
 }

--- a/gen/string.go
+++ b/gen/string.go
@@ -38,14 +38,9 @@ func isAllCaps(s string) bool {
 	return true
 }
 
-// goCase converts strings into PascalCase.
-func goCase(s string) string {
-	if len(s) == 0 {
-		panic(fmt.Sprintf("%q is not a valid identifier", s))
-	}
-
-	chunks := strings.Split(s, "_")
-	for i, chunk := range chunks {
+// pascalCase combines the given words using PascalCase.
+func pascalCase(words ...string) string {
+	for i, chunk := range words {
 		if len(chunk) == 0 {
 			// foo__bar
 			continue
@@ -54,25 +49,42 @@ func goCase(s string) string {
 		// known initalism
 		init := strings.ToUpper(chunk)
 		if _, ok := commonInitialisms[init]; ok {
-			chunks[i] = init
+			words[i] = init
 			continue
 		}
 
 		// Was SCREAMING_SNAKE_CASE and not a known initialism so Titlecase it.
-		if isAllCaps(chunk) && len(chunks) > 1 {
+		if isAllCaps(chunk) && len(words) > 1 {
 			// A single ALLCAPS word does not count as SCREAMING_SNAKE_CASE.
 			// There must be at least one underscore.
-			chunks[i] = strings.Title(strings.ToLower(chunk))
+			words[i] = strings.Title(strings.ToLower(chunk))
 			continue
 		}
 
 		// Just another word, but could already be camelCased somehow, so just
 		// change the first letter.
 		head, headIndex := utf8.DecodeRuneInString(chunk)
-		chunks[i] = string(unicode.ToUpper(head)) + string(chunk[headIndex:])
+		words[i] = string(unicode.ToUpper(head)) + string(chunk[headIndex:])
 	}
 
-	return strings.Join(chunks, "")
+	return strings.Join(words, "")
+}
+
+// enumItemName returns the Go name that should be used for an enum item with
+// the given Thrift name.
+func enumItemName(enumName string, itemName string) string {
+	words := []string{enumName}
+	words = append(words, strings.Split(itemName, "_")...)
+	return pascalCase(words...)
+}
+
+// goCase converts strings into PascalCase.
+func goCase(s string) string {
+	if len(s) == 0 {
+		panic(fmt.Sprintf("%q is not a valid identifier", s))
+	}
+
+	return pascalCase(strings.Split(s, "_")...)
 }
 
 // This set is taken from https://github.com/golang/lint/blob/master/lint.go#L692

--- a/gen/string.go
+++ b/gen/string.go
@@ -59,7 +59,9 @@ func goCase(s string) string {
 		}
 
 		// Was SCREAMING_SNAKE_CASE and not a known initialism so Titlecase it.
-		if isAllCaps(chunk) {
+		if isAllCaps(chunk) && len(chunks) > 1 {
+			// A single ALLCAPS word does not count as SCREAMING_SNAKE_CASE.
+			// There must be at least one underscore.
 			chunks[i] = strings.Title(strings.ToLower(chunk))
 			continue
 		}

--- a/gen/string_test.go
+++ b/gen/string_test.go
@@ -26,6 +26,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPascalCase(t *testing.T) {
+	tests := []struct {
+		input  []string
+		output string
+	}{
+		{
+			input:  []string{"snake", "case"},
+			output: "SnakeCase",
+		},
+		{
+			input:  []string{"get", "ZIP", "code"},
+			output: "GetZipCode",
+		},
+		{
+			input:  []string{"IP"},
+			output: "IP",
+		},
+		{
+			input:  []string{"VIP"},
+			output: "VIP",
+		},
+		{
+			input:  []string{"MyEnum", "FOO"},
+			output: "MyEnumFoo",
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.output, pascalCase(tt.input...))
+	}
+}
+
 func TestGoCase(t *testing.T) {
 	tests := []struct {
 		input  string
@@ -48,5 +80,33 @@ func TestGoCase(t *testing.T) {
 
 	for _, tt := range tests {
 		assert.Equal(t, tt.output, goCase(tt.input))
+	}
+}
+
+func TestEnumItemName(t *testing.T) {
+	tests := []struct {
+		enumName string
+		itemName string
+		want     string
+	}{
+		{
+			enumName: "MyEnum",
+			itemName: "foo",
+			want:     "MyEnumFoo",
+		},
+		{
+			enumName: "Role",
+			itemName: "USER",
+			want:     "RoleUser",
+		},
+		{
+			enumName: "Type",
+			itemName: "FIRST_NAME",
+			want:     "TypeFirstName",
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, enumItemName(tt.enumName, tt.itemName))
 	}
 }

--- a/gen/string_test.go
+++ b/gen/string_test.go
@@ -41,6 +41,9 @@ func TestGoCase(t *testing.T) {
 		{"ALL_CAPS_WITH_UNDERSCORE", "AllCapsWithUnderscore"},
 		{"get_user_id", "GetUserID"},
 		{"GET_USER_ID", "GetUserID"},
+		{"IP", "IP"},
+		{"ZIPCode", "ZIPCode"},
+		{"VIP", "VIP"}, // not a known abbreviation
 	}
 
 	for _, tt := range tests {

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -904,8 +904,8 @@ func TestStructJSON(t *testing.T) {
 			`{"name":"foo","contact":{"emailAddress":""}}`,
 		},
 		{&tu.EmptyUnion{}, "{}"},
-		{&tu.Document{Pdf: td.Pdf("hello")}, `{"pdf":"aGVsbG8="}`},
-		{&tu.Document{Pdf: td.Pdf{}}, `{"pdf":""}`},
+		{&tu.Document{Pdf: td.PDF("hello")}, `{"pdf":"aGVsbG8="}`},
+		{&tu.Document{Pdf: td.PDF{}}, `{"pdf":""}`},
 		{
 			&tu.Document{PlainText: stringp("hello")},
 			`{"pdf":null,"plainText":"hello"}`,
@@ -1243,7 +1243,7 @@ func TestStructValidation(t *testing.T) {
 		{
 			desc: "Document: multiple",
 			serialize: &tu.Document{
-				Pdf:       td.Pdf{},
+				Pdf:       td.PDF{},
 				PlainText: stringp("hello"),
 			},
 			deserialize: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -161,6 +161,36 @@ func (v EnumWithValues) String() string {
 	return fmt.Sprintf("EnumWithValues(%d)", w)
 }
 
+type RecordType int32
+
+const (
+	RecordTypeName        RecordType = 0
+	RecordTypeHomeAddress RecordType = 1
+	RecordTypeWorkAddress RecordType = 2
+)
+
+func (v RecordType) ToWire() (wire.Value, error) {
+	return wire.NewValueI32(int32(v)), nil
+}
+
+func (v *RecordType) FromWire(w wire.Value) error {
+	*v = (RecordType)(w.GetI32())
+	return nil
+}
+
+func (v RecordType) String() string {
+	w := int32(v)
+	switch w {
+	case 0:
+		return "NAME"
+	case 1:
+		return "HOME_ADDRESS"
+	case 2:
+		return "WORK_ADDRESS"
+	}
+	return fmt.Sprintf("RecordType(%d)", w)
+}
+
 type StructWithOptionalEnum struct {
 	E *EnumDefault `json:"e,omitempty"`
 }

--- a/gen/testdata/thrift/enums.thrift
+++ b/gen/testdata/thrift/enums.thrift
@@ -25,3 +25,9 @@ enum EnumWithDuplicateName {
 struct StructWithOptionalEnum {
     1: optional EnumDefault e
 }
+
+enum RecordType {
+  NAME,
+  HOME_ADDRESS,
+  WORK_ADDRESS
+}

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -441,21 +441,21 @@ func (v *MyEnum) FromWire(w wire.Value) error {
 	return err
 }
 
-type Pdf []byte
+type PDF []byte
 
-func (v Pdf) ToWire() (wire.Value, error) {
+func (v PDF) ToWire() (wire.Value, error) {
 	x := ([]byte)(v)
 	return wire.NewValueBinary(x), error(nil)
 }
 
-func (v Pdf) String() string {
+func (v PDF) String() string {
 	x := ([]byte)(v)
 	return fmt.Sprint(x)
 }
 
-func (v *Pdf) FromWire(w wire.Value) error {
+func (v *PDF) FromWire(w wire.Value) error {
 	x, err := w.GetBinary(), error(nil)
-	*v = (Pdf)(x)
+	*v = (PDF)(x)
 	return err
 }
 

--- a/gen/testdata/unions/types.go
+++ b/gen/testdata/unions/types.go
@@ -282,7 +282,7 @@ func (v *ArbitraryValue) String() string {
 }
 
 type Document struct {
-	Pdf       typedefs.Pdf `json:"pdf"`
+	Pdf       typedefs.PDF `json:"pdf"`
 	PlainText *string      `json:"plainText,omitempty"`
 }
 
@@ -315,8 +315,8 @@ func (v *Document) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _Pdf_Read(w wire.Value) (typedefs.Pdf, error) {
-	var x typedefs.Pdf
+func _PDF_Read(w wire.Value) (typedefs.PDF, error) {
+	var x typedefs.PDF
 	err := x.FromWire(w)
 	return x, err
 }
@@ -327,7 +327,7 @@ func (v *Document) FromWire(w wire.Value) error {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
-				v.Pdf, err = _Pdf_Read(field.Value)
+				v.Pdf, err = _PDF_Read(field.Value)
 				if err != nil {
 					return err
 				}

--- a/gen/typedef_test.go
+++ b/gen/typedef_test.go
@@ -70,17 +70,17 @@ func TestTypedefString(t *testing.T) {
 
 func TestTypedefBinary(t *testing.T) {
 	tests := []struct {
-		x td.Pdf
+		x td.PDF
 		v wire.Value
 	}{
 		{
-			td.Pdf{1, 2, 3},
+			td.PDF{1, 2, 3},
 			wire.NewValueBinary([]byte{1, 2, 3}),
 		},
 	}
 
 	for _, tt := range tests {
-		assertRoundTrip(t, &tt.x, tt.v, "Pdf")
+		assertRoundTrip(t, &tt.x, tt.v, "PDF")
 	}
 }
 


### PR DESCRIPTION
This changes naming in generated code in the following ways:

-   If an attribute is all-caps and is not a known abbreviation, we use it as-
    is.
-   Even if an enum item is all caps, we PascalCase it when we prepend the
    enum name.

Resolves #208 