### PR TITLE
main.go: exit non-zero if flag parsing fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,12 +77,15 @@ func do() (err error) {
 
 	var opts options
 
-	parser := flags.NewParser(&opts, flags.Default)
+	parser := flags.NewParser(&opts, flags.Default & ^flags.PrintErrors)
 	parser.Usage = "[OPTIONS] FILE"
 
 	args, err := parser.Parse()
-	if err != nil {
-		return nil // message already printed by go-flags
+	if ferr, ok := err.(*flags.Error); ok && ferr.Type == flags.ErrHelp {
+		parser.WriteHelp(os.Stdout)
+		return nil
+	} else if err != nil {
+		return err
 	}
 
 	if opts.DisplayVersion {


### PR DESCRIPTION
Currently, if an error is generated while parsing flags, an error
message is emitted by the go-flags package, but we then return a nil
error from do() causing the main function to exit with a zero status.

Let's take over the responsibility of emitting error messages from
go-flags and then propogate any errors that are produced during parsing
back up to the main function.  This means we need to handle ErrHelp
ourselves.