### PR TITLE
gen/constants: Use ptr package for primitives

### DIFF
--- a/gen/testdata/constants/constants.go
+++ b/gen/testdata/constants/constants.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/thriftrw/gen/testdata/structs"
 	"go.uber.org/thriftrw/gen/testdata/typedefs"
 	"go.uber.org/thriftrw/gen/testdata/unions"
+	"go.uber.org/thriftrw/ptr"
 )
 
 const Home enums.RecordType = enums.RecordTypeHomeAddress
@@ -18,19 +19,7 @@ const Name enums.RecordType = enums.RecordTypeName
 
 const WorkAddress enums.RecordType = enums.RecordTypeWorkAddress
 
-func _bool_ptr(v bool) *bool {
-	return &v
-}
-
-func _i64_ptr(v int64) *int64 {
-	return &v
-}
-
-func _string_ptr(v string) *string {
-	return &v
-}
-
-var ArbitraryValue *unions.ArbitraryValue = &unions.ArbitraryValue{ListValue: []*unions.ArbitraryValue{&unions.ArbitraryValue{BoolValue: _bool_ptr(true)}, &unions.ArbitraryValue{Int64Value: _i64_ptr(2)}, &unions.ArbitraryValue{StringValue: _string_ptr("hello")}, &unions.ArbitraryValue{MapValue: map[string]*unions.ArbitraryValue{"foo": &unions.ArbitraryValue{StringValue: _string_ptr("bar")}}}}}
+var ArbitraryValue *unions.ArbitraryValue = &unions.ArbitraryValue{ListValue: []*unions.ArbitraryValue{&unions.ArbitraryValue{BoolValue: ptr.Bool(true)}, &unions.ArbitraryValue{Int64Value: ptr.Int64(2)}, &unions.ArbitraryValue{StringValue: ptr.String("hello")}, &unions.ArbitraryValue{MapValue: map[string]*unions.ArbitraryValue{"foo": &unions.ArbitraryValue{StringValue: ptr.String("bar")}}}}}
 
 const BeginningOfTime typedefs.Timestamp = typedefs.Timestamp(0)
 

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"go.uber.org/thriftrw/gen/testdata/enums"
+	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/wire"
 	"strings"
 )
@@ -69,10 +70,6 @@ type DefaultsStruct struct {
 	OptionalList      []float64          `json:"optionalList"`
 	RequiredStruct    *Frame             `json:"requiredStruct,omitempty"`
 	OptionalStruct    *Edge              `json:"optionalStruct,omitempty"`
-}
-
-func _i32_ptr(v int32) *int32 {
-	return &v
 }
 
 func _EnumDefault_ptr(v enums.EnumDefault) *enums.EnumDefault {
@@ -141,7 +138,7 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 		err    error
 	)
 	if v.RequiredPrimitive == nil {
-		v.RequiredPrimitive = _i32_ptr(100)
+		v.RequiredPrimitive = ptr.Int32(100)
 	}
 	{
 		w, err = wire.NewValueI32(*(v.RequiredPrimitive)), error(nil)
@@ -152,7 +149,7 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 		i++
 	}
 	if v.OptionalPrimitive == nil {
-		v.OptionalPrimitive = _i32_ptr(200)
+		v.OptionalPrimitive = ptr.Int32(200)
 	}
 	{
 		w, err = wire.NewValueI32(*(v.OptionalPrimitive)), error(nil)
@@ -354,10 +351,10 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 		}
 	}
 	if v.RequiredPrimitive == nil {
-		v.RequiredPrimitive = _i32_ptr(100)
+		v.RequiredPrimitive = ptr.Int32(100)
 	}
 	if v.OptionalPrimitive == nil {
-		v.OptionalPrimitive = _i32_ptr(200)
+		v.OptionalPrimitive = ptr.Int32(200)
 	}
 	if v.RequiredEnum == nil {
 		v.RequiredEnum = _EnumDefault_ptr(enums.EnumDefaultBar)


### PR DESCRIPTION
Instead of genearting `_ptr_foo` functions, use our `ptr` package where
possible.

Resolves #148

@kriskowal @bombela