### PR TITLE
Add canonical path to go.uber.org/thriftrw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 Releases
 ========
 
-v0.3.0 (2016-11-29)
+v0.3.1 (2016-09-30)
+-------------------
+
+-   Fix missing canonical import path to `go.uber.org/thriftrw`.
+
+
+v0.3.0 (2016-09-29)
 ------------------
 
 -   **Breaking**: Renamed project to `go.uber.org/thriftrw`.

--- a/version.go
+++ b/version.go
@@ -18,6 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package main // import "go.uber.org/thriftrw"
 
 var version = "v0.3.0"

--- a/version.go
+++ b/version.go
@@ -20,4 +20,4 @@
 
 package main // import "go.uber.org/thriftrw"
 
-var version = "v0.3.0"
+var version = "v0.3.1"


### PR DESCRIPTION
This should be a patch since installing github.com/thriftrw/thriftrw-go wont work.