### PR TITLE
plugin: Verify ThriftRW version in handshake

### DIFF
--- a/internal/plugin/errors.go
+++ b/internal/plugin/errors.go
@@ -20,7 +20,11 @@
 
 package plugin
 
-import "fmt"
+import (
+	"fmt"
+
+	"go.uber.org/thriftrw/internal/semver"
+)
 
 type errHandshakeFailed struct {
 	Name   string
@@ -39,10 +43,30 @@ func (e errNameMismatch) Error() string {
 	return fmt.Sprintf("plugin name mismatch: expected %q but got %q", e.Want, e.Got)
 }
 
-type errVersionMismatch struct {
+type errAPIVersionMismatch struct {
 	Want, Got int32
 }
 
-func (e errVersionMismatch) Error() string {
+func (e errAPIVersionMismatch) Error() string {
 	return fmt.Sprintf("plugin API version mismatch: expected %v but got %v", e.Want, e.Got)
+}
+
+type errMalformedVersion struct {
+	Version string
+	Reason  error
+}
+
+func (e errMalformedVersion) Error() string {
+	return fmt.Sprintf("could not parse a version number from %q: %v", e.Version, e.Reason)
+}
+
+type errVersionMismatch struct {
+	Want semver.Range
+	Got  string
+}
+
+func (e errVersionMismatch) Error() string {
+	return fmt.Sprintf(
+		"plugin compiled with the wrong version of ThriftRW: "+
+			"expected >=%v and <%v but got %v", &e.Want.Begin, &e.Want.End, e.Got)
 }

--- a/internal/plugin/errors.go
+++ b/internal/plugin/errors.go
@@ -21,6 +21,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/thriftrw/internal/semver"
@@ -51,14 +52,7 @@ func (e errAPIVersionMismatch) Error() string {
 	return fmt.Sprintf("plugin API version mismatch: expected %v but got %v", e.Want, e.Got)
 }
 
-type errMalformedVersion struct {
-	Version string
-	Reason  error
-}
-
-func (e errMalformedVersion) Error() string {
-	return fmt.Sprintf("could not parse a version number from %q: %v", e.Version, e.Reason)
-}
+var errVersionIsRequired = errors.New("Version is required")
 
 type errVersionMismatch struct {
 	Want semver.Range

--- a/internal/plugin/transport.go
+++ b/internal/plugin/transport.go
@@ -90,14 +90,14 @@ func NewTransportHandle(name string, t envelope.Transport) (Handle, error) {
 
 	// If we got here, the API version matches so the plugin must have
 	// provided the Version
-	if handshake.Version == nil {
+	if handshake.LibraryVersion == nil {
 		return nil, errHandshakeFailed{
 			Name:   name,
 			Reason: errVersionIsRequired,
 		}
 	}
 
-	version, err := semver.Parse(*handshake.Version)
+	version, err := semver.Parse(*handshake.LibraryVersion)
 	if err != nil {
 		return nil, errHandshakeFailed{Name: name, Reason: err}
 	}
@@ -107,7 +107,7 @@ func NewTransportHandle(name string, t envelope.Transport) (Handle, error) {
 			Name: name,
 			Reason: errVersionMismatch{
 				Want: compatRange,
-				Got:  *handshake.Version,
+				Got:  *handshake.LibraryVersion,
 			},
 		}
 	}

--- a/internal/plugin/transport_test.go
+++ b/internal/plugin/transport_test.go
@@ -66,10 +66,10 @@ func newFakePluginServer(mockCtrl *gomock.Controller) *fakePluginServer {
 func (s *fakePluginServer) Handshake(t *testing.T, pluginName string, features []api.Feature) Handle {
 	s.Plugin.EXPECT().Handshake(&api.HandshakeRequest{}).
 		Return(&api.HandshakeResponse{
-			Name:       pluginName,
-			APIVersion: api.APIVersion,
-			Version:    ptr.String(version.Version),
-			Features:   features,
+			Name:           pluginName,
+			APIVersion:     api.APIVersion,
+			LibraryVersion: ptr.String(version.Version),
+			Features:       features,
 		}, nil)
 
 	handle, err := NewTransportHandle(pluginName, s.ClientTransport)
@@ -124,10 +124,10 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			desc: "name mismatch",
 			name: "foo",
 			response: &api.HandshakeResponse{
-				Name:       "bar",
-				APIVersion: api.APIVersion,
-				Version:    ptr.String(version.Version),
-				Features:   []api.Feature{},
+				Name:           "bar",
+				APIVersion:     api.APIVersion,
+				LibraryVersion: ptr.String(version.Version),
+				Features:       []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: ` +
 				`plugin name mismatch: expected "foo" but got "bar"`,
@@ -136,10 +136,10 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			desc: "version mismatch",
 			name: "foo",
 			response: &api.HandshakeResponse{
-				Name:       "foo",
-				APIVersion: 42,
-				Version:    ptr.String(version.Version),
-				Features:   []api.Feature{},
+				Name:           "foo",
+				APIVersion:     42,
+				LibraryVersion: ptr.String(version.Version),
+				Features:       []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: ` +
 				fmt.Sprintf("plugin API version mismatch: expected %d but got 42", api.APIVersion),
@@ -148,10 +148,10 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			desc: "missing version",
 			name: "foo",
 			response: &api.HandshakeResponse{
-				Name:       "foo",
-				APIVersion: api.APIVersion,
-				Version:    nil,
-				Features:   []api.Feature{},
+				Name:           "foo",
+				APIVersion:     api.APIVersion,
+				LibraryVersion: nil,
+				Features:       []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: Version is required`,
 		},
@@ -159,10 +159,10 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			desc: "unparseable version",
 			name: "foo",
 			response: &api.HandshakeResponse{
-				Name:       "foo",
-				APIVersion: api.APIVersion,
-				Version:    ptr.String("hello"),
-				Features:   []api.Feature{},
+				Name:           "foo",
+				APIVersion:     api.APIVersion,
+				LibraryVersion: ptr.String("hello"),
+				Features:       []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: ` +
 				`cannot parse as semantic version: "hello"`,
@@ -171,10 +171,10 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			desc: "semver mismatch",
 			name: "foo",
 			response: &api.HandshakeResponse{
-				Name:       "foo",
-				APIVersion: api.APIVersion,
-				Version:    ptr.String("12.3.4"),
-				Features:   []api.Feature{},
+				Name:           "foo",
+				APIVersion:     api.APIVersion,
+				LibraryVersion: ptr.String("12.3.4"),
+				Features:       []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: ` +
 				"plugin compiled with the wrong version of ThriftRW: " +

--- a/internal/plugin/transport_test.go
+++ b/internal/plugin/transport_test.go
@@ -144,6 +144,19 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			wantError: `handshake with plugin "foo" failed: ` +
 				fmt.Sprintf("plugin API version mismatch: expected %d but got 42", api.APIVersion),
 		},
+		{
+			desc: "semver mismatch",
+			name: "foo",
+			response: &api.HandshakeResponse{
+				Name:       "foo",
+				APIVersion: api.APIVersion,
+				Version:    "12.3.4",
+				Features:   []api.Feature{},
+			},
+			wantError: `handshake with plugin "foo" failed: ` +
+				"plugin compiled with the wrong version of ThriftRW: " +
+				fmt.Sprintf("expected >=%v and <%v but got 12.3.4", &compatRange.Begin, &compatRange.End),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/plugin/transport_test.go
+++ b/internal/plugin/transport_test.go
@@ -145,12 +145,35 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 				fmt.Sprintf("plugin API version mismatch: expected %d but got 42", api.APIVersion),
 		},
 		{
+			desc: "missing version",
+			name: "foo",
+			response: &api.HandshakeResponse{
+				Name:       "foo",
+				APIVersion: api.APIVersion,
+				Version:    nil,
+				Features:   []api.Feature{},
+			},
+			wantError: `handshake with plugin "foo" failed: Version is required`,
+		},
+		{
+			desc: "unparseable version",
+			name: "foo",
+			response: &api.HandshakeResponse{
+				Name:       "foo",
+				APIVersion: api.APIVersion,
+				Version:    ptr.String("hello"),
+				Features:   []api.Feature{},
+			},
+			wantError: `handshake with plugin "foo" failed: ` +
+				`cannot parse as semantic version: "hello"`,
+		},
+		{
 			desc: "semver mismatch",
 			name: "foo",
 			response: &api.HandshakeResponse{
 				Name:       "foo",
 				APIVersion: api.APIVersion,
-				Version:    "12.3.4",
+				Version:    ptr.String("12.3.4"),
 				Features:   []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: ` +

--- a/plugin/api.thrift
+++ b/plugin/api.thrift
@@ -243,7 +243,7 @@ struct HandshakeResponse {
      * This MUST be set to go.uber.org/thriftrw/version.Version by the plugin
      * explicitly.
      */
-    4: optional string version
+    4: optional string libraryVersion
 }
 
 service Plugin {

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -815,10 +815,10 @@ func (v *HandshakeRequest) String() string {
 }
 
 type HandshakeResponse struct {
-	Name       string    `json:"name"`
-	APIVersion int32     `json:"apiVersion"`
-	Features   []Feature `json:"features"`
-	Version    *string   `json:"version,omitempty"`
+	Name           string    `json:"name"`
+	APIVersion     int32     `json:"apiVersion"`
+	Features       []Feature `json:"features"`
+	LibraryVersion *string   `json:"libraryVersion,omitempty"`
 }
 
 type _List_Feature_ValueList []Feature
@@ -876,8 +876,8 @@ func (v *HandshakeResponse) ToWire() (wire.Value, error) {
 	}
 	fields[i] = wire.Field{ID: 3, Value: w}
 	i++
-	if v.Version != nil {
-		w, err = wire.NewValueString(*(v.Version)), error(nil)
+	if v.LibraryVersion != nil {
+		w, err = wire.NewValueString(*(v.LibraryVersion)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -945,7 +945,7 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 			if field.Value.Type() == wire.TBinary {
 				var x string
 				x, err = field.Value.GetString(), error(nil)
-				v.Version = &x
+				v.LibraryVersion = &x
 				if err != nil {
 					return err
 				}
@@ -973,8 +973,8 @@ func (v *HandshakeResponse) String() string {
 	i++
 	fields[i] = fmt.Sprintf("Features: %v", v.Features)
 	i++
-	if v.Version != nil {
-		fields[i] = fmt.Sprintf("Version: %v", *(v.Version))
+	if v.LibraryVersion != nil {
+		fields[i] = fmt.Sprintf("LibraryVersion: %v", *(v.LibraryVersion))
 		i++
 	}
 	return fmt.Sprintf("HandshakeResponse{%v}", strings.Join(fields[:i], ", "))

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -105,10 +105,10 @@ type pluginHandler struct {
 
 func (h pluginHandler) Handshake(request *api.HandshakeRequest) (*api.HandshakeResponse, error) {
 	return &api.HandshakeResponse{
-		Name:       h.plugin.Name,
-		APIVersion: api.APIVersion,
-		Features:   h.features,
-		Version:    ptr.String(version.Version),
+		Name:           h.plugin.Name,
+		APIVersion:     api.APIVersion,
+		Features:       h.features,
+		LibraryVersion: ptr.String(version.Version),
 	}, nil
 }
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -62,7 +62,7 @@ func TestEmptyPlugin(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, api.APIVersion, response.APIVersion)
 	assert.Equal(t, "hello", response.Name)
-	assert.Equal(t, version.Version, *response.Version)
+	assert.Equal(t, version.Version, *response.LibraryVersion)
 	assert.Empty(t, response.Features)
 
 	assert.NoError(t, client.Goodbye())
@@ -88,7 +88,7 @@ func TestServiceGenerator(t *testing.T) {
 	handshake, err := pluginClient.Handshake(&api.HandshakeRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, api.APIVersion, handshake.APIVersion)
-	assert.Equal(t, version.Version, *handshake.Version)
+	assert.Equal(t, version.Version, *handshake.LibraryVersion)
 	assert.Equal(t, "hello", handshake.Name)
 	assert.Contains(t, handshake.Features, api.FeatureServiceGenerator)
 


### PR DESCRIPTION
This changes the plugin handshake to verify that the version of ThriftRW used
to compile the plugin is compatible with the current version of ThriftRW.

@bombela @kriskowal