### PR TITLE
Generated enums first class JSON support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ v0.4.0 (2016-11-01)
 -   **Breaking**: The `compile` API now exposes annotations made while
     referencing native Thrift types. This changes the `TypeSpec`s for primitive
     types from values to types.
+-   **Breaking**: Generated enums now have first class JSON support. Enums are
+    (un)marshalled from/to strings if possible with fall back to integer.
 -   The `compile` API now also exposes annotations for `typedef` declarations.
 -   Generate args structs and helpers for oneway functions.
 -   Expose whether a function is oneway to plugins.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ v0.4.0 (2016-11-01)
     referencing native Thrift types. This changes the `TypeSpec`s for primitive
     types from values to types.
 -   **Breaking**: Generated enums now have first class JSON support. Enums are
-    (un)marshalled from/to strings if possible with fall back to integer.
+    (un)marshalled from/to strings if possible with fallback to integer for
+	unrecognized values.
 -   The `compile` API now also exposes annotations for `typedef` declarations.
 -   Generate args structs and helpers for oneway functions.
 -   Expose whether a function is oneway to plugins.

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -144,10 +144,10 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 					return <$err>
 				}
 				if <$x> <">="> 0x80000000 {
-					return <$fmt>.Errorf("enum overflow from JSON %q for \"<$enumName>\"", text)
+					return <$fmt>.Errorf("enum overflow from JSON %q for %q", text, "<$enumName>")
 				}
 				if <$x> <"<"> -0x80000000 {
-					return <$fmt>.Errorf("enum underflow from JSON %q for \"<$enumName>\"", text)
+					return <$fmt>.Errorf("enum underflow from JSON %q for %q", text, "<$enumName>")
 				}
 				*<$v> = (<$enumName>)(<$x>)
 				return nil
@@ -162,11 +162,11 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 						return nil
 				<end>
 					default:
-						return <$fmt>.Errorf("unknown enum value %q for \"<$enumName>\"", <$w>)
+						return <$fmt>.Errorf("unknown enum value %q for %q", <$w>, "<$enumName>")
 				}
 			}
 
-			return <$fmt>.Errorf("invalid JSON value %T $q to unmarshal into \"<$enumName>\"", <$t>, <$t>)
+			return <$fmt>.Errorf("invalid JSON value $q (%T) to unmarshal into %q", <$t>, <$t>, "<$enumName>")
 		}
 
 		func (<$v> *<$enumName>) UnmarshalJSON2(text []byte) error {

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -156,7 +156,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 				<$enum := .Spec>
 				<range .Spec.Items>
 					case "<.Name>":
-						*<$v> = <enumItemName $enum .Name>
+						*<$v> = <enumItemName $enumName .>
 						return nil
 				<end>
 					default:

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -166,39 +166,6 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 
 			return <$fmt>.Errorf("invalid JSON value %q (%T) to unmarshal into %q", <$t>, <$t>, "<$enumName>")
 		}
