### PR TITLE
plugin: Send ThriftRW version in Handshake

### DIFF
--- a/internal/plugin/transport.go
+++ b/internal/plugin/transport.go
@@ -67,10 +67,10 @@ func NewTransportHandle(name string, t envelope.Transport) (Handle, error) {
 		}
 	}
 
-	if handshake.ApiVersion != api.Version {
+	if handshake.APIVersion != api.APIVersion {
 		return nil, errHandshakeFailed{
 			Name:   name,
-			Reason: errVersionMismatch{Want: api.Version, Got: handshake.ApiVersion},
+			Reason: errVersionMismatch{Want: api.APIVersion, Got: handshake.APIVersion},
 		}
 	}
 

--- a/internal/plugin/transport_test.go
+++ b/internal/plugin/transport_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/thriftrw/plugin/api"
 	"go.uber.org/thriftrw/plugin/plugintest"
 	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/version"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -65,7 +66,8 @@ func (s *fakePluginServer) Handshake(t *testing.T, pluginName string, features [
 	s.Plugin.EXPECT().Handshake(&api.HandshakeRequest{}).
 		Return(&api.HandshakeResponse{
 			Name:       pluginName,
-			ApiVersion: api.Version,
+			APIVersion: api.APIVersion,
+			Version:    version.Version,
 			Features:   features,
 		}, nil)
 
@@ -122,7 +124,8 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			name: "foo",
 			response: &api.HandshakeResponse{
 				Name:       "bar",
-				ApiVersion: api.Version,
+				APIVersion: api.APIVersion,
+				Version:    version.Version,
 				Features:   []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: ` +
@@ -133,11 +136,12 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			name: "foo",
 			response: &api.HandshakeResponse{
 				Name:       "foo",
-				ApiVersion: 42,
+				APIVersion: 42,
+				Version:    version.Version,
 				Features:   []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: ` +
-				fmt.Sprintf("plugin API version mismatch: expected %d but got 42", api.Version),
+				fmt.Sprintf("plugin API version mismatch: expected %d but got 42", api.APIVersion),
 		},
 	}
 

--- a/plugin/api.thrift
+++ b/plugin/api.thrift
@@ -1,14 +1,9 @@
 /**
- * Package api defines the core interface which plugins use to talk to
- * ThriftRW.
+ * API_VERSION is the version of the plugin API.
+ *
+ * This MUST be provided in the HandshakeResponse.
  */
-
-/**
- * Version is the plugin API version specified in this IDL. This MUST be
- * provided in HandshakeResponses to specify which version of the API the
- * plugin implements.
- */
-const i32 VERSION = 2
+const i32 API_VERSION = 3
 
 /**
  * ServiceID is an arbitrary unique identifier to reference the different
@@ -235,15 +230,20 @@ struct HandshakeResponse {
     /**
      * Version of the plugin API.
      *
-     * This is NOT the version of the plugin but the version of the plugin API
-     * which the plugin respects. This MUST match the version that ThriftRW
-     * expects or the program will fail.
+     * This MUST be set to API_VERSION by the plugin.
      */
-    2: required i32 apiVersion
+    2: required i32 apiVersion (go.name = "APIVersion")
     /**
      * List of features the plugin provides.
      */
     3: required list<Feature> features
