### PR TITLE
ast: Add Node interface to unify AST nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v1.1.0 (unreleased)
     disconnect properly.
 -   AST: All type references and complex constant values now record the line
     numbers on which they were specified.
+-   AST: Added a Node interface to unify different AST object types.
 
 
 v1.0.0 (2016-11-14)

--- a/ast/annotation.go
+++ b/ast/annotation.go
@@ -38,6 +38,8 @@ type Annotation struct {
 	Line  int
 }
 
+func (*Annotation) node() {}
+
 func (ann *Annotation) String() string {
 	return fmt.Sprintf("%s = %q", ann.Name, ann.Value)
 }

--- a/ast/constant.go
+++ b/ast/constant.go
@@ -23,8 +23,18 @@ package ast
 // ConstantValue unifies the different types representing constant values in
 // Thrift files.
 type ConstantValue interface {
+	Node
+
 	constantValue()
 }
+
+func (ConstantBoolean) node()   {}
+func (ConstantInteger) node()   {}
+func (ConstantString) node()    {}
+func (ConstantDouble) node()    {}
+func (ConstantReference) node() {}
+func (ConstantMap) node()       {}
+func (ConstantList) node()      {}
 
 func (ConstantBoolean) constantValue()   {}
 func (ConstantInteger) constantValue()   {}
@@ -70,6 +80,8 @@ type ConstantMapItem struct {
 	Key, Value ConstantValue
 	Line       int
 }
+
+func (ConstantMapItem) node() {}
 
 // ConstantList is a list literal from the Thrift file.
 //

