### PR TITLE
make: Add generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,18 @@ LINT_EXCLUDES := $(GENERATED_GO_FILES) $(LINT_EXCLUDES_EXTRAS)
 # Pipe lint output into this to filter out ignored files.
 FILTER_LINT := grep -v $(patsubst %,-e %, $(LINT_EXCLUDES))
 
+BUILD_FLAGS ?=
+
 .PHONY: build
 build:
-	go build -i
+	go build -i $(BUILD_FLAGS)
+
+.PHONY: generate
+generate:
+	go build -i -tags=thriftrw.disableVersionCheck
+	PATH=$$(pwd):$$PATH go generate $$(glide nv)
+	make -C ./gen/testdata
+	./scripts/updateLicenses.sh
 
 .PHONY: lint
 lint:

--- a/gen/testdata/Makefile
+++ b/gen/testdata/Makefile
@@ -12,7 +12,7 @@ clean:
 	rm -rf $(PACKAGES)
 
 $(THRIFTRW):
-	make -C $(ROOT) build
+	make -C $(ROOT) build BUILD_FLAGS=-tags=thriftrw.disableVersionCheck
 
 %: thrift/%.thrift $(THRIFTRW)
 	$(THRIFTRW) --no-recurse $<

--- a/internal/plugin/gen.sh
+++ b/internal/plugin/gen.sh
@@ -24,6 +24,6 @@ PACKAGENAME=handletest
 go build go.uber.org/thriftrw/vendor/github.com/golang/mock/mockgen
 mkdir -p _mockgen
 ./mockgen -prog_only "$PACKAGE" "$INTERFACES" > _mockgen/main.go
-go build -o _mockgen/gen _mockgen/main.go
+go build -o _mockgen/gen -tags=thriftrw.disableVersionCheck _mockgen/main.go
 ./mockgen -self_package "$PACKAGENAME" -package "$PACKAGENAME" -destination "$DESTINATION" -exec_only _mockgen/gen "$PACKAGE" "$INTERFACES"
 rm -r _mockgen mockgen


### PR DESCRIPTION
This adds a `generate` target which regenerates all internal code. It relies
on the `thriftrw.disableVersionCheck` tag so that it can regenerate ThriftRW
code using a development version of the executable.

@bombela @kriskowal