### PR TITLE
plugin: Make Version parameter optional

### DIFF
--- a/internal/plugin/transport_test.go
+++ b/internal/plugin/transport_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/thriftrw/plugin/api"
 	"go.uber.org/thriftrw/plugin/plugintest"
 	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/version"
 
 	"github.com/golang/mock/gomock"
@@ -67,7 +68,7 @@ func (s *fakePluginServer) Handshake(t *testing.T, pluginName string, features [
 		Return(&api.HandshakeResponse{
 			Name:       pluginName,
 			APIVersion: api.APIVersion,
-			Version:    version.Version,
+			Version:    ptr.String(version.Version),
 			Features:   features,
 		}, nil)
 
@@ -125,7 +126,7 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			response: &api.HandshakeResponse{
 				Name:       "bar",
 				APIVersion: api.APIVersion,
-				Version:    version.Version,
+				Version:    ptr.String(version.Version),
 				Features:   []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: ` +
@@ -137,7 +138,7 @@ func TestTransportHandleHandshakeError(t *testing.T) {
 			response: &api.HandshakeResponse{
 				Name:       "foo",
 				APIVersion: 42,
-				Version:    version.Version,
+				Version:    ptr.String(version.Version),
 				Features:   []api.Feature{},
 			},
 			wantError: `handshake with plugin "foo" failed: ` +

--- a/plugin/api.thrift
+++ b/plugin/api.thrift
@@ -243,7 +243,7 @@ struct HandshakeResponse {
      * This MUST be set to go.uber.org/thriftrw/version.Version by the plugin
      * explicitly.
      */
-    4: required string version
+    4: optional string version
 }
 
 service Plugin {

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -818,7 +818,7 @@ type HandshakeResponse struct {
 	Name       string    `json:"name"`
 	APIVersion int32     `json:"apiVersion"`
 	Features   []Feature `json:"features"`
-	Version    string    `json:"version"`
+	Version    *string   `json:"version,omitempty"`
 }
 
 type _List_Feature_ValueList []Feature
@@ -876,12 +876,14 @@ func (v *HandshakeResponse) ToWire() (wire.Value, error) {
 	}
 	fields[i] = wire.Field{ID: 3, Value: w}
 	i++
-	w, err = wire.NewValueString(v.Version), error(nil)
-	if err != nil {
-		return w, err
+	if v.Version != nil {
+		w, err = wire.NewValueString(*(v.Version)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 4, Value: w}
+		i++
 	}
-	fields[i] = wire.Field{ID: 4, Value: w}
-	i++
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
@@ -913,7 +915,6 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 	nameIsSet := false
 	apiVersionIsSet := false
 	featuresIsSet := false
-	versionIsSet := false
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
@@ -942,11 +943,12 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 			}
 		case 4:
 			if field.Value.Type() == wire.TBinary {
-				v.Version, err = field.Value.GetString(), error(nil)
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.Version = &x
 				if err != nil {
 					return err
 				}
-				versionIsSet = true
 			}
 		}
 	}
@@ -958,9 +960,6 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 	}
 	if !featuresIsSet {
 		return errors.New("field Features of HandshakeResponse is required")
-	}
-	if !versionIsSet {
-		return errors.New("field Version of HandshakeResponse is required")
 	}
 	return nil
 }
@@ -974,8 +973,10 @@ func (v *HandshakeResponse) String() string {
 	i++
 	fields[i] = fmt.Sprintf("Features: %v", v.Features)
 	i++
-	fields[i] = fmt.Sprintf("Version: %v", v.Version)
-	i++
+	if v.Version != nil {
+		fields[i] = fmt.Sprintf("Version: %v", *(v.Version))
+		i++
+	}
 	return fmt.Sprintf("HandshakeResponse{%v}", strings.Join(fields[:i], ", "))
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/thriftrw/internal/multiplex"
 	"go.uber.org/thriftrw/plugin/api"
 	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/version"
 )
 
@@ -107,7 +108,7 @@ func (h pluginHandler) Handshake(request *api.HandshakeRequest) (*api.HandshakeR
 		Name:       h.plugin.Name,
 		APIVersion: api.APIVersion,
 		Features:   h.features,
-		Version:    version.Version,
+		Version:    ptr.String(version.Version),
 	}, nil
 }
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -62,7 +62,7 @@ func TestEmptyPlugin(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, api.APIVersion, response.APIVersion)
 	assert.Equal(t, "hello", response.Name)
-	assert.Equal(t, version.Version, response.Version)
+	assert.Equal(t, version.Version, *response.Version)
 	assert.Empty(t, response.Features)
 
 	assert.NoError(t, client.Goodbye())
@@ -88,7 +88,7 @@ func TestServiceGenerator(t *testing.T) {
 	handshake, err := pluginClient.Handshake(&api.HandshakeRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, api.APIVersion, handshake.APIVersion)
-	assert.Equal(t, version.Version, handshake.Version)
+	assert.Equal(t, version.Version, *handshake.Version)
 	assert.Equal(t, "hello", handshake.Name)
 	assert.Contains(t, handshake.Features, api.FeatureServiceGenerator)
 


### PR DESCRIPTION
We need to make the parameter optional at the wire level at least for now so
that we can parse the handshake response from plugins using an older version
of the plugin API.

@bombela @kriskowal