### PR TITLE
gen: Use go.uber.org/yarpc for --yarpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 Releases
 ========
 
-v0.4.0 (unreleased)
+v0.3.2 (unreleased)
 ------------------
 
--   Nothing yet.
+-   Fix import paths for code generated using `--yarpc`. Note that this flag
+    will be removed in a future version.
 
 
 v0.3.1 (2016-09-30)

--- a/gen/yarpc.go
+++ b/gen/yarpc.go
@@ -78,8 +78,8 @@ func (yg yarpcGenerator) server(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 
 	err := yg.g.DeclareFromTemplate(
 		`
-		<$yarpc := import "github.com/yarpc/yarpc-go">
-		<$thrift := import "github.com/yarpc/yarpc-go/encoding/thrift">
+		<$yarpc := import "go.uber.org/yarpc">
+		<$thrift := import "go.uber.org/yarpc/encoding/thrift">
 		<$protocol := import "go.uber.org/thriftrw/protocol">
 		<$wire := import "go.uber.org/thriftrw/wire">
 		<$context := import "golang.org/x/net/context">
@@ -184,9 +184,9 @@ func (yg yarpcGenerator) client(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 
 	err := yg.g.DeclareFromTemplate(
 		`
-		<$yarpc := import "github.com/yarpc/yarpc-go">
-		<$transport := import "github.com/yarpc/yarpc-go/transport">
-		<$thrift := import "github.com/yarpc/yarpc-go/encoding/thrift">
+		<$yarpc := import "go.uber.org/yarpc">
+		<$transport := import "go.uber.org/yarpc/transport">
+		<$thrift := import "go.uber.org/yarpc/encoding/thrift">
 		<$protocol := import "go.uber.org/thriftrw/protocol">
 		<$context := import "golang.org/x/net/context">
 
@@ -279,8 +279,8 @@ func (yg yarpcGenerator) client(s *compile.ServiceSpec) (*bytes.Buffer, error) {
 func (yg yarpcGenerator) iface(s *compile.ServiceSpec, isServer bool) error {
 	return yg.g.DeclareFromTemplate(
 		`
-		<$yarpc := import "github.com/yarpc/yarpc-go">
-		<$thrift := import "github.com/yarpc/yarpc-go/encoding/thrift">
+		<$yarpc := import "go.uber.org/yarpc">
+		<$thrift := import "go.uber.org/yarpc/encoding/thrift">
 		<$context := import "golang.org/x/net/context">
 
 		type Interface interface {

--- a/main.go
+++ b/main.go
@@ -79,6 +79,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if opts.GOpts.YARPC {
+		log.Println("Warning: The --yarpc flag will be removed in a future version. " +
+			"You should use --plugin=yarpc instead. " +
+			"You will need to install the YARPC ThriftRW plugin:\n\n" +
+			"\tgo get go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc")
+	}
+
 	inputFile := args[0]
 	if _, err := os.Stat(inputFile); err != nil {
 		if os.IsNotExist(err) {

--- a/version.go
+++ b/version.go
@@ -20,4 +20,4 @@
 
 package main // import "go.uber.org/thriftrw"
 
-var version = "v0.4.0"
+var version = "v0.3.2"


### PR DESCRIPTION
The CLI now warns users that they should use `--plugin=yarpc`.

CC @breerly