### PR TITLE
gen/enum: Implement encoding.TextUnmarshaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ v1.3.0 (unreleased)
 
 -   Plugins: Added support for overriding the communication channels used by
     plugins.
--   Enums now implement `encoding.TextUnmarshaler`.
+-   Enums now implement the `encoding.TextUnmarshaler` interface. This allows
+    retrieving enum values by name and integrates better with other encoding
+    formats.
 
 
 v1.2.0 (2017-04-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v1.3.0 (unreleased)
 
 -   Plugins: Added support for overriding the communication channels used by
     plugins.
+-   Enums now implement `encoding.TextUnmarshaler`.
 
 
 v1.2.0 (2017-04-17)

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -78,6 +78,19 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		<end>
 
 		<$v := newVar "v">
+		func (<$v> *<$enumName>) UnmarshalText(value []byte) error {
+			switch string(value) {
+			<$enum := .Spec>
+			<range .Spec.Items>
+				case "<.Name>":
+					*<$v> = <enumItemName $enumName .>
+					return nil
+			<end>
+				default:
+					return <$fmt>.Errorf("unknown enum value %q for %q", value, "<$enumName>")
+			}
+		}
+
 		func (<$v> <$enumName>) ToWire() (<$wire>.Value, error) {
 			return <$wire>.NewValueI32(int32(<$v>)), nil
 		}
@@ -146,16 +159,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 				*<$v> = (<$enumName>)(<$x>)
 				return nil
 			case string:
-				switch <$w> {
-				<$enum := .Spec>
-				<range .Spec.Items>
-					case "<.Name>":
-						*<$v> = <enumItemName $enumName .>
-						return nil
-				<end>
-					default:
-						return <$fmt>.Errorf("unknown enum value %q for %q", <$w>, "<$enumName>")
-				}
+				return <$v>.UnmarshalText([]byte(<$w>))
 			default:
 				return <$fmt>.Errorf("invalid JSON value %q (%T) to unmarshal into %q", <$t>, <$t>, "<$enumName>")
 			}

--- a/gen/enum_test.go
+++ b/gen/enum_test.go
@@ -310,3 +310,15 @@ func TestInvalidJSON(t *testing.T) {
 		})
 	}
 }
+func TestUnmarshalTextReturnsValue(t *testing.T) {
+	var v te.EnumDefault
+	err := v.UnmarshalText([]byte("Foo"))
+	assert.NoError(t, err)
+	assert.Equal(t, te.EnumDefaultFoo, v)
+}
+
+func TestUnmarshalTextReturnsErrorOnInvalidValue(t *testing.T) {
+	var v te.EnumDefault
+	err := v.UnmarshalText([]byte("blah"))
+	assert.Error(t, err)
+}

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -46,6 +46,28 @@ const (
 	MyEnumFooBar2 MyEnum = 791
 )
 
+func (v *MyEnum) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "X":
+		*v = MyEnumX
+		return nil
+	case "Y":
+		*v = MyEnumY
+		return nil
+	case "Z":
+		*v = MyEnumZ
+		return nil
+	case "FooBar":
+		*v = MyEnumFooBar
+		return nil
+	case "foo_bar":
+		*v = MyEnumFooBar2
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "MyEnum")
+	}
+}
+
 func (v MyEnum) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
@@ -114,25 +136,7 @@ func (v *MyEnum) UnmarshalJSON(text []byte) error {
 		*v = (MyEnum)(x)
 		return nil
 	case string:
-		switch w {
-		case "X":
-			*v = MyEnumX
-			return nil
-		case "Y":
-			*v = MyEnumY
-			return nil
-		case "Z":
-			*v = MyEnumZ
-			return nil
-		case "FooBar":
-			*v = MyEnumFooBar
-			return nil
-		case "foo_bar":
-			*v = MyEnumFooBar2
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "MyEnum")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "MyEnum")
 	}
