### PR TITLE
compile: Expose annotations on typedefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v0.4.0 (unreleased)
 -   **Breaking**: The `compile` API now exposes annotations made while
     referencing native Thrift types. This changes the `TypeSpec`s for primitive
     types from values to types.
+-   The `compile` API now also exposes annotations for `typedef` declarations.
 -   Generate args structs and helpers for oneway functions.
 -   Expose whether a function is oneway to plugins.
 -   Expose the version of the library under `go.uber.org/thriftrw/version.Version`.

--- a/compile/typedef.go
+++ b/compile/typedef.go
@@ -29,9 +29,10 @@ import (
 type TypedefSpec struct {
 	linkOnce
 
-	Name   string
-	File   string
-	Target TypeSpec
+	Name        string
+	File        string
+	Target      TypeSpec
+	Annotations Annotations
 
 	root TypeSpec
 }
@@ -43,10 +44,16 @@ func compileTypedef(file string, src *ast.Typedef) (*TypedefSpec, error) {
 		return nil, err
 	}
 
+	annotations, err := compileAnnotations(src.Annotations)
+	if err != nil {
+		return nil, err
+	}
+
 	return &TypedefSpec{
-		Name:   src.Name,
-		File:   file,
-		Target: typ,
+		Name:        src.Name,
+		File:        file,
+		Target:      typ,
+		Annotations: annotations,
 	}, nil
 }
 

--- a/compile/typedef.go
+++ b/compile/typedef.go
@@ -46,7 +46,11 @@ func compileTypedef(file string, src *ast.Typedef) (*TypedefSpec, error) {
 
 	annotations, err := compileAnnotations(src.Annotations)
 	if err != nil {
-		return nil, err
+		return nil, compileError{
+			Target: src.Name,
+			Line:   src.Line,
+			Reason: err,
+		}
 	}
 
 	return &TypedefSpec{

--- a/compile/typedef_test.go
+++ b/compile/typedef_test.go
@@ -120,6 +120,7 @@ func TestCompileTypedefFailure(t *testing.T) {
 			`typedef i32 bar (a = "b", a, b)`,
 			nil,
 			[]string{
+				`cannot compile "bar" on line 1:`,
 				`annotation conflict: the name "a" has already been used on line 1`,
 			},
 		},

--- a/compile/typedef_test.go
+++ b/compile/typedef_test.go
@@ -52,13 +52,14 @@ func TestCompileTypedef(t *testing.T) {
 		spec  *TypedefSpec
 	}{
 		{
-			"typedef i64 timestamp",
+			`typedef i64 (js.type = "Long") timestamp (foo = "bar")`,
 			nil,
 			wire.TI64,
 			&TypedefSpec{
-				Name:   "timestamp",
-				File:   "test.thrift",
-				Target: &I64Spec{},
+				Name:        "timestamp",
+				File:        "test.thrift",
+				Target:      &I64Spec{Annotations: Annotations{"js.type": "Long"}},
+				Annotations: Annotations{"foo": "bar"},
 			},
 		},
 		{
@@ -114,6 +115,14 @@ func TestCompileTypedefFailure(t *testing.T) {
 				`could not resolve reference "foo"`,
 			},
 		},
+		{
+			"conflicting annotations",
+			`typedef i32 bar (a = "b", a, b)`,
+			nil,
+			[]string{
+				`annotation conflict: the name "a" has already been used on line 1`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -121,15 +130,13 @@ func TestCompileTypedefFailure(t *testing.T) {
 		scope := scopeOrDefault(tt.scope)
 
 		spec, err := compileTypedef("test.thrift", src)
-		if !assert.NoError(t, err, tt.desc) {
-			continue
+		if err == nil {
+			_, err = spec.Link(scope)
 		}
 
-		_, err = spec.Link(scope)
-		if assert.Error(t, err, tt.desc) {
-			for _, msg := range tt.messages {
-				assert.Contains(t, err.Error(), msg, tt.desc)
-			}
+		assert.Error(t, err, tt.desc)
+		for _, msg := range tt.messages {
+			assert.Contains(t, err.Error(), msg, tt.desc)
 		}
 	}
 }


### PR DESCRIPTION
This is a follow up to #195 and #243. It exposes annotations on the
compiled representation of typedefs. With this, all elements of the
Thrift AST that can have annotations now expose them in the compiled
specs.

CC @breerly @kriskowal @bombela