### PR TITLE
Add hidden --no-version-check flag

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -56,6 +56,9 @@ type Options struct {
 	// files as well. If true, code gets generated only for the first module.
 	NoRecurse bool
 
+	// If true, we will not generate versioncheck.go files.
+	NoVersionCheck bool
+
 	// Code generation plugin
 	Plugin plugin.Handle
 }
@@ -203,7 +206,8 @@ func generateModule(m *compile.Module, i thriftPackageImporter, builder *generat
 	files := make(map[string][]byte)
 
 	g := NewGenerator(i, importPath, packageName)
-	{
+
+	if !o.NoVersionCheck {
 		if err := Version(g, importPath); err != nil {
 			return nil, err
 		}

--- a/main.go
+++ b/main.go
@@ -44,12 +44,15 @@ type options struct {
 
 type genOptions struct {
 	OutputDirectory string `long:"out" short:"o" value-name:"DIR" description:"Directory to which the generated files will be written."`
-	PackagePrefix   string `long:"pkg-prefix" value-name:"PREFIX" description:"Prefix for import paths of generated module. By default, this is based on the output directory's location relativet o $GOPATH."`
+	PackagePrefix   string `long:"pkg-prefix" value-name:"PREFIX" description:"Prefix for import paths of generated module. By default, this is based on the output directory's location relative to $GOPATH."`
 	ThriftRoot      string `long:"thrift-root" value-name:"DIR" description:"Directory whose descendants contain all Thrift files. The structure of the generated Go packages mirrors the paths to the Thrift files relative to this directory. By default, this is the deepest common ancestor directory of the Thrift files."`
 
-	NoRecurse         bool         `long:"no-recurse" description:"Don't generate code for included Thrift files."`
-	Plugins           plugin.Flags `long:"plugin" short:"p" value-name:"PLUGIN" description:"Code generation plugin for ThriftRW. This option may be provided multiple times to apply multiple plugins."`
-	GeneratePluginAPI bool         `long:"generate-plugin-api" hidden:"true" description:"Generates code for the plugin API"`
+	NoRecurse bool         `long:"no-recurse" description:"Don't generate code for included Thrift files."`
+	Plugins   plugin.Flags `long:"plugin" short:"p" value-name:"PLUGIN" description:"Code generation plugin for ThriftRW. This option may be provided multiple times to apply multiple plugins."`
+
+	GeneratePluginAPI bool `long:"generate-plugin-api" hidden:"true" description:"Generates code for the plugin API"`
+	NoVersionCheck    bool `long:"no-version-check" hidden:"true" description:"Does not add library version checks to generated code."`
+
 	// TODO(abg): Detailed help with examples of --thrift-root, --pkg-prefix,
 	// and --plugin
 
@@ -145,11 +148,12 @@ func main() {
 	defer pluginHandle.Close()
 
 	generatorOptions := gen.Options{
-		OutputDir:     gopts.OutputDirectory,
-		PackagePrefix: gopts.PackagePrefix,
-		ThriftRoot:    gopts.ThriftRoot,
-		NoRecurse:     gopts.NoRecurse,
-		Plugin:        pluginHandle,
+		OutputDir:      gopts.OutputDirectory,
+		PackagePrefix:  gopts.PackagePrefix,
+		ThriftRoot:     gopts.ThriftRoot,
+		NoRecurse:      gopts.NoRecurse,
+		NoVersionCheck: gopts.NoVersionCheck,
+		Plugin:         pluginHandle,
 	}
 	if err := gen.Generate(module, &generatorOptions); err != nil {
 		log.Fatalf("Failed to generate code: %v", err)


### PR DESCRIPTION
This adds a hidden `--no-version-check` flag that does not generate library
version checks.

@bombela @kriskowal