### PR TITLE
Naming: Fix all-caps constant naming

### DIFF
--- a/gen/constant.go
+++ b/gen/constant.go
@@ -30,10 +30,11 @@ import (
 // Constant generates code for `const` expressions in Thrift files.
 func Constant(g Generator, c *compile.Constant) error {
 	err := g.DeclareFromTemplate(
-		`<if canBeConstant .Type>const<else>var<end> <goCase .Name> <typeReference .Type> = <constantValue .Value .Type>`,
+		`<if canBeConstant .Type>const<else>var<end> <constantName .Name> <typeReference .Type> = <constantValue .Value .Type>`,
 		c,
 		TemplateFunc("constantValue", ConstantValue),
 		TemplateFunc("canBeConstant", canBeConstant),
+		TemplateFunc("constantName", constantName),
 	)
 	return wrapGenerateError(c.Name, err)
 }
@@ -200,7 +201,7 @@ func constantStruct(g Generator, v *compile.ConstantStruct, t compile.TypeSpec) 
 }
 
 func enumItemReference(g Generator, v compile.EnumItemReference, t compile.TypeSpec) (_ string, err error) {
-	s, err := g.TextTemplate(`<typeName .Enum><goCase .Item.Name>`, v)
+	s, err := g.TextTemplate(`<enumItemName (typeName .Enum) .Item.Name>`, v, TemplateFunc("enumItemName", enumItemName))
 	if err != nil {
 		return "", err
 	}

--- a/gen/constant.go
+++ b/gen/constant.go
@@ -201,7 +201,7 @@ func constantStruct(g Generator, v *compile.ConstantStruct, t compile.TypeSpec) 
 }
 
 func enumItemReference(g Generator, v compile.EnumItemReference, t compile.TypeSpec) (_ string, err error) {
-	s, err := g.TextTemplate(`<enumItemName (typeName .Enum) .Item.Name>`, v, TemplateFunc("enumItemName", enumItemName))
+	s, err := g.TextTemplate(`<enumItemName .Enum .Item.Name>`, v, TemplateFunc("enumItemName", enumItemName))
 	if err != nil {
 		return "", err
 	}

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -20,7 +20,11 @@
 
 package gen
 
-import "github.com/thriftrw/thriftrw-go/compile"
+import (
+	"strings"
+
+	"github.com/thriftrw/thriftrw-go/compile"
+)
 
 // enumGenerator generates code to serialize and deserialize enums.
 type enumGenerator struct {
@@ -67,8 +71,9 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 
 		<if .Spec.Items>
 			const (
+			<$enum := .Spec>
 			<range .Spec.Items>
-				<enumItemName $enumName .Name> <$enumName> = <.Value>
+				<enumItemName $enum .Name> <$enumName> = <.Value>
 			<end>
 			)
 		<end>
@@ -108,6 +113,16 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 	)
 
 	return wrapGenerateError(spec.Name, err)
+}
+
+// enumItemName returns the Go name that should be used for an enum item with
+// the given Thrift name.
+func enumItemName(g Generator, spec compile.TypeSpec, itemName string) (string, error) {
+	enumName, err := typeName(g, spec)
+	if err != nil {
+		return "", err
+	}
+	return enumName + pascalCase(false /* all caps */, strings.Split(itemName, "_")...), nil
 }
 
 // enumUniqueItems returns a subset of the given list of enum items where

--- a/gen/enum_test.go
+++ b/gen/enum_test.go
@@ -162,6 +162,18 @@ func TestEnumString(t *testing.T) {
 			te.EnumWithDuplicateValuesQ,
 			"Q",
 		},