--- a/ast/definition.go
+++ b/ast/definition.go
@@ -30,6 +30,8 @@ type DefinitionInfo struct {
 // Definition unifies the different types representing items defined in the
 // Thrift file.
 type Definition interface {
+	Node
+
 	Info() DefinitionInfo
 	definition()
 }
@@ -44,7 +46,8 @@ type Constant struct {
 	Line  int
 }
 
-func (c *Constant) definition() {}
+func (*Constant) node()       {}
+func (*Constant) definition() {}
 
 // Info for Constant
 func (c *Constant) Info() DefinitionInfo {
@@ -63,7 +66,8 @@ type Typedef struct {
 }
 
 // Definition implementation for Typedef.
-func (t *Typedef) definition() {}
+func (*Typedef) node()       {}
+func (*Typedef) definition() {}
 
 // Info for Typedef.
 func (t *Typedef) Info() DefinitionInfo {
@@ -86,7 +90,8 @@ type Enum struct {
 	Line        int
 }
 
-func (e *Enum) definition() {}
+func (*Enum) node()       {}
+func (*Enum) definition() {}
 
 // Info for Enum.
 func (e *Enum) Info() DefinitionInfo {
@@ -101,6 +106,8 @@ type EnumItem struct {
 	Annotations []*Annotation
 	Line        int
 }
+
+func (*EnumItem) node() {}
 
 // StructureType specifies whether a struct-like type is a struct, union, or
 // exception.
@@ -141,7 +148,8 @@ type Struct struct {
 	Line        int
 }
 
-func (s *Struct) definition() {}
+func (*Struct) node()       {}
+func (*Struct) definition() {}
 
 // Info for Struct.
 func (s *Struct) Info() DefinitionInfo {
@@ -164,7 +172,8 @@ type Service struct {
 	Line        int
 }
 
-func (s *Service) definition() {}
+func (*Service) node()       {}
+func (*Service) definition() {}
 
 // Info for Service.
 func (s *Service) Info() DefinitionInfo {
@@ -186,6 +195,8 @@ type Function struct {
 	Annotations []*Annotation
 	Line        int
 }
+
+func (*Function) node() {}
 
 // Requiredness represents whether a field was marked as required or optional,
 // or if the user did not specify either.
@@ -214,6 +225,8 @@ type Field struct {
 	Annotations  []*Annotation
 	Line         int
 }
+
+func (*Field) node() {}
 
 // ServiceReference is a reference to another service.
 type ServiceReference struct {

--- a/ast/header.go
+++ b/ast/header.go
@@ -27,6 +27,8 @@ type HeaderInfo struct {
 
 // Header unifies types representing header in the AST.
 type Header interface {
+	Node
+
 	Info() HeaderInfo
 	header()
 }
@@ -45,7 +47,8 @@ type Include struct {
 	Line int
 }
 
-func (i *Include) header() {}
+func (*Include) node()   {}
+func (*Include) header() {}
 
 // Info for Include.
 func (i *Include) Info() HeaderInfo {
@@ -62,7 +65,8 @@ type Namespace struct {
 	Line  int
 }
 
-func (n *Namespace) header() {}
+func (*Namespace) node()   {}
+func (*Namespace) header() {}
 
 // Info for Namespace.
 func (n *Namespace) Info() HeaderInfo {

--- a/ast/node.go
+++ b/ast/node.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,10 +20,37 @@
 
 package ast
 
-// Program represents the full syntax tree for a single .thrift file.
-type Program struct {
-	Headers     []Header
-	Definitions []Definition
+// Node is a single element in the Thrift AST.
+//
+// In addition to all Header, ConstantValue, Type, and Definition types, the
+// following types are also AST nodes: *Annotation, ConstantMapItem,
+// *EnumItem, *Field, *Function, *Program.
+type Node interface {
+	node()
 }
 
-func (*Program) node() {}
+var _ Node = (*Annotation)(nil)
+var _ Node = BaseType{}
+var _ Node = (*Constant)(nil)
+var _ Node = ConstantBoolean(true)
+var _ Node = ConstantDouble(1.0)
+var _ Node = ConstantInteger(1)
+var _ Node = ConstantList{}
+var _ Node = ConstantMap{}
+var _ Node = ConstantMapItem{}
+var _ Node = ConstantReference{}
+var _ Node = ConstantString("hi")
+var _ Node = (*Enum)(nil)
+var _ Node = (*EnumItem)(nil)
+var _ Node = (*Field)(nil)
+var _ Node = (*Function)(nil)
+var _ Node = (*Include)(nil)
+var _ Node = ListType{}
+var _ Node = MapType{}
+var _ Node = (*Namespace)(nil)
+var _ Node = (*Program)(nil)
+var _ Node = (*Service)(nil)
+var _ Node = SetType{}
+var _ Node = (*Struct)(nil)
+var _ Node = TypeReference{}
+var _ Node = (*Typedef)(nil)

--- a/ast/type.go
+++ b/ast/type.go
@@ -24,6 +24,7 @@ import "fmt"
 
 // Type unifies the different types representing Thrift field types.
 type Type interface {
+	Node
 	fmt.Stringer
 
 	fieldType()
@@ -63,6 +64,7 @@ type BaseType struct {
 	Line        int
 }
 
+func (BaseType) node()      {}
 func (BaseType) fieldType() {}
 
 func (bt BaseType) String() string {
@@ -105,6 +107,7 @@ type MapType struct {
 	Line               int
 }
 
+func (MapType) node()      {}
 func (MapType) fieldType() {}
 
 func (mt MapType) String() string {
@@ -127,6 +130,7 @@ type ListType struct {
 	Line        int
 }
 
+func (ListType) node()      {}
 func (ListType) fieldType() {}
 
 func (lt ListType) String() string {
@@ -149,6 +153,7 @@ type SetType struct {
 	Line        int
 }
 
+func (SetType) node()      {}
 func (SetType) fieldType() {}
 
 func (st SetType) String() string {
@@ -164,6 +169,7 @@ type TypeReference struct {
 	Line int
 }
 
+func (TypeReference) node()      {}
 func (TypeReference) fieldType() {}
 
 func (tr TypeReference) String() string {


### PR DESCRIPTION
This adds an `ast.Node` interface which has a single private method. This
interface is implemented by all AST types that can be counted as independent
nodes in the AST tree.