### PR TITLE
Make `make lint` pass.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go_import_path: go.uber.org/thriftrw
 
 go:
     - 1.7
+    - 1.8
     - tip
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 WANT_VERSION = $(shell grep '^v[0-9]' CHANGELOG.md | head -n1 | cut -d' ' -f1)
 
 # Minor versions of Go for which the lint check should be run.
-LINTABLE_MINOR_VERSIONS := 7
+LINTABLE_MINOR_VERSIONS := 8
 
 # Paths besides auto-detected generated files that should be excluded from
 # lint results. If generated code uses '//line' directives with a different
@@ -69,7 +69,6 @@ ifdef SHOULD_LINT
 		go tool vet $(VET_RULES) $(pkg) 2>&1 | \
 			grep -v '^exit status' | \
 			$(FILTER_LINT) | \
-			grep -v 'something"` not compatible with reflect.StructTag.Get:' \
 		> $(VET_LOG) || true; \
 	)
 	@[ ! -s "$(VET_LOG)" ] || (echo "govet failed:" | cat - $(VET_LOG) && false)

--- a/gen/typedef_test.go
+++ b/gen/typedef_test.go
@@ -151,7 +151,7 @@ func TestTypedefStruct(t *testing.T) {
 		v wire.Value
 	}{
 		{
-			(*td.UUID)(&td.I128{1, 2}),
+			(*td.UUID)(&td.I128{High: 1, Low: 2}),
 			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
 				{ID: 1, Value: wire.NewValueI64(1)},
 				{ID: 2, Value: wire.NewValueI64(2)},
@@ -170,8 +170,8 @@ func TestTypedefStructEquals(t *testing.T) {
 		x, y *td.UUID
 	}{
 		{
-			(*td.UUID)(&td.I128{1, 2}),
-			(*td.UUID)(&td.I128{3, 1}),
+			(*td.UUID)(&td.I128{High: 1, Low: 2}),
+			(*td.UUID)(&td.I128{High: 3, Low: 1}),
 		},
 	}
 


### PR DESCRIPTION
The linting command was broken in go1.7

This fixes it to pass.

r: @abhinav @kriskowal