### PR TITLE
Add -v/--version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Releases
 v0.2.0 (unreleased)
 -------------------
 
--   Add a plugin system.
+-   Added a `-v`/`--version` flag.
+
+-   Added a plugin system.
 
     ThriftRW now provides a plugin system to allow customizing code generation.
     Initially, only the generated code for `service` declarations is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ v0.2.0 (unreleased)
 -------------------
 
 -   Added a `-v`/`--version` flag.
-
 -   Added a plugin system.
 
     ThriftRW now provides a plugin system to allow customizing code generation.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-WANT_VERSION = $(shell grep '^v\d' CHANGELOG.md | head -n1 | awk '{print $$1}')
+WANT_VERSION = $(shell grep '^v\d' CHANGELOG.md | head -n1 | cut -d' ' -f1)
 
 # Minor versions of Go for which the lint check should be run.
 LINTABLE_MINOR_VERSIONS := 6

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-WANT_VERSION = $(shell grep '^v\d' CHANGELOG.md | head -n1 | cut -d' ' -f1)
+WANT_VERSION = $(shell grep '^v[0-9]' CHANGELOG.md | head -n1 | cut -d' ' -f1)
 
 # Minor versions of Go for which the lint check should be run.
 LINTABLE_MINOR_VERSIONS := 6

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+WANT_VERSION = $(shell grep '^v\d' CHANGELOG.md | head -n1 | awk '{print $$1}')
+
 # Minor versions of Go for which the lint check should be run.
 LINTABLE_MINOR_VERSIONS := 6
 
@@ -59,8 +61,19 @@ else
 	@echo "Skipping linters for $(GO_VERSION)"
 endif
 
+.PHONY: verifyVersion
+verifyVersion: build
+	@if [ "$$(./thriftrw-go --version)" != "thriftrw $(WANT_VERSION)" ]; then \
+		echo "Version number in version.go does not match CHANGELOG.md"; \
+		echo "Want: thriftrw $(WANT_VERSION)"; \
+		echo " Got: $$(./thriftrw-go --version)"; \
+		exit 1; \
+	else \
+		echo "thriftrw $(WANT_VERSION)"; \
+	fi
+
 .PHONY: test
-test: build
+test: build verifyVersion
 	go test -race $(PACKAGES)
 
 .PHONY: cover
@@ -98,5 +111,5 @@ build_ci: build
 lint_ci: lint
 
 .PHONY: test_ci
-test_ci: build_ci
+test_ci: build_ci verifyVersion
 	./scripts/cover.sh $(shell go list $(PACKAGES))

