### PR TITLE
internal: Make go generate Just Work™

### DIFF
--- a/internal/plugin/gen.go
+++ b/internal/plugin/gen.go
@@ -21,3 +21,4 @@
 package plugin
 
 //go:generate ./gen.sh
+//go:generate ../../scripts/updateLicenses.sh

--- a/internal/plugin/gen.sh
+++ b/internal/plugin/gen.sh
@@ -21,8 +21,9 @@ INTERFACES=Handle,ServiceGenerator
 DESTINATION=handletest/mock.go
 PACKAGENAME=handletest
 
+go build go.uber.org/thriftrw/vendor/github.com/golang/mock/mockgen
 mkdir -p _mockgen
-mockgen -prog_only "$PACKAGE" "$INTERFACES" > _mockgen/main.go
+./mockgen -prog_only "$PACKAGE" "$INTERFACES" > _mockgen/main.go
 go build -o _mockgen/gen _mockgen/main.go
-mockgen -self_package "$PACKAGENAME" -package "$PACKAGENAME" -destination "$DESTINATION" -exec_only _mockgen/gen "$PACKAGE" "$INTERFACES"
-rm -r _mockgen
+./mockgen -self_package "$PACKAGENAME" -package "$PACKAGENAME" -destination "$DESTINATION" -exec_only _mockgen/gen "$PACKAGE" "$INTERFACES"
+rm -r _mockgen mockgen


### PR DESCRIPTION
We have a little hack in place in internal/plugin so that we can generate
mocks for an internal interface. That relies on having access to the binary of
mockgen compiled from vendor/. Previously, we expected the caller to install
that binary but that breaks other mockgen calls. This changes the script to
build its own binary for this call.

CC @kriskowal @bombela