@@ -729,6 +733,22 @@ const (
 	MyEnum2Z MyEnum2 = 56
 )
 
+func (v *MyEnum2) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "X":
+		*v = MyEnum2X
+		return nil
+	case "Y":
+		*v = MyEnum2Y
+		return nil
+	case "Z":
+		*v = MyEnum2Z
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "MyEnum2")
+	}
+}
+
 func (v MyEnum2) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
@@ -789,19 +809,7 @@ func (v *MyEnum2) UnmarshalJSON(text []byte) error {
 		*v = (MyEnum2)(x)
 		return nil
 	case string:
-		switch w {
-		case "X":
-			*v = MyEnum2X
-			return nil
-		case "Y":
-			*v = MyEnum2Y
-			return nil
-		case "Z":
-			*v = MyEnum2Z
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "MyEnum2")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "MyEnum2")
 	}

--- a/gen/testdata/enum_conflict/types.go
+++ b/gen/testdata/enum_conflict/types.go
@@ -21,6 +21,19 @@ const (
 	RecordTypeEmail RecordType = 1
 )
 
+func (v *RecordType) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "Name":
+		*v = RecordTypeName
+		return nil
+	case "Email":
+		*v = RecordTypeEmail
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "RecordType")
+	}
+}
+
 func (v RecordType) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
@@ -77,16 +90,7 @@ func (v *RecordType) UnmarshalJSON(text []byte) error {
 		*v = (RecordType)(x)
 		return nil
 	case string:
-		switch w {
-		case "Name":
-			*v = RecordTypeName
-			return nil
-		case "Email":
-			*v = RecordTypeEmail
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "RecordType")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "RecordType")
 	}

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -15,6 +15,13 @@ import (
 
 type EmptyEnum int32
 
+func (v *EmptyEnum) UnmarshalText(value []byte) error {
+	switch string(value) {
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "EmptyEnum")
+	}
+}
+
 func (v EmptyEnum) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
@@ -59,10 +66,7 @@ func (v *EmptyEnum) UnmarshalJSON(text []byte) error {
 		*v = (EmptyEnum)(x)
 		return nil
 	case string:
-		switch w {
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "EmptyEnum")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EmptyEnum")
 	}
@@ -75,6 +79,22 @@ const (
 	EnumDefaultBar EnumDefault = 1
 	EnumDefaultBaz EnumDefault = 2
 )
+
+func (v *EnumDefault) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "Foo":
+		*v = EnumDefaultFoo
+		return nil
+	case "Bar":
+		*v = EnumDefaultBar
+		return nil
+	case "Baz":
+		*v = EnumDefaultBaz
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "EnumDefault")
+	}
+}
 
 func (v EnumDefault) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
@@ -136,19 +156,7 @@ func (v *EnumDefault) UnmarshalJSON(text []byte) error {
 		*v = (EnumDefault)(x)
 		return nil
 	case string:
-		switch w {
-		case "Foo":
-			*v = EnumDefaultFoo
-			return nil
-		case "Bar":
-			*v = EnumDefaultBar
-			return nil
-		case "Baz":
-			*v = EnumDefaultBaz
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "EnumDefault")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumDefault")
 	}
@@ -167,6 +175,40 @@ const (
 	EnumWithDuplicateNameY EnumWithDuplicateName = 7
 	EnumWithDuplicateNameZ EnumWithDuplicateName = 8
 )
+
+func (v *EnumWithDuplicateName) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "A":
+		*v = EnumWithDuplicateNameA
+		return nil
+	case "B":
+		*v = EnumWithDuplicateNameB
+		return nil
+	case "C":
+		*v = EnumWithDuplicateNameC
+		return nil
+	case "P":
+		*v = EnumWithDuplicateNameP
+		return nil
+	case "Q":
+		*v = EnumWithDuplicateNameQ
+		return nil
+	case "R":
+		*v = EnumWithDuplicateNameR
+		return nil
+	case "X":
+		*v = EnumWithDuplicateNameX
+		return nil
+	case "Y":
+		*v = EnumWithDuplicateNameY
+		return nil
+	case "Z":
+		*v = EnumWithDuplicateNameZ
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "EnumWithDuplicateName")
+	}
+}
 
 func (v EnumWithDuplicateName) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
