### PR TITLE
Add --no-{types,constants,service-helpers} flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.1.0 (unreleased)
 -------------------
 
--   No changes yet.
+-   Added flags `--no-types`, `--no-constants`, `--no-service-helpers`
 
 
 v1.0.0 (2016-11-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.1.0 (unreleased)
 -------------------
 
--   Added flags `--no-types`, `--no-constants`, `--no-service-helpers`
+-   Added flags `--no-types`, `--no-constants`, `--no-service-helpers`.
 -   Plugins: Fail code generation if communication with a plugin fails to
     disconnect properly.
 

--- a/main.go
+++ b/main.go
@@ -52,9 +52,9 @@ type genOptions struct {
 
 	GeneratePluginAPI bool `long:"generate-plugin-api" hidden:"true" description:"Generates code for the plugin API"`
 	NoVersionCheck    bool `long:"no-version-check" hidden:"true" description:"Does not add library version checks to generated code."`
-	NoTypes           bool `long:"no-types" description:"Do not generate types.go, implies --no-service-helpers."`
-	NoConstants       bool `long:"no-constants" description:"Do not generate constants.go."`
-	NoServiceHelpers  bool `long:"no-service-helpers" description:"Do not generate service helper go files."`
+	NoTypes           bool `long:"no-types" description:"Do not generate code for types, implies --no-service-helpers."`
+	NoConstants       bool `long:"no-constants" description:"Do not generate code for const declarations."`
+	NoServiceHelpers  bool `long:"no-service-helpers" description:"Do not generate service helpers."`
 
 	// TODO(abg): Detailed help with examples of --thrift-root, --pkg-prefix,
 	// and --plugin

--- a/main.go
+++ b/main.go
@@ -52,7 +52,9 @@ type genOptions struct {
 
 	GeneratePluginAPI bool `long:"generate-plugin-api" hidden:"true" description:"Generates code for the plugin API"`
 	NoVersionCheck    bool `long:"no-version-check" hidden:"true" description:"Does not add library version checks to generated code."`
-	PluginOnly        bool `long:"plugin-only" description:"Only run the plugins, do not generate golang code from thriftrw."`
+	NoTypes           bool `long:"no-types" description:"Do not generate types.go, implies --no-service-helpers."`
+	NoConstants       bool `long:"no-constants" description:"Do not generate constants.go."`
+	NoServiceHelpers  bool `long:"no-service-helpers" description:"Do not generate service helper go files."`
 
 	// TODO(abg): Detailed help with examples of --thrift-root, --pkg-prefix,
 	// and --plugin
@@ -149,13 +151,15 @@ func main() {
 	defer pluginHandle.Close()
 
 	generatorOptions := gen.Options{
-		OutputDir:      gopts.OutputDirectory,
-		PackagePrefix:  gopts.PackagePrefix,
-		ThriftRoot:     gopts.ThriftRoot,
-		NoRecurse:      gopts.NoRecurse,
-		NoVersionCheck: gopts.NoVersionCheck,
-		Plugin:         pluginHandle,
-		PluginOnly:     gopts.PluginOnly,
+		OutputDir:        gopts.OutputDirectory,
+		PackagePrefix:    gopts.PackagePrefix,
+		ThriftRoot:       gopts.ThriftRoot,
+		NoRecurse:        gopts.NoRecurse,
+		NoVersionCheck:   gopts.NoVersionCheck,
+		Plugin:           pluginHandle,
+		NoTypes:          gopts.NoTypes,
+		NoConstants:      gopts.NoConstants,
+		NoServiceHelpers: gopts.NoServiceHelpers || gopts.NoTypes,
 	}
 	if err := gen.Generate(module, &generatorOptions); err != nil {
 		log.Fatalf("Failed to generate code: %v", err)

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ type genOptions struct {
 
 	GeneratePluginAPI bool `long:"generate-plugin-api" hidden:"true" description:"Generates code for the plugin API"`
 	NoVersionCheck    bool `long:"no-version-check" hidden:"true" description:"Does not add library version checks to generated code."`
+	PluginOnly        bool `long:"plugin-only" description:"Only run the plugins, do not generate golang code from thriftrw."`
 
 	// TODO(abg): Detailed help with examples of --thrift-root, --pkg-prefix,
 	// and --plugin
@@ -154,6 +155,7 @@ func main() {
 		NoRecurse:      gopts.NoRecurse,
 		NoVersionCheck: gopts.NoVersionCheck,
 		Plugin:         pluginHandle,
+		PluginOnly:     gopts.PluginOnly,
 	}
 	if err := gen.Generate(module, &generatorOptions); err != nil {
 		log.Fatalf("Failed to generate code: %v", err)


### PR DESCRIPTION
This adds flags to disable code generation for types, constants and
service helpers defined in Thrift files. This is useful in situations
where you don't actually want or need the extra Go code, and just want
to use ThriftRW's plugin interface.