-
-		func (<$v> *<$enumName>) UnmarshalJSON2(<$text> []byte) error {
-			<$e := newVar "e">
-
-			<$w>, err := <$strconv>.ParseInt(string(<$text>), 10, 32)
-			if err == nil {
-				*<$v> = (<$enumName>)(<$w>)
-				return nil
-			}
-
-			<$e> := err.(*strconv.NumError)
-			if <$e>.Err != <$strconv>.ErrSyntax {
-				return err
-			}
-
-			<$s := newVar "s">
-			var <$s> string
-			if err := <$json>.Unmarshal(<$text>, &<$s>); err != nil {
-				return err
-			}
-
-			<if len .Spec.Items>
-				switch string(<$s>) {
-				<range .Spec.Items>
-					case "<.Name>":
-						*<$v> = (<$enumName>)(<.Value>)
-						return nil
-				<end>
-				}
-			<end>
-
-			return <$fmt>.Errorf("unknown enum value %q for \"<$enumName>\"", <$s>)
-		}
 		`,
 		struct {
 			Spec        *compile.EnumSpec

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -151,7 +151,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 				*<$v> = (<$enumName>)(<$x>)
 				return nil
 			case string:
-				switch string(<$w>) {
+				switch <$w> {
 				<$enum := .Spec>
 				<range .Spec.Items>
 					case "<.Name>":

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -106,7 +106,7 @@ func (v *MyEnum) UnmarshalJSON(text []byte) error {
 		*v = (MyEnum)(x)
 		return nil
 	case string:
-		switch string(w) {
+		switch w {
 		case "X":
 			*v = MyEnumX
 			return nil
@@ -662,7 +662,7 @@ func (v *MyEnum2) UnmarshalJSON(text []byte) error {
 		*v = (MyEnum2)(x)
 		return nil
 	case string:
-		switch string(w) {
+		switch w {
 		case "X":
 			*v = MyEnum2X
 			return nil

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"go.uber.org/thriftrw/wire"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -90,21 +91,21 @@ func (v *MyEnum) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
-	if w, ok := t.(json.Number); ok {
+	switch w := t.(type) {
+	case json.Number:
 		x, err := w.Int64()
 		if err != nil {
 			return err
 		}
-		if x >= 0x80000000 {
+		if x > math.MaxInt32 {
 			return fmt.Errorf("enum overflow from JSON %q for %q", text, "MyEnum")
 		}
-		if x < -0x80000000 {
+		if x < math.MinInt32 {
 			return fmt.Errorf("enum underflow from JSON %q for %q", text, "MyEnum")
 		}
 		*v = (MyEnum)(x)
 		return nil
-	}
-	if w, ok := t.(string); ok {
+	case string:
 		switch string(w) {
 		case "X":
 			*v = MyEnumX
@@ -124,8 +125,9 @@ func (v *MyEnum) UnmarshalJSON(text []byte) error {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "MyEnum")
 		}
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "MyEnum")
 	}
-	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "MyEnum")
 }
 
 type PrimitiveContainers struct {
@@ -645,21 +647,21 @@ func (v *MyEnum2) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
-	if w, ok := t.(json.Number); ok {
+	switch w := t.(type) {
+	case json.Number:
 		x, err := w.Int64()
 		if err != nil {
 			return err
 		}
-		if x >= 0x80000000 {
+		if x > math.MaxInt32 {
 			return fmt.Errorf("enum overflow from JSON %q for %q", text, "MyEnum2")
 		}
-		if x < -0x80000000 {
+		if x < math.MinInt32 {
 			return fmt.Errorf("enum underflow from JSON %q for %q", text, "MyEnum2")
 		}
 		*v = (MyEnum2)(x)
 		return nil
-	}
-	if w, ok := t.(string); ok {
+	case string:
 		switch string(w) {
 		case "X":
 			*v = MyEnum2X
@@ -673,8 +675,9 @@ func (v *MyEnum2) UnmarshalJSON(text []byte) error {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "MyEnum2")
 		}
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "MyEnum2")
 	}
-	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "MyEnum2")
 }
 
 type StructCollision2 struct {

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -4,9 +4,12 @@
 package collision
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"go.uber.org/thriftrw/wire"
+	"strconv"
 	"strings"
 )
 
@@ -62,6 +65,67 @@ func (v MyEnum) String() string {
 		return "foo_bar"
 	}
 	return fmt.Sprintf("MyEnum(%d)", w)
+}
+
+func (v MyEnum) MarshalJSON() ([]byte, error) {
+	switch int32(v) {
+	case 123:
+		return ([]byte)("\"X\""), nil
+	case 456:
+		return ([]byte)("\"Y\""), nil
+	case 789:
+		return ([]byte)("\"Z\""), nil
+	case 790:
+		return ([]byte)("\"FooBar\""), nil
+	case 791:
+		return ([]byte)("\"foo_bar\""), nil
+	}
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+func (v *MyEnum) UnmarshalJSON(text []byte) error {
+	d := json.NewDecoder(bytes.NewReader(text))
+	d.UseNumber()
+	t, err := d.Token()
+	if err != nil {
+		return err
+	}
+	if w, ok := t.(json.Number); ok {
+		x, err := w.Int64()
+		if err != nil {
+			return err
+		}
+		if x >= 0x80000000 {
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "MyEnum")
+		}
+		if x < -0x80000000 {
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "MyEnum")
+		}
+		*v = (MyEnum)(x)
+		return nil
+	}
+	if w, ok := t.(string); ok {
+		switch string(w) {
+		case "X":
+			*v = MyEnumX
+			return nil
+		case "Y":
+			*v = MyEnumY
+			return nil
+		case "Z":
+			*v = MyEnumZ
+			return nil
+		case "FooBar":
+			*v = MyEnumFooBar
+			return nil
+		case "foo_bar":
+			*v = MyEnumFooBar2
+			return nil
+		default:
+			return fmt.Errorf("unknown enum value %q for %q", w, "MyEnum")
+		}
+	}
+	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "MyEnum")
 }
 
 type PrimitiveContainers struct {
@@ -560,6 +624,57 @@ func (v MyEnum2) String() string {
 		return "Z"
 	}
 	return fmt.Sprintf("MyEnum2(%d)", w)
+}
+
+func (v MyEnum2) MarshalJSON() ([]byte, error) {
+	switch int32(v) {
+	case 12:
+		return ([]byte)("\"X\""), nil
+	case 34:
+		return ([]byte)("\"Y\""), nil
+	case 56:
+		return ([]byte)("\"Z\""), nil
+	}
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+func (v *MyEnum2) UnmarshalJSON(text []byte) error {
+	d := json.NewDecoder(bytes.NewReader(text))
+	d.UseNumber()
+	t, err := d.Token()
+	if err != nil {
+		return err
+	}
+	if w, ok := t.(json.Number); ok {
+		x, err := w.Int64()
+		if err != nil {
+			return err
+		}
+		if x >= 0x80000000 {
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "MyEnum2")
+		}
+		if x < -0x80000000 {
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "MyEnum2")
+		}
+		*v = (MyEnum2)(x)
+		return nil
+	}
+	if w, ok := t.(string); ok {
+		switch string(w) {
+		case "X":
+			*v = MyEnum2X
+			return nil
+		case "Y":
+			*v = MyEnum2Y
+			return nil
+		case "Z":
+			*v = MyEnum2Z
+			return nil
+		default:
+			return fmt.Errorf("unknown enum value %q for %q", w, "MyEnum2")
+		}
+	}
+	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "MyEnum2")
 }
 
 type StructCollision2 struct {

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -6,6 +6,7 @@ package enums
 import (
 	"fmt"
 	"go.uber.org/thriftrw/wire"
+	"strconv"
 	"strings"
 )
 
@@ -23,6 +24,23 @@ func (v *EmptyEnum) FromWire(w wire.Value) error {
 func (v EmptyEnum) String() string {
 	w := int32(v)
 	return fmt.Sprintf("EmptyEnum(%d)", w)
+}
+
+func (v EmptyEnum) MarshalText() (text []byte, err error) {
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+func (v EmptyEnum) UnmarshalText(text []byte) error {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
+		v = (EmptyEnum)(w)
+		return err
+	}
+	e := err.(*strconv.NumError)
+	if e.Err != strconv.ErrSyntax {
+		return err
+	}
+	return fmt.Errorf("impossible to unmarshal %q from %q", "EmptyEnum", text)
 }
 
 type EnumDefault int32
@@ -53,6 +71,43 @@ func (v EnumDefault) String() string {
 		return "Baz"
 	}
 	return fmt.Sprintf("EnumDefault(%d)", w)
+}
+
+func (v EnumDefault) MarshalText() (text []byte, err error) {
+	w := int32(v)
+	switch w {
+	case 0:
+		return ([]byte)("Foo"), nil
+	case 1:
+		return ([]byte)("Bar"), nil
+	case 2:
+		return ([]byte)("Baz"), nil
+	}
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+func (v EnumDefault) UnmarshalText(text []byte) error {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
+		v = (EnumDefault)(w)
+		return err
+	}
+	e := err.(*strconv.NumError)
+	if e.Err != strconv.ErrSyntax {
+		return err
+	}
+	switch string(text) {
+	case "Foo":
+		v = (EnumDefault)(0)
+		return nil
+	case "Bar":
+		v = (EnumDefault)(1)
+		return nil
+	case "Baz":
+		v = (EnumDefault)(2)
+		return nil
+	}
+	return fmt.Errorf("impossible to unmarshal %q from %q", "EnumDefault", text)
 }
 
 type EnumWithDuplicateName int32
@@ -103,6 +158,73 @@ func (v EnumWithDuplicateName) String() string {
 	return fmt.Sprintf("EnumWithDuplicateName(%d)", w)
 }
 
+func (v EnumWithDuplicateName) MarshalText() (text []byte, err error) {
+	w := int32(v)
+	switch w {
+	case 0:
+		return ([]byte)("A"), nil
+	case 1:
+		return ([]byte)("B"), nil
+	case 2:
+		return ([]byte)("C"), nil
+	case 3:
+		return ([]byte)("P"), nil
+	case 4:
+		return ([]byte)("Q"), nil
+	case 5:
+		return ([]byte)("R"), nil
+	case 6:
+		return ([]byte)("X"), nil
+	case 7:
+		return ([]byte)("Y"), nil
+	case 8:
+		return ([]byte)("Z"), nil
+	}
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+func (v EnumWithDuplicateName) UnmarshalText(text []byte) error {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
+		v = (EnumWithDuplicateName)(w)
+		return err
+	}
+	e := err.(*strconv.NumError)
+	if e.Err != strconv.ErrSyntax {
+		return err
+	}
+	switch string(text) {
+	case "A":
+		v = (EnumWithDuplicateName)(0)
+		return nil
+	case "B":
+		v = (EnumWithDuplicateName)(1)
+		return nil
+	case "C":
+		v = (EnumWithDuplicateName)(2)
+		return nil
+	case "P":
+		v = (EnumWithDuplicateName)(3)
+		return nil
+	case "Q":
+		v = (EnumWithDuplicateName)(4)
+		return nil
+	case "R":
+		v = (EnumWithDuplicateName)(5)
+		return nil
+	case "X":
+		v = (EnumWithDuplicateName)(6)
+		return nil
+	case "Y":
+		v = (EnumWithDuplicateName)(7)
+		return nil
+	case "Z":
+		v = (EnumWithDuplicateName)(8)
+		return nil
+	}
+	return fmt.Errorf("impossible to unmarshal %q from %q", "EnumWithDuplicateName", text)
+}
+
 type EnumWithDuplicateValues int32
 
 const (
@@ -129,6 +251,41 @@ func (v EnumWithDuplicateValues) String() string {
 		return "Q"
 	}
 	return fmt.Sprintf("EnumWithDuplicateValues(%d)", w)
+}
+
+func (v EnumWithDuplicateValues) MarshalText() (text []byte, err error) {
+	w := int32(v)
+	switch w {
+	case 0:
+		return ([]byte)("P"), nil
+	case -1:
+		return ([]byte)("Q"), nil
+	}
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+func (v EnumWithDuplicateValues) UnmarshalText(text []byte) error {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
+		v = (EnumWithDuplicateValues)(w)
+		return err
+	}
+	e := err.(*strconv.NumError)
+	if e.Err != strconv.ErrSyntax {
+		return err
+	}
+	switch string(text) {
+	case "P":
+		v = (EnumWithDuplicateValues)(0)
+		return nil
+	case "Q":
+		v = (EnumWithDuplicateValues)(-1)
+		return nil
+	case "R":
+		v = (EnumWithDuplicateValues)(0)
+		return nil
+	}
+	return fmt.Errorf("impossible to unmarshal %q from %q", "EnumWithDuplicateValues", text)
 }
 
 type EnumWithValues int32
@@ -161,6 +318,43 @@ func (v EnumWithValues) String() string {
 	return fmt.Sprintf("EnumWithValues(%d)", w)
 }
 
+func (v EnumWithValues) MarshalText() (text []byte, err error) {
+	w := int32(v)
+	switch w {
+	case 123:
+		return ([]byte)("X"), nil
+	case 456:
+		return ([]byte)("Y"), nil
+	case 789:
+		return ([]byte)("Z"), nil
+	}
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+func (v EnumWithValues) UnmarshalText(text []byte) error {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
+		v = (EnumWithValues)(w)
+		return err
+	}
+	e := err.(*strconv.NumError)
+	if e.Err != strconv.ErrSyntax {
+		return err
+	}
+	switch string(text) {
+	case "X":
+		v = (EnumWithValues)(123)
+		return nil
+	case "Y":
+		v = (EnumWithValues)(456)
+		return nil
+	case "Z":
+		v = (EnumWithValues)(789)
+		return nil
+	}
+	return fmt.Errorf("impossible to unmarshal %q from %q", "EnumWithValues", text)
+}
+
 type RecordType int32
 
 const (
@@ -189,6 +383,43 @@ func (v RecordType) String() string {
 		return "WORK_ADDRESS"
 	}
 	return fmt.Sprintf("RecordType(%d)", w)
+}
+
+func (v RecordType) MarshalText() (text []byte, err error) {
+	w := int32(v)
+	switch w {
+	case 0:
+		return ([]byte)("NAME"), nil
+	case 1:
+		return ([]byte)("HOME_ADDRESS"), nil
+	case 2:
+		return ([]byte)("WORK_ADDRESS"), nil
+	}
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+func (v RecordType) UnmarshalText(text []byte) error {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
+		v = (RecordType)(w)
+		return err
+	}
+	e := err.(*strconv.NumError)
+	if e.Err != strconv.ErrSyntax {
+		return err
+	}
+	switch string(text) {
+	case "NAME":
+		v = (RecordType)(0)
+		return nil
+	case "HOME_ADDRESS":
+		v = (RecordType)(1)
+		return nil
+	case "WORK_ADDRESS":
+		v = (RecordType)(2)
+		return nil
+	}
+	return fmt.Errorf("impossible to unmarshal %q from %q", "RecordType", text)
 }
 
 type StructWithOptionalEnum struct {
@@ -275,4 +506,41 @@ func (v LowerCaseEnum) String() string {
 		return "items"
 	}
 	return fmt.Sprintf("LowerCaseEnum(%d)", w)
+}
+
+func (v LowerCaseEnum) MarshalText() (text []byte, err error) {
+	w := int32(v)
+	switch w {
+	case 0:
+		return ([]byte)("containing"), nil
+	case 1:
+		return ([]byte)("lower_case"), nil
+	case 2:
+		return ([]byte)("items"), nil
+	}
+	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
+}
+
+func (v LowerCaseEnum) UnmarshalText(text []byte) error {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
+		v = (LowerCaseEnum)(w)
+		return err
+	}
+	e := err.(*strconv.NumError)
+	if e.Err != strconv.ErrSyntax {
+		return err
+	}
+	switch string(text) {
+	case "containing":
+		v = (LowerCaseEnum)(0)
+		return nil
+	case "lower_case":
+		v = (LowerCaseEnum)(1)
+		return nil
+	case "items":
+		v = (LowerCaseEnum)(2)
+		return nil
+	}
+	return fmt.Errorf("impossible to unmarshal %q from %q", "LowerCaseEnum", text)
 }

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -62,23 +62,6 @@ func (v *EmptyEnum) UnmarshalJSON(text []byte) error {
 	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EmptyEnum")
 }
 
-func (v *EmptyEnum) UnmarshalJSON2(text []byte) error {
-	w, err := strconv.ParseInt(string(text), 10, 32)
-	if err == nil {
-		*v = (EmptyEnum)(w)
-		return nil
-	}
-	e := err.(*strconv.NumError)
-	if e.Err != strconv.ErrSyntax {
-		return err
-	}
-	var s string
-	if err := json.Unmarshal(text, &s); err != nil {
-		return err
-	}
-	return fmt.Errorf("unknown enum value %q for \"EmptyEnum\"", s)
-}
-
 type EnumDefault int32
 
 const (
@@ -158,34 +141,6 @@ func (v *EnumDefault) UnmarshalJSON(text []byte) error {
 		}
 	}
 	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumDefault")
-}
-
-func (v *EnumDefault) UnmarshalJSON2(text []byte) error {
-	w, err := strconv.ParseInt(string(text), 10, 32)
-	if err == nil {
-		*v = (EnumDefault)(w)
-		return nil
-	}
-	e := err.(*strconv.NumError)
-	if e.Err != strconv.ErrSyntax {
-		return err
-	}
-	var s string
-	if err := json.Unmarshal(text, &s); err != nil {
-		return err
-	}
-	switch string(s) {
-	case "Foo":
-		*v = (EnumDefault)(0)
-		return nil
-	case "Bar":
-		*v = (EnumDefault)(1)
-		return nil
-	case "Baz":
-		*v = (EnumDefault)(2)
-		return nil
-	}
-	return fmt.Errorf("unknown enum value %q for \"EnumDefault\"", s)
 }
 
 type EnumWithDuplicateName int32
@@ -317,52 +272,6 @@ func (v *EnumWithDuplicateName) UnmarshalJSON(text []byte) error {
 	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateName")
 }
 
-func (v *EnumWithDuplicateName) UnmarshalJSON2(text []byte) error {
-	w, err := strconv.ParseInt(string(text), 10, 32)
-	if err == nil {
-		*v = (EnumWithDuplicateName)(w)
-		return nil
-	}
-	e := err.(*strconv.NumError)
-	if e.Err != strconv.ErrSyntax {
-		return err
-	}
-	var s string
-	if err := json.Unmarshal(text, &s); err != nil {
-		return err
-	}
-	switch string(s) {
-	case "A":
-		*v = (EnumWithDuplicateName)(0)
-		return nil
-	case "B":
-		*v = (EnumWithDuplicateName)(1)
-		return nil
-	case "C":
-		*v = (EnumWithDuplicateName)(2)
-		return nil
-	case "P":
-		*v = (EnumWithDuplicateName)(3)
-		return nil
-	case "Q":
-		*v = (EnumWithDuplicateName)(4)
-		return nil
-	case "R":
-		*v = (EnumWithDuplicateName)(5)
-		return nil
-	case "X":
-		*v = (EnumWithDuplicateName)(6)
-		return nil
-	case "Y":
-		*v = (EnumWithDuplicateName)(7)
-		return nil
-	case "Z":
-		*v = (EnumWithDuplicateName)(8)
-		return nil
-	}
-	return fmt.Errorf("unknown enum value %q for \"EnumWithDuplicateName\"", s)
-}
-
 type EnumWithDuplicateValues int32
 
 const (
@@ -438,34 +347,6 @@ func (v *EnumWithDuplicateValues) UnmarshalJSON(text []byte) error {
 		}
 	}
 	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateValues")
-}
-
-func (v *EnumWithDuplicateValues) UnmarshalJSON2(text []byte) error {
-	w, err := strconv.ParseInt(string(text), 10, 32)
-	if err == nil {
-		*v = (EnumWithDuplicateValues)(w)
-		return nil
-	}
-	e := err.(*strconv.NumError)
-	if e.Err != strconv.ErrSyntax {
-		return err
-	}
-	var s string
-	if err := json.Unmarshal(text, &s); err != nil {
-		return err
-	}
-	switch string(s) {
-	case "P":
-		*v = (EnumWithDuplicateValues)(0)
-		return nil
-	case "Q":
-		*v = (EnumWithDuplicateValues)(-1)
-		return nil
-	case "R":
-		*v = (EnumWithDuplicateValues)(0)
-		return nil
-	}
-	return fmt.Errorf("unknown enum value %q for \"EnumWithDuplicateValues\"", s)
 }
 
 type EnumWithValues int32
@@ -549,34 +430,6 @@ func (v *EnumWithValues) UnmarshalJSON(text []byte) error {
 	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithValues")
 }
 
-func (v *EnumWithValues) UnmarshalJSON2(text []byte) error {
-	w, err := strconv.ParseInt(string(text), 10, 32)
-	if err == nil {
-		*v = (EnumWithValues)(w)
-		return nil
-	}
-	e := err.(*strconv.NumError)
-	if e.Err != strconv.ErrSyntax {
-		return err
-	}
-	var s string
-	if err := json.Unmarshal(text, &s); err != nil {
-		return err
-	}
-	switch string(s) {
-	case "X":
-		*v = (EnumWithValues)(123)
-		return nil
-	case "Y":
-		*v = (EnumWithValues)(456)
-		return nil
-	case "Z":
-		*v = (EnumWithValues)(789)
-		return nil
-	}
-	return fmt.Errorf("unknown enum value %q for \"EnumWithValues\"", s)
-}
-
 type RecordType int32
 
 const (
@@ -656,34 +509,6 @@ func (v *RecordType) UnmarshalJSON(text []byte) error {
 		}
 	}
 	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "RecordType")
-}
-
-func (v *RecordType) UnmarshalJSON2(text []byte) error {
-	w, err := strconv.ParseInt(string(text), 10, 32)
-	if err == nil {
-		*v = (RecordType)(w)
-		return nil
-	}
-	e := err.(*strconv.NumError)
-	if e.Err != strconv.ErrSyntax {
-		return err
-	}
-	var s string
-	if err := json.Unmarshal(text, &s); err != nil {
-		return err
-	}
-	switch string(s) {
-	case "NAME":
-		*v = (RecordType)(0)
-		return nil
-	case "HOME_ADDRESS":
-		*v = (RecordType)(1)
-		return nil
-	case "WORK_ADDRESS":
-		*v = (RecordType)(2)
-		return nil
-	}
-	return fmt.Errorf("unknown enum value %q for \"RecordType\"", s)
 }
 
 type StructWithOptionalEnum struct {
@@ -821,32 +646,4 @@ func (v *LowerCaseEnum) UnmarshalJSON(text []byte) error {
 		}
 	}
 	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "LowerCaseEnum")
-}
-
-func (v *LowerCaseEnum) UnmarshalJSON2(text []byte) error {
-	w, err := strconv.ParseInt(string(text), 10, 32)
-	if err == nil {
-		*v = (LowerCaseEnum)(w)
-		return nil
-	}
-	e := err.(*strconv.NumError)
-	if e.Err != strconv.ErrSyntax {
-		return err
-	}
-	var s string
-	if err := json.Unmarshal(text, &s); err != nil {
-		return err
-	}
-	switch string(s) {
-	case "containing":
-		*v = (LowerCaseEnum)(0)
-		return nil
-	case "lower_case":
-		*v = (LowerCaseEnum)(1)
-		return nil
-	case "items":
-		*v = (LowerCaseEnum)(2)
-		return nil
-	}
-	return fmt.Errorf("unknown enum value %q for \"LowerCaseEnum\"", s)
 }

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -59,22 +59,22 @@ func (v *EmptyEnum) UnmarshalJSON(text []byte) error {
 			return fmt.Errorf("unknown enum value %q for %q", w, "EmptyEnum")
 		}
 	}
-	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EmptyEnum")
+	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EmptyEnum")
 }
 
 func (v *EmptyEnum) UnmarshalJSON2(text []byte) error {
-	w, err2 := strconv.ParseInt(string(text), 10, 32)
-	if err2 == nil {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
 		*v = (EmptyEnum)(w)
 		return nil
 	}
-	e := err2.(*strconv.NumError)
+	e := err.(*strconv.NumError)
 	if e.Err != strconv.ErrSyntax {
-		return err2
+		return err
 	}
 	var s string
-	if err2 := json.Unmarshal(text, &s); err2 != nil {
-		return err2
+	if err := json.Unmarshal(text, &s); err != nil {
+		return err
 	}
 	return fmt.Errorf("unknown enum value %q for \"EmptyEnum\"", s)
 }
@@ -110,8 +110,7 @@ func (v EnumDefault) String() string {
 }
 
 func (v EnumDefault) MarshalJSON() ([]byte, error) {
-	w := int32(v)
-	switch w {
+	switch int32(v) {
 	case 0:
 		return ([]byte)("\"Foo\""), nil
 	case 1:
@@ -158,22 +157,22 @@ func (v *EnumDefault) UnmarshalJSON(text []byte) error {
 			return fmt.Errorf("unknown enum value %q for %q", w, "EnumDefault")
 		}
 	}
-	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EnumDefault")
+	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumDefault")
 }
 
 func (v *EnumDefault) UnmarshalJSON2(text []byte) error {
-	w, err2 := strconv.ParseInt(string(text), 10, 32)
-	if err2 == nil {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
 		*v = (EnumDefault)(w)
 		return nil
 	}
-	e := err2.(*strconv.NumError)
+	e := err.(*strconv.NumError)
 	if e.Err != strconv.ErrSyntax {
-		return err2
+		return err
 	}
 	var s string
-	if err2 := json.Unmarshal(text, &s); err2 != nil {
-		return err2
+	if err := json.Unmarshal(text, &s); err != nil {
+		return err
 	}
 	switch string(s) {
 	case "Foo":
@@ -238,8 +237,7 @@ func (v EnumWithDuplicateName) String() string {
 }
 
 func (v EnumWithDuplicateName) MarshalJSON() ([]byte, error) {
-	w := int32(v)
-	switch w {
+	switch int32(v) {
 	case 0:
 		return ([]byte)("\"A\""), nil
 	case 1:
@@ -316,22 +314,22 @@ func (v *EnumWithDuplicateName) UnmarshalJSON(text []byte) error {
 			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithDuplicateName")
 		}
 	}
-	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateName")
+	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateName")
 }
 
 func (v *EnumWithDuplicateName) UnmarshalJSON2(text []byte) error {
-	w, err2 := strconv.ParseInt(string(text), 10, 32)
-	if err2 == nil {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
 		*v = (EnumWithDuplicateName)(w)
 		return nil
 	}
-	e := err2.(*strconv.NumError)
+	e := err.(*strconv.NumError)
 	if e.Err != strconv.ErrSyntax {
-		return err2
+		return err
 	}
 	var s string
-	if err2 := json.Unmarshal(text, &s); err2 != nil {
-		return err2
+	if err := json.Unmarshal(text, &s); err != nil {
+		return err
 	}
 	switch string(s) {
 	case "A":
@@ -394,8 +392,7 @@ func (v EnumWithDuplicateValues) String() string {
 }
 
 func (v EnumWithDuplicateValues) MarshalJSON() ([]byte, error) {
-	w := int32(v)
-	switch w {
+	switch int32(v) {
 	case 0:
 		return ([]byte)("\"P\""), nil
 	case -1:
@@ -440,22 +437,22 @@ func (v *EnumWithDuplicateValues) UnmarshalJSON(text []byte) error {
 			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithDuplicateValues")
 		}
 	}
-	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateValues")
+	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateValues")
 }
 
 func (v *EnumWithDuplicateValues) UnmarshalJSON2(text []byte) error {
-	w, err2 := strconv.ParseInt(string(text), 10, 32)
-	if err2 == nil {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
 		*v = (EnumWithDuplicateValues)(w)
 		return nil
 	}
-	e := err2.(*strconv.NumError)
+	e := err.(*strconv.NumError)
 	if e.Err != strconv.ErrSyntax {
-		return err2
+		return err
 	}
 	var s string
-	if err2 := json.Unmarshal(text, &s); err2 != nil {
-		return err2
+	if err := json.Unmarshal(text, &s); err != nil {
+		return err
 	}
 	switch string(s) {
 	case "P":
@@ -502,8 +499,7 @@ func (v EnumWithValues) String() string {
 }
 
 func (v EnumWithValues) MarshalJSON() ([]byte, error) {
-	w := int32(v)
-	switch w {
+	switch int32(v) {
 	case 123:
 		return ([]byte)("\"X\""), nil
 	case 456:
@@ -550,22 +546,22 @@ func (v *EnumWithValues) UnmarshalJSON(text []byte) error {
 			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithValues")
 		}
 	}
-	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EnumWithValues")
+	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithValues")
 }
 
 func (v *EnumWithValues) UnmarshalJSON2(text []byte) error {
-	w, err2 := strconv.ParseInt(string(text), 10, 32)
-	if err2 == nil {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
 		*v = (EnumWithValues)(w)
 		return nil
 	}
-	e := err2.(*strconv.NumError)
+	e := err.(*strconv.NumError)
 	if e.Err != strconv.ErrSyntax {
-		return err2
+		return err
 	}
 	var s string
-	if err2 := json.Unmarshal(text, &s); err2 != nil {
-		return err2
+	if err := json.Unmarshal(text, &s); err != nil {
+		return err
 	}
 	switch string(s) {
 	case "X":
@@ -612,8 +608,7 @@ func (v RecordType) String() string {
 }
 
 func (v RecordType) MarshalJSON() ([]byte, error) {
-	w := int32(v)
-	switch w {
+	switch int32(v) {
 	case 0:
 		return ([]byte)("\"NAME\""), nil
 	case 1:
@@ -660,22 +655,22 @@ func (v *RecordType) UnmarshalJSON(text []byte) error {
 			return fmt.Errorf("unknown enum value %q for %q", w, "RecordType")
 		}
 	}
-	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "RecordType")
+	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "RecordType")
 }
 
 func (v *RecordType) UnmarshalJSON2(text []byte) error {
-	w, err2 := strconv.ParseInt(string(text), 10, 32)
-	if err2 == nil {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
 		*v = (RecordType)(w)
 		return nil
 	}
-	e := err2.(*strconv.NumError)
+	e := err.(*strconv.NumError)
 	if e.Err != strconv.ErrSyntax {
-		return err2
+		return err
 	}
 	var s string
-	if err2 := json.Unmarshal(text, &s); err2 != nil {
-		return err2
+	if err := json.Unmarshal(text, &s); err != nil {
+		return err
 	}
 	switch string(s) {
 	case "NAME":
@@ -778,8 +773,7 @@ func (v LowerCaseEnum) String() string {
 }
 
 func (v LowerCaseEnum) MarshalJSON() ([]byte, error) {
-	w := int32(v)
-	switch w {
+	switch int32(v) {
 	case 0:
 		return ([]byte)("\"containing\""), nil
 	case 1:
@@ -826,22 +820,22 @@ func (v *LowerCaseEnum) UnmarshalJSON(text []byte) error {
 			return fmt.Errorf("unknown enum value %q for %q", w, "LowerCaseEnum")
 		}
 	}
-	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "LowerCaseEnum")
+	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "LowerCaseEnum")
 }
 
 func (v *LowerCaseEnum) UnmarshalJSON2(text []byte) error {
-	w, err2 := strconv.ParseInt(string(text), 10, 32)
-	if err2 == nil {
+	w, err := strconv.ParseInt(string(text), 10, 32)
+	if err == nil {
 		*v = (LowerCaseEnum)(w)
 		return nil
 	}
-	e := err2.(*strconv.NumError)
+	e := err.(*strconv.NumError)
 	if e.Err != strconv.ErrSyntax {
-		return err2
+		return err
 	}
 	var s string
-	if err2 := json.Unmarshal(text, &s); err2 != nil {
-		return err2
+	if err := json.Unmarshal(text, &s); err != nil {
+		return err
 	}
 	switch string(s) {
 	case "containing":

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go.uber.org/thriftrw/wire"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -39,27 +40,28 @@ func (v *EmptyEnum) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
-	if w, ok := t.(json.Number); ok {
+	switch w := t.(type) {
+	case json.Number:
 		x, err := w.Int64()
 		if err != nil {
 			return err
 		}
-		if x >= 0x80000000 {
+		if x > math.MaxInt32 {
 			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EmptyEnum")
 		}
-		if x < -0x80000000 {
+		if x < math.MinInt32 {
 			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EmptyEnum")
 		}
 		*v = (EmptyEnum)(x)
 		return nil
-	}
-	if w, ok := t.(string); ok {
+	case string:
 		switch string(w) {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "EmptyEnum")
 		}
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EmptyEnum")
 	}
-	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EmptyEnum")
 }
 
 type EnumDefault int32
@@ -111,21 +113,21 @@ func (v *EnumDefault) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
-	if w, ok := t.(json.Number); ok {
+	switch w := t.(type) {
+	case json.Number:
 		x, err := w.Int64()
 		if err != nil {
 			return err
 		}
-		if x >= 0x80000000 {
+		if x > math.MaxInt32 {
 			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EnumDefault")
 		}
-		if x < -0x80000000 {
+		if x < math.MinInt32 {
 			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EnumDefault")
 		}
 		*v = (EnumDefault)(x)
 		return nil
-	}
-	if w, ok := t.(string); ok {
+	case string:
 		switch string(w) {
 		case "Foo":
 			*v = EnumDefaultFoo
@@ -139,8 +141,9 @@ func (v *EnumDefault) UnmarshalJSON(text []byte) error {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "EnumDefault")
 		}
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumDefault")
 	}
-	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumDefault")
 }
 
 type EnumWithDuplicateName int32
@@ -222,21 +225,21 @@ func (v *EnumWithDuplicateName) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
-	if w, ok := t.(json.Number); ok {
+	switch w := t.(type) {
+	case json.Number:
 		x, err := w.Int64()
 		if err != nil {
 			return err
 		}
-		if x >= 0x80000000 {
+		if x > math.MaxInt32 {
 			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EnumWithDuplicateName")
 		}
-		if x < -0x80000000 {
+		if x < math.MinInt32 {
 			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EnumWithDuplicateName")
 		}
 		*v = (EnumWithDuplicateName)(x)
 		return nil
-	}
-	if w, ok := t.(string); ok {
+	case string:
 		switch string(w) {
 		case "A":
 			*v = EnumWithDuplicateNameA
@@ -268,8 +271,9 @@ func (v *EnumWithDuplicateName) UnmarshalJSON(text []byte) error {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithDuplicateName")
 		}
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateName")
 	}
-	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateName")
 }
 
 type EnumWithDuplicateValues int32
@@ -317,21 +321,21 @@ func (v *EnumWithDuplicateValues) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
-	if w, ok := t.(json.Number); ok {
+	switch w := t.(type) {
+	case json.Number:
 		x, err := w.Int64()
 		if err != nil {
 			return err
 		}
-		if x >= 0x80000000 {
+		if x > math.MaxInt32 {
 			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EnumWithDuplicateValues")
 		}
-		if x < -0x80000000 {
+		if x < math.MinInt32 {
 			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EnumWithDuplicateValues")
 		}
 		*v = (EnumWithDuplicateValues)(x)
 		return nil
-	}
-	if w, ok := t.(string); ok {
+	case string:
 		switch string(w) {
 		case "P":
 			*v = EnumWithDuplicateValuesP
@@ -345,8 +349,9 @@ func (v *EnumWithDuplicateValues) UnmarshalJSON(text []byte) error {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithDuplicateValues")
 		}
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateValues")
 	}
-	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateValues")
 }
 
 type EnumWithValues int32
@@ -398,21 +403,21 @@ func (v *EnumWithValues) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
-	if w, ok := t.(json.Number); ok {
+	switch w := t.(type) {
+	case json.Number:
 		x, err := w.Int64()
 		if err != nil {
 			return err
 		}
-		if x >= 0x80000000 {
+		if x > math.MaxInt32 {
 			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EnumWithValues")
 		}
-		if x < -0x80000000 {
+		if x < math.MinInt32 {
 			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EnumWithValues")
 		}
 		*v = (EnumWithValues)(x)
 		return nil
-	}
-	if w, ok := t.(string); ok {
+	case string:
 		switch string(w) {
 		case "X":
 			*v = EnumWithValuesX
@@ -426,8 +431,9 @@ func (v *EnumWithValues) UnmarshalJSON(text []byte) error {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithValues")
 		}
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithValues")
 	}
-	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithValues")
 }
 
 type RecordType int32
@@ -479,21 +485,21 @@ func (v *RecordType) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
-	if w, ok := t.(json.Number); ok {
+	switch w := t.(type) {
+	case json.Number:
 		x, err := w.Int64()
 		if err != nil {
 			return err
 		}
-		if x >= 0x80000000 {
+		if x > math.MaxInt32 {
 			return fmt.Errorf("enum overflow from JSON %q for %q", text, "RecordType")
 		}
-		if x < -0x80000000 {
+		if x < math.MinInt32 {
 			return fmt.Errorf("enum underflow from JSON %q for %q", text, "RecordType")
 		}
 		*v = (RecordType)(x)
 		return nil
-	}
-	if w, ok := t.(string); ok {
+	case string:
 		switch string(w) {
 		case "NAME":
 			*v = RecordTypeName
@@ -507,8 +513,9 @@ func (v *RecordType) UnmarshalJSON(text []byte) error {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "RecordType")
 		}
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "RecordType")
 	}
-	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "RecordType")
 }
 
 type StructWithOptionalEnum struct {
@@ -616,21 +623,21 @@ func (v *LowerCaseEnum) UnmarshalJSON(text []byte) error {
 	if err != nil {
 		return err
 	}
-	if w, ok := t.(json.Number); ok {
+	switch w := t.(type) {
+	case json.Number:
 		x, err := w.Int64()
 		if err != nil {
 			return err
 		}
-		if x >= 0x80000000 {
+		if x > math.MaxInt32 {
 			return fmt.Errorf("enum overflow from JSON %q for %q", text, "LowerCaseEnum")
 		}
-		if x < -0x80000000 {
+		if x < math.MinInt32 {
 			return fmt.Errorf("enum underflow from JSON %q for %q", text, "LowerCaseEnum")
 		}
 		*v = (LowerCaseEnum)(x)
 		return nil
-	}
-	if w, ok := t.(string); ok {
+	case string:
 		switch string(w) {
 		case "containing":
 			*v = LowerCaseEnumContaining
@@ -644,6 +651,7 @@ func (v *LowerCaseEnum) UnmarshalJSON(text []byte) error {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "LowerCaseEnum")
 		}
+	default:
+		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "LowerCaseEnum")
 	}
-	return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "LowerCaseEnum")
 }

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -55,7 +55,7 @@ func (v *EmptyEnum) UnmarshalJSON(text []byte) error {
 		*v = (EmptyEnum)(x)
 		return nil
 	case string:
-		switch string(w) {
+		switch w {
 		default:
 			return fmt.Errorf("unknown enum value %q for %q", w, "EmptyEnum")
 		}
@@ -128,7 +128,7 @@ func (v *EnumDefault) UnmarshalJSON(text []byte) error {
 		*v = (EnumDefault)(x)
 		return nil
 	case string:
-		switch string(w) {
+		switch w {
 		case "Foo":
 			*v = EnumDefaultFoo
 			return nil
@@ -240,7 +240,7 @@ func (v *EnumWithDuplicateName) UnmarshalJSON(text []byte) error {
 		*v = (EnumWithDuplicateName)(x)
 		return nil
 	case string:
-		switch string(w) {
+		switch w {
 		case "A":
 			*v = EnumWithDuplicateNameA
 			return nil
@@ -336,7 +336,7 @@ func (v *EnumWithDuplicateValues) UnmarshalJSON(text []byte) error {
 		*v = (EnumWithDuplicateValues)(x)
 		return nil
 	case string:
-		switch string(w) {
+		switch w {
 		case "P":
 			*v = EnumWithDuplicateValuesP
 			return nil
@@ -418,7 +418,7 @@ func (v *EnumWithValues) UnmarshalJSON(text []byte) error {
 		*v = (EnumWithValues)(x)
 		return nil
 	case string:
-		switch string(w) {
+		switch w {
 		case "X":
 			*v = EnumWithValuesX
 			return nil
@@ -500,7 +500,7 @@ func (v *RecordType) UnmarshalJSON(text []byte) error {
 		*v = (RecordType)(x)
 		return nil
 	case string:
-		switch string(w) {
+		switch w {
 		case "NAME":
 			*v = RecordTypeName
 			return nil
@@ -638,7 +638,7 @@ func (v *LowerCaseEnum) UnmarshalJSON(text []byte) error {
 		*v = (LowerCaseEnum)(x)
 		return nil
 	case string:
-		switch string(w) {
+		switch w {
 		case "containing":
 			*v = LowerCaseEnumContaining
 			return nil

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -45,10 +45,10 @@ func (v *EmptyEnum) UnmarshalJSON(text []byte) error {
 			return err
 		}
 		if x >= 0x80000000 {
-			return fmt.Errorf("enum overflow from JSON %q for \"EmptyEnum\"", text)
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EmptyEnum")
 		}
 		if x < -0x80000000 {
-			return fmt.Errorf("enum underflow from JSON %q for \"EmptyEnum\"", text)
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EmptyEnum")
 		}
 		*v = (EmptyEnum)(x)
 		return nil
@@ -56,10 +56,10 @@ func (v *EmptyEnum) UnmarshalJSON(text []byte) error {
 	if w, ok := t.(string); ok {
 		switch string(w) {
 		default:
-			return fmt.Errorf("unknown enum value %q for \"EmptyEnum\"", w)
+			return fmt.Errorf("unknown enum value %q for %q", w, "EmptyEnum")
 		}
 	}
-	return fmt.Errorf("invalid JSON value %T $q to unmarshal into \"EmptyEnum\"", t, t)
+	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EmptyEnum")
 }
 
 func (v *EmptyEnum) UnmarshalJSON2(text []byte) error {
@@ -135,10 +135,10 @@ func (v *EnumDefault) UnmarshalJSON(text []byte) error {
 			return err
 		}
 		if x >= 0x80000000 {
-			return fmt.Errorf("enum overflow from JSON %q for \"EnumDefault\"", text)
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EnumDefault")
 		}
 		if x < -0x80000000 {
-			return fmt.Errorf("enum underflow from JSON %q for \"EnumDefault\"", text)
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EnumDefault")
 		}
 		*v = (EnumDefault)(x)
 		return nil
@@ -155,10 +155,10 @@ func (v *EnumDefault) UnmarshalJSON(text []byte) error {
 			*v = EnumDefaultBaz
 			return nil
 		default:
-			return fmt.Errorf("unknown enum value %q for \"EnumDefault\"", w)
+			return fmt.Errorf("unknown enum value %q for %q", w, "EnumDefault")
 		}
 	}
-	return fmt.Errorf("invalid JSON value %T $q to unmarshal into \"EnumDefault\"", t, t)
+	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EnumDefault")
 }
 
 func (v *EnumDefault) UnmarshalJSON2(text []byte) error {
@@ -275,10 +275,10 @@ func (v *EnumWithDuplicateName) UnmarshalJSON(text []byte) error {
 			return err
 		}
 		if x >= 0x80000000 {
-			return fmt.Errorf("enum overflow from JSON %q for \"EnumWithDuplicateName\"", text)
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EnumWithDuplicateName")
 		}
 		if x < -0x80000000 {
-			return fmt.Errorf("enum underflow from JSON %q for \"EnumWithDuplicateName\"", text)
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EnumWithDuplicateName")
 		}
 		*v = (EnumWithDuplicateName)(x)
 		return nil
@@ -313,10 +313,10 @@ func (v *EnumWithDuplicateName) UnmarshalJSON(text []byte) error {
 			*v = EnumWithDuplicateNameZ
 			return nil
 		default:
-			return fmt.Errorf("unknown enum value %q for \"EnumWithDuplicateName\"", w)
+			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithDuplicateName")
 		}
 	}
-	return fmt.Errorf("invalid JSON value %T $q to unmarshal into \"EnumWithDuplicateName\"", t, t)
+	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateName")
 }
 
 func (v *EnumWithDuplicateName) UnmarshalJSON2(text []byte) error {
@@ -417,10 +417,10 @@ func (v *EnumWithDuplicateValues) UnmarshalJSON(text []byte) error {
 			return err
 		}
 		if x >= 0x80000000 {
-			return fmt.Errorf("enum overflow from JSON %q for \"EnumWithDuplicateValues\"", text)
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EnumWithDuplicateValues")
 		}
 		if x < -0x80000000 {
-			return fmt.Errorf("enum underflow from JSON %q for \"EnumWithDuplicateValues\"", text)
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EnumWithDuplicateValues")
 		}
 		*v = (EnumWithDuplicateValues)(x)
 		return nil
@@ -437,10 +437,10 @@ func (v *EnumWithDuplicateValues) UnmarshalJSON(text []byte) error {
 			*v = EnumWithDuplicateValuesR
 			return nil
 		default:
-			return fmt.Errorf("unknown enum value %q for \"EnumWithDuplicateValues\"", w)
+			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithDuplicateValues")
 		}
 	}
-	return fmt.Errorf("invalid JSON value %T $q to unmarshal into \"EnumWithDuplicateValues\"", t, t)
+	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateValues")
 }
 
 func (v *EnumWithDuplicateValues) UnmarshalJSON2(text []byte) error {
@@ -527,10 +527,10 @@ func (v *EnumWithValues) UnmarshalJSON(text []byte) error {
 			return err
 		}
 		if x >= 0x80000000 {
-			return fmt.Errorf("enum overflow from JSON %q for \"EnumWithValues\"", text)
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "EnumWithValues")
 		}
 		if x < -0x80000000 {
-			return fmt.Errorf("enum underflow from JSON %q for \"EnumWithValues\"", text)
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "EnumWithValues")
 		}
 		*v = (EnumWithValues)(x)
 		return nil
@@ -547,10 +547,10 @@ func (v *EnumWithValues) UnmarshalJSON(text []byte) error {
 			*v = EnumWithValuesZ
 			return nil
 		default:
-			return fmt.Errorf("unknown enum value %q for \"EnumWithValues\"", w)
+			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithValues")
 		}
 	}
-	return fmt.Errorf("invalid JSON value %T $q to unmarshal into \"EnumWithValues\"", t, t)
+	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "EnumWithValues")
 }
 
 func (v *EnumWithValues) UnmarshalJSON2(text []byte) error {
@@ -637,10 +637,10 @@ func (v *RecordType) UnmarshalJSON(text []byte) error {
 			return err
 		}
 		if x >= 0x80000000 {
-			return fmt.Errorf("enum overflow from JSON %q for \"RecordType\"", text)
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "RecordType")
 		}
 		if x < -0x80000000 {
-			return fmt.Errorf("enum underflow from JSON %q for \"RecordType\"", text)
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "RecordType")
 		}
 		*v = (RecordType)(x)
 		return nil
@@ -657,10 +657,10 @@ func (v *RecordType) UnmarshalJSON(text []byte) error {
 			*v = RecordTypeWorkAddress
 			return nil
 		default:
-			return fmt.Errorf("unknown enum value %q for \"RecordType\"", w)
+			return fmt.Errorf("unknown enum value %q for %q", w, "RecordType")
 		}
 	}
-	return fmt.Errorf("invalid JSON value %T $q to unmarshal into \"RecordType\"", t, t)
+	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "RecordType")
 }
 
 func (v *RecordType) UnmarshalJSON2(text []byte) error {
@@ -803,10 +803,10 @@ func (v *LowerCaseEnum) UnmarshalJSON(text []byte) error {
 			return err
 		}
 		if x >= 0x80000000 {
-			return fmt.Errorf("enum overflow from JSON %q for \"LowerCaseEnum\"", text)
+			return fmt.Errorf("enum overflow from JSON %q for %q", text, "LowerCaseEnum")
 		}
 		if x < -0x80000000 {
-			return fmt.Errorf("enum underflow from JSON %q for \"LowerCaseEnum\"", text)
+			return fmt.Errorf("enum underflow from JSON %q for %q", text, "LowerCaseEnum")
 		}
 		*v = (LowerCaseEnum)(x)
 		return nil
@@ -823,10 +823,10 @@ func (v *LowerCaseEnum) UnmarshalJSON(text []byte) error {
 			*v = LowerCaseEnumItems
 			return nil
 		default:
-			return fmt.Errorf("unknown enum value %q for \"LowerCaseEnum\"", w)
+			return fmt.Errorf("unknown enum value %q for %q", w, "LowerCaseEnum")
 		}
 	}
-	return fmt.Errorf("invalid JSON value %T $q to unmarshal into \"LowerCaseEnum\"", t, t)
+	return fmt.Errorf("invalid JSON value $q (%T) to unmarshal into %q", t, t, "LowerCaseEnum")
 }
 
 func (v *LowerCaseEnum) UnmarshalJSON2(text []byte) error {


### PR DESCRIPTION
Implements https://golang.org/pkg/encoding/json/#Marshaler for generated enum types.

enums are marshaled to a JSON string, with fall back to a JSON number. unmarshalling is symetrical.

fix #214