@@ -252,37 +294,7 @@ func (v *EnumWithDuplicateName) UnmarshalJSON(text []byte) error {
 		*v = (EnumWithDuplicateName)(x)
 		return nil
 	case string:
-		switch w {
-		case "A":
-			*v = EnumWithDuplicateNameA
-			return nil
-		case "B":
-			*v = EnumWithDuplicateNameB
-			return nil
-		case "C":
-			*v = EnumWithDuplicateNameC
-			return nil
-		case "P":
-			*v = EnumWithDuplicateNameP
-			return nil
-		case "Q":
-			*v = EnumWithDuplicateNameQ
-			return nil
-		case "R":
-			*v = EnumWithDuplicateNameR
-			return nil
-		case "X":
-			*v = EnumWithDuplicateNameX
-			return nil
-		case "Y":
-			*v = EnumWithDuplicateNameY
-			return nil
-		case "Z":
-			*v = EnumWithDuplicateNameZ
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithDuplicateName")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateName")
 	}
@@ -295,6 +307,22 @@ const (
 	EnumWithDuplicateValuesQ EnumWithDuplicateValues = -1
 	EnumWithDuplicateValuesR EnumWithDuplicateValues = 0
 )
+
+func (v *EnumWithDuplicateValues) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "P":
+		*v = EnumWithDuplicateValuesP
+		return nil
+	case "Q":
+		*v = EnumWithDuplicateValuesQ
+		return nil
+	case "R":
+		*v = EnumWithDuplicateValuesR
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "EnumWithDuplicateValues")
+	}
+}
 
 func (v EnumWithDuplicateValues) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
@@ -352,19 +380,7 @@ func (v *EnumWithDuplicateValues) UnmarshalJSON(text []byte) error {
 		*v = (EnumWithDuplicateValues)(x)
 		return nil
 	case string:
-		switch w {
-		case "P":
-			*v = EnumWithDuplicateValuesP
-			return nil
-		case "Q":
-			*v = EnumWithDuplicateValuesQ
-			return nil
-		case "R":
-			*v = EnumWithDuplicateValuesR
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithDuplicateValues")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithDuplicateValues")
 	}
@@ -377,6 +393,22 @@ const (
 	EnumWithValuesY EnumWithValues = 456
 	EnumWithValuesZ EnumWithValues = 789
 )
+
+func (v *EnumWithValues) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "X":
+		*v = EnumWithValuesX
+		return nil
+	case "Y":
+		*v = EnumWithValuesY
+		return nil
+	case "Z":
+		*v = EnumWithValuesZ
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "EnumWithValues")
+	}
+}
 
 func (v EnumWithValues) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
@@ -438,19 +470,7 @@ func (v *EnumWithValues) UnmarshalJSON(text []byte) error {
 		*v = (EnumWithValues)(x)
 		return nil
 	case string:
-		switch w {
-		case "X":
-			*v = EnumWithValuesX
-			return nil
-		case "Y":
-			*v = EnumWithValuesY
-			return nil
-		case "Z":
-			*v = EnumWithValuesZ
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "EnumWithValues")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "EnumWithValues")
 	}
@@ -463,6 +483,22 @@ const (
 	RecordTypeHomeAddress RecordType = 1
 	RecordTypeWorkAddress RecordType = 2
 )
+
+func (v *RecordType) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "NAME":
+		*v = RecordTypeName
+		return nil
+	case "HOME_ADDRESS":
+		*v = RecordTypeHomeAddress
+		return nil
+	case "WORK_ADDRESS":
+		*v = RecordTypeWorkAddress
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "RecordType")
+	}
+}
 
 func (v RecordType) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