+		{
+			te.LowerCaseEnumWith,
+			"with",
+		},
+		{
+			te.LowerCaseEnumLowerCase,
+			"lower_case",
+		},
+		{
+			te.LowerCaseEnumItems,
+			"items",
+		},
 	}
 
 	for _, tt := range tests {

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -161,7 +161,7 @@ func (g *generator) LookupConstantName(c *compile.Constant) (string, error) {
 		return "", err
 	}
 
-	name := goCase(c.Name)
+	name := constantName(c.Name)
 	if importPath != g.ImportPath {
 		pkg := g.Import(importPath)
 		name = pkg + "." + name

--- a/gen/string.go
+++ b/gen/string.go
@@ -78,12 +78,6 @@ func constantName(s string) string {
 	return pascalCase(false /* all caps */, strings.Split(s, "_")...)
 }
 
-// enumItemName returns the Go name that should be used for an enum item with
-// the given Thrift name.
-func enumItemName(enumName string, itemName string) string {
-	return enumName + pascalCase(false /* all caps */, strings.Split(itemName, "_")...)
-}
-
 // goCase converts strings into PascalCase.
 func goCase(s string) string {
 	if len(s) == 0 {

--- a/gen/string.go
+++ b/gen/string.go
@@ -39,7 +39,11 @@ func isAllCaps(s string) bool {
 }
 
 // pascalCase combines the given words using PascalCase.
-func pascalCase(words ...string) string {
+//
+// If allowAllCaps is true, when an all-caps word that is not a known
+// abbreviation is encountered, it is left unchanged. Otherwise, it is
+// Titlecased.
+func pascalCase(allowAllCaps bool, words ...string) string {
 	for i, chunk := range words {
 		if len(chunk) == 0 {
 			// foo__bar
@@ -54,7 +58,7 @@ func pascalCase(words ...string) string {
 		}
 
 		// Was SCREAMING_SNAKE_CASE and not a known initialism so Titlecase it.
-		if isAllCaps(chunk) && len(words) > 1 {
+		if isAllCaps(chunk) && !allowAllCaps {
 			// A single ALLCAPS word does not count as SCREAMING_SNAKE_CASE.
 			// There must be at least one underscore.
 			words[i] = strings.Title(strings.ToLower(chunk))
@@ -70,12 +74,14 @@ func pascalCase(words ...string) string {
 	return strings.Join(words, "")
 }
 
+func constantName(s string) string {
+	return pascalCase(false /* all caps */, strings.Split(s, "_")...)
+}
+
 // enumItemName returns the Go name that should be used for an enum item with
 // the given Thrift name.
 func enumItemName(enumName string, itemName string) string {
-	words := []string{enumName}
-	words = append(words, strings.Split(itemName, "_")...)
-	return pascalCase(words...)
+	return enumName + pascalCase(false /* all caps */, strings.Split(itemName, "_")...)
 }
 
 // goCase converts strings into PascalCase.
@@ -84,7 +90,10 @@ func goCase(s string) string {
 		panic(fmt.Sprintf("%q is not a valid identifier", s))
 	}
 
-	return pascalCase(strings.Split(s, "_")...)
+	words := strings.Split(s, "_")
+	return pascalCase(len(words) == 1 /* all caps */, words...)
+	// goCase allows all caps only if the string is a single all caps word.
+	// That is, "FOO" is allowed but "FOO_BAR" is changed to "FooBar".
 }
 
 // This set is taken from https://github.com/golang/lint/blob/master/lint.go#L692

--- a/gen/string_test.go
+++ b/gen/string_test.go
@@ -96,34 +96,6 @@ func TestGoCase(t *testing.T) {
 	}
 }
 
-func TestEnumItemName(t *testing.T) {
-	tests := []struct {
-		enumName string
-		itemName string
-		want     string
-	}{
-		{
-			enumName: "MyEnum",
-			itemName: "foo",
-			want:     "MyEnumFoo",
-		},
-		{
-			enumName: "Role",
-			itemName: "USER",
-			want:     "RoleUser",
-		},
-		{
-			enumName: "Type",
-			itemName: "FIRST_NAME",
-			want:     "TypeFirstName",
-		},
-	}
-
-	for _, tt := range tests {
-		assert.Equal(t, tt.want, enumItemName(tt.enumName, tt.itemName))
-	}
-}
-
 func TestConstantName(t *testing.T) {
 	tests := []struct {
 		give string

--- a/gen/string_test.go
+++ b/gen/string_test.go
@@ -28,33 +28,46 @@ import (
 
 func TestPascalCase(t *testing.T) {
 	tests := []struct {
-		input  []string
-		output string
+		allCaps bool
+		words   []string
+		output  string
 	}{
 		{
-			input:  []string{"snake", "case"},
+			words:  []string{"snake", "case"},
 			output: "SnakeCase",
 		},
 		{
-			input:  []string{"get", "ZIP", "code"},
+			words:  []string{"get", "ZIP", "code"},
 			output: "GetZipCode",
 		},
 		{
-			input:  []string{"IP"},
+			allCaps: true,
+			words:   []string{"get", "ZIP", "code"},
+			output:  "GetZIPCode",
+		},
+		{
+			words:  []string{"IP"},
 			output: "IP",
 		},
 		{
-			input:  []string{"VIP"},
-			output: "VIP",
+			allCaps: true,
+			words:   []string{"VIP"},
+			output:  "VIP",
 		},
 		{
-			input:  []string{"MyEnum", "FOO"},
-			output: "MyEnumFoo",
+			allCaps: false,
+			words:   []string{"VIP"},
+			output:  "Vip",
+		},
+		{
+			allCaps: false,
+			words:   []string{"MyEnum", "FOO"},
+			output:  "MyEnumFoo",
 		},
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.output, pascalCase(tt.input...))
+		assert.Equal(t, tt.output, pascalCase(tt.allCaps, tt.words...))
 	}
 }
 
@@ -108,5 +121,25 @@ func TestEnumItemName(t *testing.T) {
 
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, enumItemName(tt.enumName, tt.itemName))
+	}
+}
+
+func TestConstantName(t *testing.T) {
+	tests := []struct {
+		give string
+		want string
+	}{
+		{
+			give: "VERSION",
+			want: "Version",
+		},
+		{
+			give: "API_VERSION",
+			want: "APIVersion",
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, constantName(tt.give))
 	}
 }

--- a/gen/testdata/constants/constants.go
+++ b/gen/testdata/constants/constants.go
@@ -13,6 +13,12 @@ import (
 	"github.com/thriftrw/thriftrw-go/gen/testdata/unions"
 )
 
+const Home enums.RecordType = enums.RecordTypeHomeAddress
+
+const Name enums.RecordType = enums.RecordTypeName
+
+const WorkAddress enums.RecordType = enums.RecordTypeWorkAddress
+
 func _bool_ptr(v bool) *bool {
 	return &v
 }

--- a/gen/testdata/constants/constants.go
+++ b/gen/testdata/constants/constants.go
@@ -58,6 +58,8 @@ var I128 *typedefs.I128 = &typedefs.I128{High: 1234, Low: 5678}
 
 var LastNode *structs.Node = &structs.Node{Value: 3}
 
+const Lower enums.LowerCaseEnum = enums.LowerCaseEnumItems
+
 const MyEnum typedefs.MyEnum = typedefs.MyEnum(enums.EnumWithValuesY)
 
 var Node *structs.Node = &structs.Node{Next: &structs.List{Next: &structs.List{Value: 3}, Value: 2}, Value: 1}

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -246,3 +246,33 @@ func (v *StructWithOptionalEnum) String() string {
 	}
 	return fmt.Sprintf("StructWithOptionalEnum{%v}", strings.Join(fields[:i], ", "))
 }
+
+type LowerCaseEnum int32
+
+const (
+	LowerCaseEnumWith      LowerCaseEnum = 0
+	LowerCaseEnumLowerCase LowerCaseEnum = 1
+	LowerCaseEnumItems     LowerCaseEnum = 2
+)
+
+func (v LowerCaseEnum) ToWire() (wire.Value, error) {
+	return wire.NewValueI32(int32(v)), nil
+}
+
+func (v *LowerCaseEnum) FromWire(w wire.Value) error {
+	*v = (LowerCaseEnum)(w.GetI32())
+	return nil
+}
+
+func (v LowerCaseEnum) String() string {
+	w := int32(v)
+	switch w {
+	case 0:
+		return "with"
+	case 1:
+		return "lower_case"
+	case 2:
+		return "items"
+	}
+	return fmt.Sprintf("LowerCaseEnum(%d)", w)
+}

--- a/gen/testdata/thrift/constants.thrift
+++ b/gen/testdata/thrift/constants.thrift
@@ -105,3 +105,5 @@ const typedefs.MyEnum myEnum = enums.EnumWithValues.Y
 const enums.RecordType NAME = enums.RecordType.NAME
 const enums.RecordType HOME = enums.RecordType.HOME_ADDRESS
 const enums.RecordType WORK_ADDRESS = enums.RecordType.WORK_ADDRESS
+
+const enums.lowerCaseEnum lower = enums.lowerCaseEnum.items

--- a/gen/testdata/thrift/constants.thrift
+++ b/gen/testdata/thrift/constants.thrift
@@ -101,3 +101,7 @@ const typedefs.FrameGroup frameGroup = [
 ]
 
 const typedefs.MyEnum myEnum = enums.EnumWithValues.Y
+
+const enums.RecordType NAME = enums.RecordType.NAME
+const enums.RecordType HOME = enums.RecordType.HOME_ADDRESS
+const enums.RecordType WORK_ADDRESS = enums.RecordType.WORK_ADDRESS

--- a/gen/testdata/thrift/enums.thrift
+++ b/gen/testdata/thrift/enums.thrift
@@ -31,3 +31,7 @@ enum RecordType {
   HOME_ADDRESS,
   WORK_ADDRESS
 }
+
+enum lowerCaseEnum {
+    with, lower_case, items
+}


### PR DESCRIPTION
Follow up to #209: That change would leave single word all caps constants
in that form as well. This fixes the behavior for constants to always pascal
case.

Resolves #215

CC @prashantv @breerly @kriskowal @bombela