### PR TITLE
version: Refactor compatiblity check

### DIFF
--- a/internal/semver/compat.go
+++ b/internal/semver/compat.go
@@ -18,7 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package version
+package semver
 
-// Version is the current ThriftRW version.
-const Version = "0.6.0"
+// CompatibleRange generates the compatibility range for generated code and
+// plugins.
+//
+// Assuming current Version is 1.2.3-pre we get:
+//
+// begin >= 1.0.0
+//   end  < 1.3.0-pre
+func CompatibleRange(v Version) (r Range) {
+	r.Begin = v
+	r.End = v
+
+	r.Begin.Pre = nil
+	r.Begin.Patch = 0
+	r.Begin.Minor = 0
+
+	r.End.Patch = 0
+	r.End.Minor++
+	return r
+}

--- a/internal/semver/compat_test.go
+++ b/internal/semver/compat_test.go
@@ -18,49 +18,52 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package version
+package semver
 
 import (
 	"testing"
-
-	"go.uber.org/thriftrw/internal/semver"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCodeCompatRange(t *testing.T) {
+func TestCompatibleRange(t *testing.T) {
 	test := []struct {
-		libVer     string
-		compatVer  []string
-		invalidVer []string
+		library      string
+		compatible   []string
+		incompatible []string
 	}{
 		{
-			"1.2.3",
-			[]string{"1.2.3", "1.2.4", "1.0.0"},
-			[]string{"1.3.0", "0.9.9"},
+			library:      "1.2.3",
+			compatible:   []string{"1.2.3", "1.2.4", "1.0.0"},
+			incompatible: []string{"1.3.0", "0.9.9"},
 		},
 		{
-			"2.0.0",
-			[]string{"2.0.0", "2.0.9", "2.1.0-pre"},
-			[]string{"2.1.0", "1.9.9", "2.0.0-pre"},
+			library:      "2.0.0",
+			compatible:   []string{"2.0.0", "2.0.9", "2.1.0-pre"},
+			incompatible: []string{"2.1.0", "1.9.9", "2.0.0-pre"},
 		},
 	}
 	for _, tt := range test {
-		t.Run(tt.libVer, func(t *testing.T) {
-			compatRange := computeGenCodeCompabilityRange(tt.libVer)
-			for _, compatVer := range tt.compatVer {
-				t.Run(compatVer, func(t *testing.T) {
-					genv, err := semver.Parse(compatVer)
+		t.Run(tt.library, func(t *testing.T) {
+			libVersion, err := Parse(tt.library)
+			require.NoError(t, err)
+
+			compatRange := CompatibleRange(libVersion)
+
+			for _, v := range tt.compatible {
+				t.Run(v, func(t *testing.T) {
+					version, err := Parse(v)
 					require.NoError(t, err)
-					assert.True(t, compatRange.IsCompatibleWith(genv))
+					assert.True(t, compatRange.Matches(version))
 				})
 			}
-			for _, invalidVer := range tt.invalidVer {
-				t.Run(invalidVer, func(t *testing.T) {
-					genv, err := semver.Parse(invalidVer)
+
+			for _, v := range tt.incompatible {
+				t.Run(v, func(t *testing.T) {
+					version, err := Parse(v)
 					require.NoError(t, err)
-					assert.False(t, compatRange.IsCompatibleWith(genv))
+					assert.False(t, compatRange.Matches(version))
 				})
 			}
 		})

--- a/internal/semver/compat_test.go
+++ b/internal/semver/compat_test.go
@@ -55,7 +55,7 @@ func TestCompatibleRange(t *testing.T) {
 				t.Run(v, func(t *testing.T) {
 					version, err := Parse(v)
 					require.NoError(t, err)
-					assert.True(t, compatRange.Matches(version))
+					assert.True(t, compatRange.Contains(version))
 				})
 			}
 
@@ -63,7 +63,7 @@ func TestCompatibleRange(t *testing.T) {
 				t.Run(v, func(t *testing.T) {
 					version, err := Parse(v)
 					require.NoError(t, err)
-					assert.False(t, compatRange.Matches(version))
+					assert.False(t, compatRange.Contains(version))
 				})
 			}
 		})

--- a/internal/semver/range.go
+++ b/internal/semver/range.go
@@ -18,7 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package version
+package semver
 
-// Version is the current ThriftRW version.
-const Version = "0.6.0"
+// Range is the range of version numbers that lie in [Begin, End).
+type Range struct {
+	Begin Version
+	End   Version
+}
+
+// Matches returns true if the given semver version number is in this range.
+func (r *Range) Matches(other Version) bool {
+	return other.Compare(&r.Begin) >= 0 && other.Compare(&r.End) < 0
+}

--- a/internal/semver/range.go
+++ b/internal/semver/range.go
@@ -26,7 +26,7 @@ type Range struct {
 	End   Version
 }
 
-// Matches returns true if the given semver version number is in this range.
-func (r *Range) Matches(other Version) bool {
+// Contains returns true if the given semver version number is in this range.
+func (r *Range) Contains(other Version) bool {
 	return other.Compare(&r.Begin) >= 0 && other.Compare(&r.End) < 0
 }

--- a/version/check.go
+++ b/version/check.go
@@ -55,7 +55,7 @@ func CheckCompatWithGeneratedCodeAt(genCodeVersion string, fromPkg string) {
 		panic(err)
 	}
 
-	if !compatRange.Matches(v) {
+	if !compatRange.Contains(v) {
 		log.Panicf(`incompatible version from generated package %q, expected >=%s and <%s, got %s`,
 			fromPkg, &compatRange.Begin, &compatRange.End, &v)
 	}

--- a/version/check.go
+++ b/version/check.go
@@ -22,7 +22,22 @@
 
 package version
 
-import "log"
+import (
+	"log"
+
+	"go.uber.org/thriftrw/internal/semver"
+)
+
+var compatRange = computeCompatibleRange()
+
+func computeCompatibleRange() semver.Range {
+	v, err := semver.Parse(Version)
+	if err != nil {
+		panic(err)
+	}
+
+	return semver.CompatibleRange(v)
+}
 
 // CheckCompatWithGeneratedCodeAt will panic if the ThriftRW version used to
 // generated code (given by `genCodeVersion`) is not compatible with the
@@ -35,10 +50,13 @@ import "log"
 // This function will ensure that the version mismatch is detected and help
 // avoid bugs that could be caused by this discrepancy.
 func CheckCompatWithGeneratedCodeAt(genCodeVersion string, fromPkg string) {
-	genv := parseSemVerOrPanic(genCodeVersion)
-	if !genCodeCompatbilityRange.IsCompatibleWith(genv) {
+	v, err := semver.Parse(genCodeVersion)
+	if err != nil {
+		panic(err)
+	}
+
+	if !compatRange.Matches(v) {
 		log.Panicf(`incompatible version from generated package %q, expected >=%s and <%s, got %s`,
-			fromPkg, &genCodeCompatbilityRange.begin,
-			&genCodeCompatbilityRange.end, &genv)
+			fromPkg, &compatRange.Begin, &compatRange.End, &v)
 	}
 }


### PR DESCRIPTION
This pulls compatibility check code into an internal package so we can re-use
it for plugins.

@bombela