### PR TITLE
version: Add thriftrw.disableVersionCheck tag

### DIFF
--- a/version/check.go
+++ b/version/check.go
@@ -18,23 +18,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// +build !thriftrw.disableVersionCheck
+
 package version
 
-// Version is the current ThriftRW version.
-const Version = "0.5.0"
+import "log"
 
-var genCodeCompatbilityRange = computeGenCodeCompabilityRange()
-
-type genCodeCompatbilityRangeHolder struct {
-	begin semVer
-	end   semVer
-}
-
-func computeGenCodeCompabilityRange() (r genCodeCompatbilityRangeHolder) {
-	r.begin = parseSemVerOrPanic(Version)
-	r.begin.Patch = 0
-	r.end = r.begin
-	r.end.Minor++
-	r.end.Pre = nil
-	return r
+// CheckCompatWithGeneratedCodeAt will panic if the ThriftRW version used to
+// generated code (given by `genCodeVersion`) is not compatible with the
+// current version of ThriftRW.
+// This function is designed to be called during initialization of the
+// generated code.
+//
+// Rationale: It is possible that the old generated code is not compatible with
+// the new version of ThriftRW in subtle ways but still compiles successfully.
+// This function will ensure that the version mismatch is detected and help
+// avoid bugs that could be caused by this discrepancy.
+func CheckCompatWithGeneratedCodeAt(genCodeVersion string, fromPkg string) {
+	genv := parseSemVerOrPanic(genCodeVersion)
+	compatible := (genv.Compare(&genCodeCompatbilityRange.begin) >= 0 &&
+		genv.Compare(&genCodeCompatbilityRange.end) < 0)
+	if !compatible {
+		log.Panicf(`incompatible version from generated package %q, expected >=%s and <%s, got %s`,
+			fromPkg, &genCodeCompatbilityRange.begin,
+			&genCodeCompatbilityRange.end, &genv)
+	}
 }

--- a/version/no_check.go
+++ b/version/no_check.go
@@ -18,23 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// +build thriftrw.disableVersionCheck
+
 package version
 
-// Version is the current ThriftRW version.
-const Version = "0.5.0"
-
-var genCodeCompatbilityRange = computeGenCodeCompabilityRange()
-
-type genCodeCompatbilityRangeHolder struct {
-	begin semVer
-	end   semVer
-}
-
-func computeGenCodeCompabilityRange() (r genCodeCompatbilityRangeHolder) {
-	r.begin = parseSemVerOrPanic(Version)
-	r.begin.Patch = 0
-	r.end = r.begin
-	r.end.Minor++
-	r.end.Pre = nil
-	return r
+// CheckCompatWithGeneratedCodeAt will panic if the ThriftRW version used to
+// generated code (given by `genCodeVersion`) is not compatible with the
+// current version of ThriftRW.
+// This function is designed to be called during initialization of the
+// generated code.
+//
+// Rationale: It is possible that the old generated code is not compatible with
+// the new version of ThriftRW in subtle ways but still compiles successfully.
+// This function will ensure that the version mismatch is detected and help
+// avoid bugs that could be caused by this discrepancy.
+func CheckCompatWithGeneratedCodeAt(string, string) {
+	// This version does not do anything. It is used only when the
+	// disableVersionCheck is used. Use the following command to build a
+	// binary with this tag.
+	//
+	// 	go build -tags thriftrw.disableVersionCheck
 }


### PR DESCRIPTION
This adds a `thriftrw.disableVersionCheck` build tag which disables the
version check for generated code when enabled. By default, the version check
is still enabled. To disable version checks, use

    go build -tags=thriftrw.disableVersionCheck

The generated executable will no longer have that check.

We need this so that we can use development versions of thriftrw to generate
internal Thrift code.

@bombela @kriskowal