### PR TITLE
ast: Add LineNumber function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Releases
 v1.4.0 (unreleased)
 -------------------
 
+-   AST: Added a `LineNumber` function to get the line on which an AST Node was
+    defined.
+
+
 v1.3.0 (2017-07-05)
 -------------------
 

--- a/ast/constant.go
+++ b/ast/constant.go
@@ -67,6 +67,11 @@ func (i ConstantMapItem) visitChildren(ss nodeStack, v visitor) {
 	v.visit(ss, i.Value)
 }
 
+func (m ConstantMap) lineNumber() int       { return m.Line }
+func (i ConstantMapItem) lineNumber() int   { return i.Line }
+func (l ConstantList) lineNumber() int      { return l.Line }
+func (r ConstantReference) lineNumber() int { return r.Line }
+
 // ConstantBoolean is a boolean value specified in the Thrift file.
 //
 //   true

--- a/ast/definition.go
+++ b/ast/definition.go
@@ -49,6 +49,8 @@ type Constant struct {
 func (*Constant) node()       {}
 func (*Constant) definition() {}
 
+func (c *Constant) lineNumber() int { return c.Line }
+
 func (c *Constant) visitChildren(ss nodeStack, v visitor) {
 	v.visit(ss, c.Type)
 	v.visit(ss, c.Value)
@@ -73,6 +75,8 @@ type Typedef struct {
 // Definition implementation for Typedef.
 func (*Typedef) node()       {}
 func (*Typedef) definition() {}
+
+func (t *Typedef) lineNumber() int { return t.Line }
 
 func (t *Typedef) visitChildren(ss nodeStack, v visitor) {
 	v.visit(ss, t.Type)
@@ -105,6 +109,8 @@ type Enum struct {
 func (*Enum) node()       {}
 func (*Enum) definition() {}
 
+func (e *Enum) lineNumber() int { return e.Line }
+
 func (e *Enum) visitChildren(ss nodeStack, v visitor) {
 	for _, item := range e.Items {
 		v.visit(ss, item)
@@ -130,6 +136,8 @@ type EnumItem struct {
 }
 
 func (*EnumItem) node() {}
+
+func (i *EnumItem) lineNumber() int { return i.Line }
 
 func (i *EnumItem) visitChildren(ss nodeStack, v visitor) {
 	for _, ann := range i.Annotations {
@@ -179,6 +187,8 @@ type Struct struct {
 func (*Struct) node()       {}
 func (*Struct) definition() {}
 
+func (s *Struct) lineNumber() int { return s.Line }
+
 func (s *Struct) visitChildren(ss nodeStack, v visitor) {
 	for _, field := range s.Fields {
 		v.visit(ss, field)
@@ -212,6 +222,8 @@ type Service struct {
 func (*Service) node()       {}
 func (*Service) definition() {}
 
+func (s *Service) lineNumber() int { return s.Line }
+
 func (s *Service) visitChildren(ss nodeStack, v visitor) {
 	for _, function := range s.Functions {
 		v.visit(ss, function)
@@ -243,6 +255,8 @@ type Function struct {
 }
 
 func (*Function) node() {}
+
+func (n *Function) lineNumber() int { return n.Line }
 
 func (n *Function) visitChildren(ss nodeStack, v visitor) {
 	v.visit(ss, n.ReturnType)
@@ -286,6 +300,8 @@ type Field struct {
 }
 
 func (*Field) node() {}
+
+func (n *Field) lineNumber() int { return n.Line }
 
 func (n *Field) visitChildren(ss nodeStack, v visitor) {
 	v.visit(ss, n.Type)

--- a/ast/header.go
+++ b/ast/header.go
@@ -50,6 +50,8 @@ type Include struct {
 func (*Include) node()   {}
 func (*Include) header() {}
 
+func (i *Include) lineNumber() int { return i.Line }
+
 func (*Include) visitChildren(nodeStack, visitor) {}
 
 // Info for Include.
@@ -69,6 +71,8 @@ type Namespace struct {
 
 func (*Namespace) node()   {}
 func (*Namespace) header() {}
+
+func (n *Namespace) lineNumber() int { return n.Line }
 
 func (*Namespace) visitChildren(nodeStack, visitor) {}
 

--- a/ast/line_no.go
+++ b/ast/line_no.go
@@ -20,44 +20,40 @@
 
 package ast
 
-import (
-	"fmt"
-	"strings"
-)
+// Nodes which know the line number they were defined on can implement this
+// interface.
+type nodeWithLine interface {
+	Node
 
-// Annotation represents a type annotation. Type annotations are key-value
-// pairs in the form,
-//
-// 	(foo = "bar", baz = "qux")
-//
-// They may be used to customize the generated code. Annotations are optional
-// anywhere in the code where they're accepted and may be skipped completely.
-type Annotation struct {
-	Name  string
-	Value string
-	Line  int
+	lineNumber() int
 }
 
-func (*Annotation) node() {}
-
-func (*Annotation) visitChildren(nodeStack, visitor) {}
-
-func (ann *Annotation) lineNumber() int { return ann.Line }
-
-func (ann *Annotation) String() string {
-	return fmt.Sprintf("%s = %q", ann.Name, ann.Value)
-}
-
-// FormatAnnotations formats a collection of annotations into a string.
-func FormatAnnotations(anns []*Annotation) string {
-	if len(anns) == 0 {
-		return ""
+// LineNumber returns the line in the file at which the given node was defined
+// or 0 if the Node does not record its line number.
+func LineNumber(n Node) int {
+	if nl, ok := n.(nodeWithLine); ok {
+		return nl.lineNumber()
 	}
-
-	as := make([]string, len(anns))
-	for i, ann := range anns {
-		as[i] = ann.String()
-	}
-
-	return "(" + strings.Join(as, ", ") + ")"
+	return 0
 }
+
+var _ nodeWithLine = (*Annotation)(nil)
+var _ nodeWithLine = BaseType{}
+var _ nodeWithLine = (*Constant)(nil)
+var _ nodeWithLine = ConstantList{}
+var _ nodeWithLine = ConstantMap{}
+var _ nodeWithLine = ConstantMapItem{}
+var _ nodeWithLine = ConstantReference{}
+var _ nodeWithLine = (*Enum)(nil)
+var _ nodeWithLine = (*EnumItem)(nil)
+var _ nodeWithLine = (*Field)(nil)
+var _ nodeWithLine = (*Function)(nil)
+var _ nodeWithLine = (*Include)(nil)
+var _ nodeWithLine = ListType{}
+var _ nodeWithLine = MapType{}
+var _ nodeWithLine = (*Namespace)(nil)
+var _ nodeWithLine = (*Service)(nil)
+var _ nodeWithLine = SetType{}
+var _ nodeWithLine = (*Struct)(nil)
+var _ nodeWithLine = TypeReference{}
+var _ nodeWithLine = (*Typedef)(nil)

--- a/ast/line_no_test.go
+++ b/ast/line_no_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ast
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLineNumber(t *testing.T) {
+	tests := []struct {
+		give Node
+		want int
+	}{
+		// The following don't record their line numbers because they're just
+		// type aliases. We can't change this anymore because converting them
+		// to structs is a breaking change.
+		{give: ConstantBoolean(true), want: 0},
+		{give: ConstantDouble(42.0), want: 0},
+		{give: ConstantInteger(42), want: 0},
+		{give: ConstantString("foo"), want: 0},
+
+		// Program is the whole Thrift file. It doesn't have a line number.
+		{give: &Program{}, want: 0},
+
+		{give: &Annotation{Line: 1}, want: 1},
+		{give: ConstantMap{Line: 2}, want: 2},
+		{give: ConstantMapItem{Line: 3}, want: 3},
+		{give: ConstantList{Line: 4}, want: 4},
+		{give: ConstantReference{Line: 5}, want: 5},
+		{give: &Constant{Line: 6}, want: 6},
+		{give: &Typedef{Line: 7}, want: 7},
+		{give: &Enum{Line: 8}, want: 8},
+		{give: &EnumItem{Line: 9}, want: 9},
+		{give: &Struct{Line: 10}, want: 10},
+		{give: &Service{Line: 11}, want: 11},
+		{give: &Function{Line: 12}, want: 12},
+		{give: &Field{Line: 13}, want: 13},
+		{give: &Include{Line: 14}, want: 14},
+		{give: &Namespace{Line: 15}, want: 15},
+		{give: BaseType{Line: 16}, want: 16},
+		{give: MapType{Line: 17}, want: 17},
+		{give: ListType{Line: 18}, want: 18},
+		{give: SetType{Line: 19}, want: 19},
+		{give: TypeReference{Line: 20}, want: 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%T", tt.give), func(t *testing.T) {
+			assert.Equal(t, tt.want, LineNumber(tt.give))
+		})
+	}
+}

--- a/ast/type.go
+++ b/ast/type.go
@@ -67,6 +67,8 @@ type BaseType struct {
 func (BaseType) node()      {}
 func (BaseType) fieldType() {}
 
+func (bt BaseType) lineNumber() int { return bt.Line }
+
 func (bt BaseType) visitChildren(ss nodeStack, v visitor) {
 	for _, ann := range bt.Annotations {
 		v.visit(ss, ann)
@@ -116,6 +118,8 @@ type MapType struct {
 func (MapType) node()      {}
 func (MapType) fieldType() {}
 
+func (mt MapType) lineNumber() int { return mt.Line }
+
 func (mt MapType) visitChildren(ss nodeStack, v visitor) {
 	v.visit(ss, mt.KeyType)
 	v.visit(ss, mt.ValueType)
@@ -147,6 +151,8 @@ type ListType struct {
 func (ListType) node()      {}
 func (ListType) fieldType() {}
 
+func (lt ListType) lineNumber() int { return lt.Line }
+
 func (lt ListType) visitChildren(ss nodeStack, v visitor) {
 	v.visit(ss, lt.ValueType)
 	for _, ann := range lt.Annotations {
@@ -177,6 +183,8 @@ type SetType struct {
 func (SetType) node()      {}
 func (SetType) fieldType() {}
 
+func (st SetType) lineNumber() int { return st.Line }
+
 func (st SetType) visitChildren(ss nodeStack, v visitor) {
 	v.visit(ss, st.ValueType)
 	for _, ann := range st.Annotations {
@@ -199,6 +207,8 @@ type TypeReference struct {
 
 func (TypeReference) node()      {}
 func (TypeReference) fieldType() {}
+
+func (tr TypeReference) lineNumber() int { return tr.Line }
 
 func (TypeReference) visitChildren(nodeStack, visitor) {}
 


### PR DESCRIPTION
This adds an ast.LineNumber function which returns the line on which a
Node was defined. This only works if the Node actually records the line
number it was defined on.

This is a useful function to have for code that is using `ast.Walk`. There
will be need of it in the linter.