### PR TITLE
version: Move semver to internal package

### DIFF
--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package version
+package semver
 
 import (
 	"fmt"
@@ -27,7 +27,8 @@ import (
 	"strings"
 )
 
-type semVer struct {
+// Version is a parsed semantic version representation.
+type Version struct {
 	Major uint
 	Minor uint
 	Patch uint
@@ -44,7 +45,8 @@ const (
 
 var semVerRegex = regexp.MustCompile(`^` + numPart + `(?:` + preReleasePart + `)?(?:` + metaPart + `)?$`)
 
-func parseSemVer(v string) (r semVer, err error) {
+// Parse a semantic version string.
+func Parse(v string) (r Version, err error) {
 	parts := semVerRegex.FindStringSubmatch(v)
 	if parts == nil {
 		return r, fmt.Errorf(`cannot parse as semantic version: %q`, v)
@@ -67,20 +69,12 @@ func parseSemVer(v string) (r semVer, err error) {
 	return r, nil
 }
 
-func parseSemVerOrPanic(v string) semVer {
-	semVer, err := parseSemVer(v)
-	if err != nil {
-		panic(err)
-	}
-	return semVer
-}
-
 func parseUint(s string) (uint, error) {
 	v, err := strconv.ParseUint(s, 10, 31)
 	return uint(v), err
 }
 
-func (v *semVer) String() string {
+func (v *Version) String() string {
 	r := fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 	if len(v.Pre) > 0 {
 		r += "-" + strings.Join(v.Pre, ".")
@@ -95,7 +89,7 @@ func (v *semVer) String() string {
 //  0 if a == b
 // -1 if a < b
 // +1 if a > b
-func (v *semVer) Compare(b *semVer) int {
+func (v *Version) Compare(b *Version) int {
 	a := v
 	if r := uintCmp(a.Major, b.Major); r != 0 {
 		return r

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package version
+package semver
 
 import (
 	"fmt"
@@ -63,9 +63,9 @@ func TestCompare(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s > %s", test.GreaterVersion, test.LesserVersion), func(t *testing.T) {
-			gv, err := parseSemVer(test.GreaterVersion)
+			gv, err := Parse(test.GreaterVersion)
 			require.NoError(t, err)
-			lv, err := parseSemVer(test.LesserVersion)
+			lv, err := Parse(test.LesserVersion)
 			require.NoError(t, err)
 			assert.Equal(t, test.GreaterVersion, gv.String(), "GreaterVersion input != parsed output")
 			assert.Equal(t, test.LesserVersion, lv.String(), "LesserVersion input != parsed output")
@@ -94,9 +94,9 @@ func TestCompareEqual(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s == %s", test.A, test.B), func(t *testing.T) {
-			av, err := parseSemVer(test.A)
+			av, err := Parse(test.A)
 			require.NoError(t, err)
-			bv, err := parseSemVer(test.B)
+			bv, err := Parse(test.B)
 			require.NoError(t, err)
 			assert.Equal(t, test.A, av.String(), "a input != parsed output")
 			assert.Equal(t, test.B, bv.String(), "b input != parsed output")

--- a/version/version.go
+++ b/version/version.go
@@ -20,14 +20,18 @@
 
 package version
 
+import (
+	"go.uber.org/thriftrw/internal/semver"
+)
+
 // Version is the current ThriftRW version.
 const Version = "0.6.0"
 
 var genCodeCompatbilityRange = computeGenCodeCompabilityRange()
 
 type genCodeCompatbilityRangeHolder struct {
-	begin semVer
-	end   semVer
+	begin semver.Version
+	end   semver.Version
 }
 
 func computeGenCodeCompabilityRange() (r genCodeCompatbilityRangeHolder) {
@@ -37,4 +41,12 @@ func computeGenCodeCompabilityRange() (r genCodeCompatbilityRangeHolder) {
 	r.end.Minor++
 	r.end.Pre = nil
 	return r
+}
+
+func parseSemVerOrPanic(v string) semver.Version {
+	semVer, err := semver.Parse(v)
+	if err != nil {
+		panic(err)
+	}
+	return semVer
 }


### PR DESCRIPTION
This moves the semver types to an internal package so this can be re-used
elsewhere.

@bombela @kriskowal