### PR TITLE
Fix lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ install:
     - make install_ci
 
 script:
-    # TODO lint_ci fails on 1.7 due to https://github.com/stretchr/testify/issues/339
-    # uncomment once the fix for testify is out.
-    #- make lint_ci
+    - make lint_ci
     - make test_ci
     - travis_retry goveralls -coverprofile=cover.out -service=travis-ci
     - rm -rf vendor/*

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ LINTABLE_MINOR_VERSIONS := 7
 LINT_EXCLUDES_EXTRAS = \
 	idl/internal/lex.rl \
 	idl/internal/thrift.y \
-	idl/internal/yaccpar
+	idl/internal/yaccpar \
+	compile/primitive.go
 
 ##############################################################################
 export GO15VENDOREXPERIMENT=1

--- a/idl/parser_test.go
+++ b/idl/parser_test.go
@@ -154,8 +154,8 @@ func TestParseHeaders(t *testing.T) {
 				namespace * foo
 			`,
 			&Program{Headers: []Header{
-				&Namespace{"py", "bar", 2},
-				&Namespace{"*", "foo", 3},
+				&Namespace{Scope: "py", Name: "bar", Line: 2},
+				&Namespace{Scope: "*", Name: "foo", Line: 3},
 			}},
 		},
 		{
@@ -175,9 +175,9 @@ func TestParseHeaders(t *testing.T) {
 			&Program{
 				Headers: []Header{
 					&Include{Path: "shared.thrift", Line: 3},
-					&Namespace{"go", "foo_service", 4},
+					&Namespace{Scope: "go", Name: "foo_service", Line: 4},
 					&Include{Path: "errors.thrift", Line: 9},
-					&Namespace{"py", "services.foo", 12},
+					&Namespace{Scope: "py", Name: "services.foo", Line: 12},
 				},
 			},
 		},


### PR DESCRIPTION
This fixes make lint by fixing some errors in idl/parser_test.go, and adding compile/primitive.go to `LINT_EXCLUDE_EXTRAS` (there are a ton of uncommented public types that are not worth commenting for now). It also uncomments `make lint_ci` in .travis.yml, as this appears to work again (let's see what travis says).