@@ -524,19 +560,7 @@ func (v *RecordType) UnmarshalJSON(text []byte) error {
 		*v = (RecordType)(x)
 		return nil
 	case string:
-		switch w {
-		case "NAME":
-			*v = RecordTypeName
-			return nil
-		case "HOME_ADDRESS":
-			*v = RecordTypeHomeAddress
-			return nil
-		case "WORK_ADDRESS":
-			*v = RecordTypeWorkAddress
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "RecordType")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "RecordType")
 	}
@@ -625,6 +649,22 @@ const (
 	LowerCaseEnumItems      LowerCaseEnum = 2
 )
 
+func (v *LowerCaseEnum) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "containing":
+		*v = LowerCaseEnumContaining
+		return nil
+	case "lower_case":
+		*v = LowerCaseEnumLowerCase
+		return nil
+	case "items":
+		*v = LowerCaseEnumItems
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "LowerCaseEnum")
+	}
+}
+
 func (v LowerCaseEnum) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
@@ -685,19 +725,7 @@ func (v *LowerCaseEnum) UnmarshalJSON(text []byte) error {
 		*v = (LowerCaseEnum)(x)
 		return nil
 	case string:
-		switch w {
-		case "containing":
-			*v = LowerCaseEnumContaining
-			return nil
-		case "lower_case":
-			*v = LowerCaseEnumLowerCase
-			return nil
-		case "items":
-			*v = LowerCaseEnumItems
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "LowerCaseEnum")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "LowerCaseEnum")
 	}

--- a/internal/envelope/exception/types.go
+++ b/internal/envelope/exception/types.go
@@ -49,6 +49,46 @@ const (
 	ExceptionTypeUnsupportedClientType ExceptionType = 10
 )
 
+func (v *ExceptionType) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "UNKNOWN":
+		*v = ExceptionTypeUnknown
+		return nil
+	case "UNKNOWN_METHOD":
+		*v = ExceptionTypeUnknownMethod
+		return nil
+	case "INVALID_MESSAGE_TYPE":
+		*v = ExceptionTypeInvalidMessageType
+		return nil
+	case "WRONG_METHOD_NAME":
+		*v = ExceptionTypeWrongMethodName
+		return nil
+	case "BAD_SEQUENCE_ID":
+		*v = ExceptionTypeBadSequenceID
+		return nil
+	case "MISSING_RESULT":
+		*v = ExceptionTypeMissingResult
+		return nil
+	case "INTERNAL_ERROR":
+		*v = ExceptionTypeInternalError
+		return nil
+	case "PROTOCOL_ERROR":
+		*v = ExceptionTypeProtocolError
+		return nil
+	case "INVALID_TRANSFORM":
+		*v = ExceptionTypeInvalidTransform
+		return nil
+	case "INVALID_PROTOCOL":
+		*v = ExceptionTypeInvalidProtocol
+		return nil
+	case "UNSUPPORTED_CLIENT_TYPE":
+		*v = ExceptionTypeUnsupportedClientType
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "ExceptionType")
+	}
+}
+
 func (v ExceptionType) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