+    /**
+     * Version of ThriftRW with which the plugin was built.
+     *
+     * This MUST be set to go.uber.org/thriftrw/version.Version by the plugin
+     * explicitly.
+     */
+    4: required string version
 }
 
 service Plugin {

--- a/plugin/api/constants.go
+++ b/plugin/api/constants.go
@@ -25,4 +25,4 @@ package api
 
 
 
-const Version int32 = 2
+const APIVersion int32 = 3

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -816,8 +816,9 @@ func (v *HandshakeRequest) String() string {
 
 type HandshakeResponse struct {
 	Name       string    `json:"name"`
-	ApiVersion int32     `json:"apiVersion"`
+	APIVersion int32     `json:"apiVersion"`
 	Features   []Feature `json:"features"`
+	Version    string    `json:"version"`
 }
 
 type _List_Feature_ValueList []Feature
@@ -849,7 +850,7 @@ func (_List_Feature_ValueList) Close() {
 
 func (v *HandshakeResponse) ToWire() (wire.Value, error) {
 	var (
-		fields [3]wire.Field
+		fields [4]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -860,7 +861,7 @@ func (v *HandshakeResponse) ToWire() (wire.Value, error) {
 	}
 	fields[i] = wire.Field{ID: 1, Value: w}
 	i++
-	w, err = wire.NewValueI32(v.ApiVersion), error(nil)
+	w, err = wire.NewValueI32(v.APIVersion), error(nil)
 	if err != nil {
 		return w, err
 	}
@@ -874,6 +875,12 @@ func (v *HandshakeResponse) ToWire() (wire.Value, error) {
 		return w, err
 	}
 	fields[i] = wire.Field{ID: 3, Value: w}
+	i++
+	w, err = wire.NewValueString(v.Version), error(nil)
+	if err != nil {
+		return w, err
+	}
+	fields[i] = wire.Field{ID: 4, Value: w}
 	i++
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
@@ -906,6 +913,7 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 	nameIsSet := false
 	apiVersionIsSet := false
 	featuresIsSet := false
+	versionIsSet := false
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
@@ -918,7 +926,7 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TI32 {
-				v.ApiVersion, err = field.Value.GetI32(), error(nil)
+				v.APIVersion, err = field.Value.GetI32(), error(nil)
 				if err != nil {
 					return err
 				}
@@ -932,28 +940,41 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 				}
 				featuresIsSet = true
 			}
+		case 4:
+			if field.Value.Type() == wire.TBinary {
+				v.Version, err = field.Value.GetString(), error(nil)
+				if err != nil {
+					return err
+				}
+				versionIsSet = true
+			}
 		}
 	}
 	if !nameIsSet {
 		return errors.New("field Name of HandshakeResponse is required")
 	}
 	if !apiVersionIsSet {
-		return errors.New("field ApiVersion of HandshakeResponse is required")
+		return errors.New("field APIVersion of HandshakeResponse is required")
 	}
 	if !featuresIsSet {
 		return errors.New("field Features of HandshakeResponse is required")
+	}
+	if !versionIsSet {
+		return errors.New("field Version of HandshakeResponse is required")
 	}
 	return nil
 }
 
 func (v *HandshakeResponse) String() string {
-	var fields [3]string
+	var fields [4]string
 	i := 0
 	fields[i] = fmt.Sprintf("Name: %v", v.Name)
 	i++
-	fields[i] = fmt.Sprintf("ApiVersion: %v", v.ApiVersion)
+	fields[i] = fmt.Sprintf("APIVersion: %v", v.APIVersion)
 	i++
 	fields[i] = fmt.Sprintf("Features: %v", v.Features)
+	i++
+	fields[i] = fmt.Sprintf("Version: %v", v.Version)
 	i++
 	return fmt.Sprintf("HandshakeResponse{%v}", strings.Join(fields[:i], ", "))
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/thriftrw/internal/multiplex"
 	"go.uber.org/thriftrw/plugin/api"
 	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/version"
 )
 
 const _fastPathFrameSize = 10 * 1024 * 1024 // 10 MB
@@ -104,8 +105,9 @@ type pluginHandler struct {
 func (h pluginHandler) Handshake(request *api.HandshakeRequest) (*api.HandshakeResponse, error) {
 	return &api.HandshakeResponse{
 		Name:       h.plugin.Name,
-		ApiVersion: api.Version,
+		APIVersion: api.APIVersion,
 		Features:   h.features,
+		Version:    version.Version,
 	}, nil
 }
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/thriftrw/plugin/api"
 	"go.uber.org/thriftrw/plugin/plugintest"
 	"go.uber.org/thriftrw/ptr"
+	"go.uber.org/thriftrw/version"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -59,8 +60,9 @@ func TestEmptyPlugin(t *testing.T) {
 
 	response, err := client.Handshake(&api.HandshakeRequest{})
 	require.NoError(t, err)
-	assert.Equal(t, api.Version, response.ApiVersion)
+	assert.Equal(t, api.APIVersion, response.APIVersion)
 	assert.Equal(t, "hello", response.Name)
+	assert.Equal(t, version.Version, response.Version)
 	assert.Empty(t, response.Features)
 
 	assert.NoError(t, client.Goodbye())
@@ -85,7 +87,8 @@ func TestServiceGenerator(t *testing.T) {
 
 	handshake, err := pluginClient.Handshake(&api.HandshakeRequest{})
 	require.NoError(t, err)
-	assert.Equal(t, api.Version, handshake.ApiVersion)
+	assert.Equal(t, api.APIVersion, handshake.APIVersion)
+	assert.Equal(t, version.Version, handshake.Version)
 	assert.Equal(t, "hello", handshake.Name)
 	assert.Contains(t, handshake.Features, api.FeatureServiceGenerator)
 


### PR DESCRIPTION
This changes the plugin handshake protocol:

-   API Version was bumped. This will continue to serve its original purpose:
    Facilitate breaking changes in the plugin protocol.
-   The ThriftRW version itself is now sent over the wire. A future change
    will match this against the version of ThriftRW to ensure compatibility.
    This will enable adding features to the plugin protocol in a backwards
    compatible way by allowing plugins to state the version of ThriftRW they
    expect.
-   The VERSION constant was renamed to API_VERSION to clarify its meaning.

@kriskowal @bombela