### PR TITLE
Handle the nil case in generated String() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v1.1.0 (unreleased)
 -   AST: All type references and complex constant values now record the line
     numbers on which they were specified.
 -   AST: Added a Node interface to unify different AST object types.
+-   Handle `nil` values in generated `String()` methods.
 
 
 v1.0.0 (2016-11-14)

--- a/gen/field.go
+++ b/gen/field.go
@@ -323,8 +323,12 @@ func (f fieldGroupGenerator) String(g Generator) error {
 
 		<$v := newVar "v">
 		func (<$v> *<.Name>) String() string {
-    		<$fields := newVar "fields">
-    		<$i := newVar "i">
+			if <$v> == nil {
+				return "<"<nil>">"
+			}
+
+			<$fields := newVar "fields">
+			<$i := newVar "i">
 
 			var <$fields> [<len .Fields>]string
 			<$i> := 0

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -496,6 +496,11 @@ func TestPrimitiveRequiredMissingFields(t *testing.T) {
 	}
 }
 
+func TestStructStringWithNil(t *testing.T) {
+	var f *ts.Frame
+	assert.Equal(t, "<nil>", f.String())
+}
+
 func TestStructStringWithMissingRequiredFields(t *testing.T) {
 	tests := []struct {
 		i fmt.Stringer

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -348,6 +348,9 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 }
 
 func (v *PrimitiveContainers) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [3]string
 	i := 0
 	if v.A != nil {
@@ -426,6 +429,9 @@ func (v *StructCollision) FromWire(w wire.Value) error {
 }
 
 func (v *StructCollision) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("CollisionField: %v", v.CollisionField)
@@ -507,6 +513,9 @@ func (v *UnionCollision) FromWire(w wire.Value) error {
 }
 
 func (v *UnionCollision) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	if v.CollisionField != nil {
@@ -571,6 +580,9 @@ func (v *WithDefault) FromWire(w wire.Value) error {
 }
 
 func (v *WithDefault) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	if v.Pouet != nil {
@@ -741,6 +753,9 @@ func (v *StructCollision2) FromWire(w wire.Value) error {
 }
 
 func (v *StructCollision2) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("CollisionField: %v", v.CollisionField)
@@ -822,6 +837,9 @@ func (v *UnionCollision2) FromWire(w wire.Value) error {
 }
 
 func (v *UnionCollision2) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	if v.CollisionField != nil {

--- a/gen/testdata/containers/types.go
+++ b/gen/testdata/containers/types.go
@@ -1144,6 +1144,9 @@ func (v *ContainersOfContainers) FromWire(w wire.Value) error {
 }
 
 func (v *ContainersOfContainers) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [9]string
 	i := 0
 	if v.ListOfLists != nil {
@@ -1421,6 +1424,9 @@ func (v *EnumContainers) FromWire(w wire.Value) error {
 }
 
 func (v *EnumContainers) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [3]string
 	i := 0
 	if v.ListOfEnums != nil {
@@ -1634,6 +1640,9 @@ func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
 }
 
 func (v *MapOfBinaryAndString) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	if v.BinaryToString != nil {
@@ -2019,6 +2028,9 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 }
 
 func (v *PrimitiveContainers) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [6]string
 	i := 0
 	if v.ListOfBinary != nil {
@@ -2196,6 +2208,9 @@ func (v *PrimitiveContainersRequired) FromWire(w wire.Value) error {
 }
 
 func (v *PrimitiveContainersRequired) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [3]string
 	i := 0
 	fields[i] = fmt.Sprintf("ListOfStrings: %v", v.ListOfStrings)

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -565,6 +565,9 @@ func (v *StructWithOptionalEnum) FromWire(w wire.Value) error {
 }
 
 func (v *StructWithOptionalEnum) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	if v.E != nil {

--- a/gen/testdata/exceptions/types.go
+++ b/gen/testdata/exceptions/types.go
@@ -70,6 +70,9 @@ func (v *DoesNotExistException) FromWire(w wire.Value) error {
 }
 
 func (v *DoesNotExistException) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("Key: %v", v.Key)
@@ -104,6 +107,9 @@ func (v *EmptyException) FromWire(w wire.Value) error {
 }
 
 func (v *EmptyException) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("EmptyException{%v}", strings.Join(fields[:i], ", "))

--- a/gen/testdata/services/cache_clear.go
+++ b/gen/testdata/services/cache_clear.go
@@ -28,6 +28,9 @@ func (v *Cache_Clear_Args) FromWire(w wire.Value) error {
 }
 
 func (v *Cache_Clear_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("Cache_Clear_Args{%v}", strings.Join(fields[:i], ", "))

--- a/gen/testdata/services/cache_clearafter.go
+++ b/gen/testdata/services/cache_clearafter.go
@@ -50,6 +50,9 @@ func (v *Cache_ClearAfter_Args) FromWire(w wire.Value) error {
 }
 
 func (v *Cache_ClearAfter_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	if v.DurationMS != nil {

--- a/gen/testdata/services/conflictingnames_setvalue.go
+++ b/gen/testdata/services/conflictingnames_setvalue.go
@@ -54,6 +54,9 @@ func (v *ConflictingNames_SetValue_Args) FromWire(w wire.Value) error {
 }
 
 func (v *ConflictingNames_SetValue_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	if v.Request != nil {
@@ -118,6 +121,9 @@ func (v *ConflictingNames_SetValue_Result) FromWire(w wire.Value) error {
 }
 
 func (v *ConflictingNames_SetValue_Result) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("ConflictingNames_SetValue_Result{%v}", strings.Join(fields[:i], ", "))

--- a/gen/testdata/services/keyvalue_deletevalue.go
+++ b/gen/testdata/services/keyvalue_deletevalue.go
@@ -58,6 +58,9 @@ func (v *KeyValue_DeleteValue_Args) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_DeleteValue_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	if v.Key != nil {
@@ -207,6 +210,9 @@ func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_DeleteValue_Result) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	if v.DoesNotExist != nil {

--- a/gen/testdata/services/keyvalue_getmanyvalues.go
+++ b/gen/testdata/services/keyvalue_getmanyvalues.go
@@ -95,6 +95,9 @@ func (v *KeyValue_GetManyValues_Args) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_GetManyValues_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	if v.Range != nil {
@@ -279,6 +282,9 @@ func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_GetManyValues_Result) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	if v.Success != nil {

--- a/gen/testdata/services/keyvalue_getvalue.go
+++ b/gen/testdata/services/keyvalue_getvalue.go
@@ -53,6 +53,9 @@ func (v *KeyValue_GetValue_Args) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_GetValue_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	if v.Key != nil {
@@ -184,6 +187,9 @@ func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_GetValue_Result) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	if v.Success != nil {

--- a/gen/testdata/services/keyvalue_setvalue.go
+++ b/gen/testdata/services/keyvalue_setvalue.go
@@ -67,6 +67,9 @@ func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_SetValue_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	if v.Key != nil {
@@ -135,6 +138,9 @@ func (v *KeyValue_SetValue_Result) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_SetValue_Result) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("KeyValue_SetValue_Result{%v}", strings.Join(fields[:i], ", "))

--- a/gen/testdata/services/keyvalue_setvaluev2.go
+++ b/gen/testdata/services/keyvalue_setvaluev2.go
@@ -75,6 +75,9 @@ func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_SetValueV2_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("Key: %v", v.Key)
@@ -139,6 +142,9 @@ func (v *KeyValue_SetValueV2_Result) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_SetValueV2_Result) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("KeyValue_SetValueV2_Result{%v}", strings.Join(fields[:i], ", "))

--- a/gen/testdata/services/keyvalue_size.go
+++ b/gen/testdata/services/keyvalue_size.go
@@ -29,6 +29,9 @@ func (v *KeyValue_Size_Args) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_Size_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("KeyValue_Size_Args{%v}", strings.Join(fields[:i], ", "))
@@ -126,6 +129,9 @@ func (v *KeyValue_Size_Result) FromWire(w wire.Value) error {
 }
 
 func (v *KeyValue_Size_Result) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	if v.Success != nil {

--- a/gen/testdata/services/non_standard_service_name_non_standard_function_name.go
+++ b/gen/testdata/services/non_standard_service_name_non_standard_function_name.go
@@ -28,6 +28,9 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) FromWire(w wire.Va
 }
 
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("NonStandardServiceName_NonStandardFunctionName_Args{%v}", strings.Join(fields[:i], ", "))
@@ -88,6 +91,9 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) FromWire(w wire.
 }
 
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("NonStandardServiceName_NonStandardFunctionName_Result{%v}", strings.Join(fields[:i], ", "))

--- a/gen/testdata/services/types.go
+++ b/gen/testdata/services/types.go
@@ -74,6 +74,9 @@ func (v *ConflictingNamesSetValueArgs) FromWire(w wire.Value) error {
 }
 
 func (v *ConflictingNamesSetValueArgs) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("Key: %v", v.Key)
@@ -124,6 +127,9 @@ func (v *InternalError) FromWire(w wire.Value) error {
 }
 
 func (v *InternalError) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	if v.Message != nil {

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -54,6 +54,9 @@ func (v *ContactInfo) FromWire(w wire.Value) error {
 }
 
 func (v *ContactInfo) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	fields[i] = fmt.Sprintf("EmailAddress: %v", v.EmailAddress)
@@ -378,6 +381,9 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 }
 
 func (v *DefaultsStruct) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [8]string
 	i := 0
 	if v.RequiredPrimitive != nil {
@@ -488,6 +494,9 @@ func (v *Edge) FromWire(w wire.Value) error {
 }
 
 func (v *Edge) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("StartPoint: %v", v.StartPoint)
@@ -516,6 +525,9 @@ func (v *EmptyStruct) FromWire(w wire.Value) error {
 }
 
 func (v *EmptyStruct) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("EmptyStruct{%v}", strings.Join(fields[:i], ", "))
@@ -594,6 +606,9 @@ func (v *Frame) FromWire(w wire.Value) error {
 }
 
 func (v *Frame) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("TopLeft: %v", v.TopLeft)
@@ -695,6 +710,9 @@ func (v *Graph) FromWire(w wire.Value) error {
 }
 
 func (v *Graph) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [1]string
 	i := 0
 	fields[i] = fmt.Sprintf("Edges: %v", v.Edges)
@@ -782,6 +800,9 @@ func (v *Node) FromWire(w wire.Value) error {
 }
 
 func (v *Node) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("Value: %v", v.Value)
@@ -854,6 +875,9 @@ func (v *Point) FromWire(w wire.Value) error {
 }
 
 func (v *Point) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("X: %v", v.X)
@@ -1028,6 +1052,9 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 }
 
 func (v *PrimitiveOptionalStruct) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [8]string
 	i := 0
 	if v.BoolField != nil {
@@ -1243,6 +1270,9 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 }
 
 func (v *PrimitiveRequiredStruct) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [8]string
 	i := 0
 	fields[i] = fmt.Sprintf("BoolField: %v", v.BoolField)
@@ -1325,6 +1355,9 @@ func (v *Size) FromWire(w wire.Value) error {
 }
 
 func (v *Size) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("Width: %v", v.Width)
@@ -1398,6 +1431,9 @@ func (v *User) FromWire(w wire.Value) error {
 }
 
 func (v *User) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("Name: %v", v.Name)

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -264,6 +264,9 @@ func (v *Event) FromWire(w wire.Value) error {
 }
 
 func (v *Event) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("UUID: %v", v.UUID)
@@ -696,6 +699,9 @@ func (v *Transition) FromWire(w wire.Value) error {
 }
 
 func (v *Transition) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [3]string
 	i := 0
 	fields[i] = fmt.Sprintf("FromState: %v", v.FromState)
@@ -786,6 +792,9 @@ func (v *I128) FromWire(w wire.Value) error {
 }
 
 func (v *I128) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	fields[i] = fmt.Sprintf("High: %v", v.High)

--- a/gen/testdata/unions/types.go
+++ b/gen/testdata/unions/types.go
@@ -256,6 +256,9 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 }
 
 func (v *ArbitraryValue) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [5]string
 	i := 0
 	if v.BoolValue != nil {
@@ -357,6 +360,9 @@ func (v *Document) FromWire(w wire.Value) error {
 }
 
 func (v *Document) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [2]string
 	i := 0
 	if v.Pdf != nil {
@@ -389,6 +395,9 @@ func (v *EmptyUnion) FromWire(w wire.Value) error {
 }
 
 func (v *EmptyUnion) String() string {
+	if v == nil {
+		return "<nil>"
+	}
 	var fields [0]string
 	i := 0
 	return fmt.Sprintf("EmptyUnion{%v}", strings.Join(fields[:i], ", "))


### PR DESCRIPTION
I was seeing panics when I tried to log nil values with [zap](https://github.com/uber-go/zap). I'll add a `nil` check there to make sure other libraries don't introduce panics, but this seemed like a good safeguard to have in the generated structs.

Here's a [link](https://play.golang.org/p/zcXKrbDSwn) to some code that demonstrates the issue.