@@ -141,43 +181,7 @@ func (v *ExceptionType) UnmarshalJSON(text []byte) error {
 		*v = (ExceptionType)(x)
 		return nil
 	case string:
-		switch w {
-		case "UNKNOWN":
-			*v = ExceptionTypeUnknown
-			return nil
-		case "UNKNOWN_METHOD":
-			*v = ExceptionTypeUnknownMethod
-			return nil
-		case "INVALID_MESSAGE_TYPE":
-			*v = ExceptionTypeInvalidMessageType
-			return nil
-		case "WRONG_METHOD_NAME":
-			*v = ExceptionTypeWrongMethodName
-			return nil
-		case "BAD_SEQUENCE_ID":
-			*v = ExceptionTypeBadSequenceID
-			return nil
-		case "MISSING_RESULT":
-			*v = ExceptionTypeMissingResult
-			return nil
-		case "INTERNAL_ERROR":
-			*v = ExceptionTypeInternalError
-			return nil
-		case "PROTOCOL_ERROR":
-			*v = ExceptionTypeProtocolError
-			return nil
-		case "INVALID_TRANSFORM":
-			*v = ExceptionTypeInvalidTransform
-			return nil
-		case "INVALID_PROTOCOL":
-			*v = ExceptionTypeInvalidProtocol
-			return nil
-		case "UNSUPPORTED_CLIENT_TYPE":
-			*v = ExceptionTypeUnsupportedClientType
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "ExceptionType")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "ExceptionType")
 	}

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -132,6 +132,16 @@ const (
 	FeatureServiceGenerator Feature = 1
 )
 
+func (v *Feature) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "SERVICE_GENERATOR":
+		*v = FeatureServiceGenerator
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "Feature")
+	}
+}
+
 func (v Feature) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
@@ -184,13 +194,7 @@ func (v *Feature) UnmarshalJSON(text []byte) error {
 		*v = (Feature)(x)
 		return nil
 	case string:
-		switch w {
-		case "SERVICE_GENERATOR":
-			*v = FeatureServiceGenerator
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "Feature")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "Feature")
 	}
@@ -1554,6 +1558,40 @@ const (
 	SimpleTypeStructEmpty SimpleType = 9
 )
 
+func (v *SimpleType) UnmarshalText(value []byte) error {
+	switch string(value) {
+	case "BOOL":
+		*v = SimpleTypeBool
+		return nil
+	case "BYTE":
+		*v = SimpleTypeByte
+		return nil
+	case "INT8":
+		*v = SimpleTypeInt8
+		return nil
+	case "INT16":
+		*v = SimpleTypeInt16
+		return nil
+	case "INT32":
+		*v = SimpleTypeInt32
+		return nil
+	case "INT64":
+		*v = SimpleTypeInt64
+		return nil
+	case "FLOAT64":
+		*v = SimpleTypeFloat64
+		return nil
+	case "STRING":
+		*v = SimpleTypeString
+		return nil
+	case "STRUCT_EMPTY":
+		*v = SimpleTypeStructEmpty
+		return nil
+	default:
+		return fmt.Errorf("unknown enum value %q for %q", value, "SimpleType")
+	}
+}
+
 func (v SimpleType) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
@@ -1638,37 +1676,7 @@ func (v *SimpleType) UnmarshalJSON(text []byte) error {
 		*v = (SimpleType)(x)
 		return nil
 	case string:
-		switch w {
-		case "BOOL":
-			*v = SimpleTypeBool
-			return nil
-		case "BYTE":
-			*v = SimpleTypeByte
-			return nil
-		case "INT8":
-			*v = SimpleTypeInt8
-			return nil
-		case "INT16":
-			*v = SimpleTypeInt16
-			return nil
-		case "INT32":
-			*v = SimpleTypeInt32
-			return nil
-		case "INT64":
-			*v = SimpleTypeInt64
-			return nil
-		case "FLOAT64":
-			*v = SimpleTypeFloat64
-			return nil
-		case "STRING":
-			*v = SimpleTypeString
-			return nil
-		case "STRUCT_EMPTY":
-			*v = SimpleTypeStructEmpty
-			return nil
-		default:
-			return fmt.Errorf("unknown enum value %q for %q", w, "SimpleType")
-		}
+		return v.UnmarshalText([]byte(w))
 	default:
 		return fmt.Errorf("invalid JSON value %q (%T) to unmarshal into %q", t, t, "SimpleType")
 	}


### PR DESCRIPTION
This changes generated code for enums to implement the
encoding.TextUnmarshaler interface. This exposes a simple API to users
for reading enums by name in addition to integrating better with
other encoding libraries.

(This was pulled from #308. Thanks @recht!)