--- a/main.go
+++ b/main.go
@@ -36,20 +36,23 @@ import (
 )
 
 type options struct {
+	DisplayVersion bool       `long:"version" short:"v" description:"Show the ThriftRW version number"`
+	GOpts          genOptions `group:"Generator Options"`
+}
+
+type genOptions struct {
 	OutputDirectory string `long:"out" short:"o" value-name:"DIR" description:"Directory to which the generated files will be written."`
+	PackagePrefix   string `long:"pkg-prefix" value-name:"PREFIX" description:"Prefix for import paths of generated module. By default, this is based on the output directory's location relativet o $GOPATH."`
+	ThriftRoot      string `long:"thrift-root" value-name:"DIR" description:"Directory whose descendants contain all Thrift files. The structure of the generated Go packages mirrors the paths to the Thrift files relative to this directory. By default, this is the deepest common ancestor directory of the Thrift files."`
 
-	PackagePrefix string `long:"pkg-prefix" value-name:"PREFIX" description:"Prefix for import paths of generated module. By default, this is based on the output directory's location relativet o $GOPATH."`
-	ThriftRoot    string `long:"thrift-root" value-name:"DIR" description:"Directory whose descendants contain all Thrift files. The structure of the generated Go packages mirrors the paths to the Thrift files relative to this directory. By default, this is the deepest common ancestor directory of the Thrift files."`
-
-	NoRecurse bool `long:"no-recurse" description:"Don't generate code for included Thrift files."`
-	YARPC     bool `long:"yarpc" description:"Generate code for YARPC. Defaults to false."`
-
+	NoRecurse bool         `long:"no-recurse" description:"Don't generate code for included Thrift files."`
+	YARPC     bool         `long:"yarpc" description:"Generate code for YARPC. Defaults to false."`
+	Plugins   plugin.Flags `long:"plugin" short:"p" value-name:"PLUGIN" description:"Code generation plugin for ThriftRW. This option may be provided multiple times to apply multiple plugins."`
 	// TODO(abg): Drop --yarpc flag
-
-	Plugins plugin.Flags `long:"plugin" short:"p" value-name:"PLUGIN" description:"Code generation plugin for ThriftRW. This option may be provided multiple times to apply multiple plugins."`
 
 	// TODO(abg): Detailed help with examples of --thrift-root, --pkg-prefix,
 	// and --plugin
+
 }
 
 func main() {
@@ -61,6 +64,11 @@ func main() {
 	args, err := parser.Parse()
 	if err != nil {
 		return // message already printed by go-flags
+	}
+
+	if opts.DisplayVersion {
+		fmt.Println("thriftrw", version)
+		os.Exit(0)
 	}
 
 	if len(args) != 1 {
@@ -76,16 +84,17 @@ func main() {
 		log.Fatalf("error describing file %q: %v", inputFile, err)
 	}
 
-	if len(opts.OutputDirectory) == 0 {
-		opts.OutputDirectory = "."
+	gopts := opts.GOpts
+	if len(gopts.OutputDirectory) == 0 {
+		gopts.OutputDirectory = "."
 	}
-	opts.OutputDirectory, err = filepath.Abs(opts.OutputDirectory)
+	gopts.OutputDirectory, err = filepath.Abs(gopts.OutputDirectory)
 	if err != nil {
-		log.Fatalf("could not resolve path %q: %v", opts.OutputDirectory, err)
+		log.Fatalf("could not resolve path %q: %v", gopts.OutputDirectory, err)
 	}
 
-	if opts.PackagePrefix == "" {
-		opts.PackagePrefix, err = determinePackagePrefix(opts.OutputDirectory)
+	if gopts.PackagePrefix == "" {
+		gopts.PackagePrefix, err = determinePackagePrefix(gopts.OutputDirectory)
 		if err != nil {
 			log.Fatalf("could not determine the package prefix: %v", err)
 		}
@@ -96,33 +105,33 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if opts.ThriftRoot == "" {
-		opts.ThriftRoot, err = findCommonAncestor(module)
+	if gopts.ThriftRoot == "" {
+		gopts.ThriftRoot, err = findCommonAncestor(module)
 		if err != nil {
 			log.Fatal(err)
 		}
 	} else {
-		opts.ThriftRoot, err = filepath.Abs(opts.ThriftRoot)
+		gopts.ThriftRoot, err = filepath.Abs(gopts.ThriftRoot)
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := verifyAncestry(module, opts.ThriftRoot); err != nil {
+		if err := verifyAncestry(module, gopts.ThriftRoot); err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	pluginHandle, err := opts.Plugins.Handle()
+	pluginHandle, err := gopts.Plugins.Handle()
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer pluginHandle.Close()
 
 	generatorOptions := gen.Options{
-		OutputDir:     opts.OutputDirectory,
-		PackagePrefix: opts.PackagePrefix,
-		ThriftRoot:    opts.ThriftRoot,
-		NoRecurse:     opts.NoRecurse,
-		YARPC:         opts.YARPC,
+		OutputDir:     gopts.OutputDirectory,
+		PackagePrefix: gopts.PackagePrefix,
+		ThriftRoot:    gopts.ThriftRoot,
+		NoRecurse:     gopts.NoRecurse,
+		YARPC:         gopts.YARPC,
 		Plugin:        pluginHandle,
 	}
 	if err := gen.Generate(module, &generatorOptions); err != nil {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+var version = "v0.2.0"


### PR DESCRIPTION
    $ thriftrw-go --version
    thriftrw v0.2.0

`make test` verifies that the version number on the top of the changelog
matches `--version`. Example failure:

    Version number in version.go does not match CHANGELOG.md
    Want: thriftrw v0.2.0
     Got: thriftrw v0.2.1
    make: *** [verifyVersion] Error 1

Resolves #210

CC @prashantv @kriskowal @breerly @bombela