### PR TITLE
gen: Document generated entities

### DIFF
--- a/gen/field.go
+++ b/gen/field.go
@@ -210,6 +210,21 @@ func (f fieldGroupGenerator) ToWire(g Generator) error {
 		<$wire := import "go.uber.org/thriftrw/wire">
 
 		<$v := newVar "v">
+		// ToWire translates a <.Name> struct into a Thrift-level intermediate
+		// representation. This intermediate representation may be serialized
+		// into bytes using a ThriftRW protocol implementation.
+		//
+		// An error is returned if the struct or any of its fields failed to
+		// validate.
+		//
+		//   x, err := <$v>.ToWire()
+		//   if err != nil {
+		//     return err
+		//   }
+		//
+		//   if err := binaryProtocol.Encode(x, writer); err != nil {
+		//     return err
+		//   }
 		func (<$v> *<.Name>) ToWire() (<$wire>.Value, error) {
     		<$fields := newVar "fields" ->
     		<- $i := newVar "i" ->
@@ -284,6 +299,23 @@ func (f fieldGroupGenerator) FromWire(g Generator) error {
 
 		<$v := newVar "v">
 		<$w := newVar "w">
+		// FromWire deserializes a <.Name> struct from its Thrift-level
+		// representation. The Thrift-level representation may be obtained
+		// from a ThriftRW protocol implementation.
+		//
+		// An error is returned if we were unable to build a <.Name> struct
+		// from the provided intermediate representation.
+		//
+		//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+		//   if err != nil {
+		//     return nil, err
+		//   }
+		//
+		//   var <$v> <.Name>
+		//   if err := <$v>.FromWire(x); err != nil {
+		//     return nil, err
+		//   }
+		//   return &<$v>, nil
 		func (<$v> *<.Name>) FromWire(<$w> <$wire>.Value) error {
 			<if len .Fields> var err error <end>
 			<$f := newVar "field">
@@ -366,6 +398,8 @@ func (f fieldGroupGenerator) String(g Generator) error {
 		<$strings := import "strings">
 
 		<$v := newVar "v">
+		// String returns a readable string representation of a <.Name>
+		// struct.
 		func (<$v> *<.Name>) String() string {
 			if <$v> == nil {
 				return "<"<nil>">"
@@ -405,6 +439,10 @@ func (f fieldGroupGenerator) Equals(g Generator) error {
 		`
 		<$v := newVar "v">
 		<$rhs := newVar "rhs">
+		// Equals returns true if all the fields of this <.Name> match the
+		// provided <.Name>.
+		//
+		// This function performs a deep comparison.
 		func (<$v> *<.Name>) Equals(<$rhs> *<.Name>) bool {
 			<range .Fields>
 				<- $fname := goName . ->
@@ -439,6 +477,8 @@ func (f fieldGroupGenerator) PrimitiveAccessors(g Generator) error {
 			<reserveFieldOrMethod $fname>
 			<reserveFieldOrMethod (printf "Get%v" $fname)>
 			<if and (not .Required) (isPrimitiveType .Type)>
+			// Get<$fname> returns the value of <$fname> if it is set or its
+			// zero value if it is unset.
 			func (<$v> *<$name>) Get<$fname>() (<$o> <typeReference .Type>) {
 				if <$v>.<$fname> != nil {
 					return *<$v>.<$fname>

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -19,6 +19,21 @@ type AccessorConflict struct {
 	GetName2 *string `json:"get_name,omitempty"`
 }
 
+// ToWire translates a AccessorConflict struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *AccessorConflict) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -47,6 +62,23 @@ func (v *AccessorConflict) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a AccessorConflict struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a AccessorConflict struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v AccessorConflict
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *AccessorConflict) FromWire(w wire.Value) error {
 	var err error
 
@@ -78,6 +110,8 @@ func (v *AccessorConflict) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a AccessorConflict
+// struct.
 func (v *AccessorConflict) String() string {
 	if v == nil {
 		return "<nil>"
@@ -107,6 +141,10 @@ func _String_EqualsPtr(lhs, rhs *string) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this AccessorConflict match the
+// provided AccessorConflict.
+//
+// This function performs a deep comparison.
 func (v *AccessorConflict) Equals(rhs *AccessorConflict) bool {
 	if !_String_EqualsPtr(v.Name, rhs.Name) {
 		return false
@@ -118,6 +156,8 @@ func (v *AccessorConflict) Equals(rhs *AccessorConflict) bool {
 	return true
 }
 
+// GetName returns the value of Name if it is set or its
+// zero value if it is unset.
 func (v *AccessorConflict) GetName() (o string) {
 	if v.Name != nil {
 		return *v.Name
@@ -126,6 +166,8 @@ func (v *AccessorConflict) GetName() (o string) {
 	return
 }
 
+// GetGetName2 returns the value of GetName2 if it is set or its
+// zero value if it is unset.
 func (v *AccessorConflict) GetGetName2() (o string) {
 	if v.GetName2 != nil {
 		return *v.GetName2
@@ -139,6 +181,21 @@ type AccessorNoConflict struct {
 	GetName *string `json:"get_name,omitempty"`
 }
 
+// ToWire translates a AccessorNoConflict struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *AccessorNoConflict) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -167,6 +224,23 @@ func (v *AccessorNoConflict) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a AccessorNoConflict struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a AccessorNoConflict struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v AccessorNoConflict
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *AccessorNoConflict) FromWire(w wire.Value) error {
 	var err error
 
@@ -198,6 +272,8 @@ func (v *AccessorNoConflict) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a AccessorNoConflict
+// struct.
 func (v *AccessorNoConflict) String() string {
 	if v == nil {
 		return "<nil>"
@@ -217,6 +293,10 @@ func (v *AccessorNoConflict) String() string {
 	return fmt.Sprintf("AccessorNoConflict{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this AccessorNoConflict match the
+// provided AccessorNoConflict.
+//
+// This function performs a deep comparison.
 func (v *AccessorNoConflict) Equals(rhs *AccessorNoConflict) bool {
 	if !_String_EqualsPtr(v.Getname, rhs.Getname) {
 		return false
@@ -228,6 +308,8 @@ func (v *AccessorNoConflict) Equals(rhs *AccessorNoConflict) bool {
 	return true
 }
 
+// GetGetname returns the value of Getname if it is set or its
+// zero value if it is unset.
 func (v *AccessorNoConflict) GetGetname() (o string) {
 	if v.Getname != nil {
 		return *v.Getname
@@ -236,6 +318,8 @@ func (v *AccessorNoConflict) GetGetname() (o string) {
 	return
 }
 
+// GetGetName returns the value of GetName if it is set or its
+// zero value if it is unset.
 func (v *AccessorNoConflict) GetGetName() (o string) {
 	if v.GetName != nil {
 		return *v.GetName
@@ -246,22 +330,31 @@ func (v *AccessorNoConflict) GetGetName() (o string) {
 
 type LittlePotatoe int64
 
+// ToWire translates LittlePotatoe into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v LittlePotatoe) ToWire() (wire.Value, error) {
 	x := (int64)(v)
 	return wire.NewValueI64(x), error(nil)
 }
 
+// String returns a readable string representation of LittlePotatoe.
 func (v LittlePotatoe) String() string {
 	x := (int64)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes LittlePotatoe from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *LittlePotatoe) FromWire(w wire.Value) error {
 	x, err := w.GetI64(), error(nil)
 	*v = (LittlePotatoe)(x)
 	return err
 }
 
+// Equals returns true if this LittlePotatoe is equal to the provided
+// LittlePotatoe.
 func (lhs LittlePotatoe) Equals(rhs LittlePotatoe) bool {
 	return (lhs == rhs)
 }
@@ -276,6 +369,7 @@ const (
 	MyEnumFooBar2 MyEnum = 791
 )
 
+// MyEnum_Values returns all recognized values of MyEnum.
 func MyEnum_Values() []MyEnum {
 	return []MyEnum{
 		MyEnumX,
@@ -286,6 +380,11 @@ func MyEnum_Values() []MyEnum {
 	}
 }
 
+// UnmarshalText tries to decode MyEnum from a byte slice
+// containing its name.
+//
+//   var v MyEnum
+//   err := v.UnmarshalText([]byte("X"))
 func (v *MyEnum) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "X":
@@ -308,15 +407,34 @@ func (v *MyEnum) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates MyEnum into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v MyEnum) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes MyEnum from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return MyEnum(0), err
+//   }
+//
+//   var v MyEnum
+//   if err := v.FromWire(x); err != nil {
+//     return MyEnum(0), err
+//   }
+//   return v, nil
 func (v *MyEnum) FromWire(w wire.Value) error {
 	*v = (MyEnum)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of MyEnum.
 func (v MyEnum) String() string {
 	w := int32(v)
 	switch w {
@@ -334,10 +452,18 @@ func (v MyEnum) String() string {
 	return fmt.Sprintf("MyEnum(%d)", w)
 }
 
+// Equals returns true if this MyEnum value matches the provided
+// value.
 func (v MyEnum) Equals(rhs MyEnum) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes MyEnum into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v MyEnum) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 123:
@@ -354,6 +480,13 @@ func (v MyEnum) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode MyEnum from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *MyEnum) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -476,6 +609,21 @@ func (_Map_String_String_MapItemList) ValueType() wire.Type {
 
 func (_Map_String_String_MapItemList) Close() {}
 
+// ToWire translates a PrimitiveContainers struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -577,6 +725,23 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 	return o, err
 }
 
+// FromWire deserializes a PrimitiveContainers struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a PrimitiveContainers struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v PrimitiveContainers
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	var err error
 
@@ -612,6 +777,8 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a PrimitiveContainers
+// struct.
 func (v *PrimitiveContainers) String() string {
 	if v == nil {
 		return "<nil>"
@@ -681,6 +848,10 @@ func _Map_String_String_Equals(lhs, rhs map[string]string) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this PrimitiveContainers match the
+// provided PrimitiveContainers.
+//
+// This function performs a deep comparison.
 func (v *PrimitiveContainers) Equals(rhs *PrimitiveContainers) bool {
 	if !((v.A == nil && rhs.A == nil) || (v.A != nil && rhs.A != nil && _List_String_Equals(v.A, rhs.A))) {
 		return false
@@ -700,6 +871,21 @@ type StructCollision struct {
 	CollisionField2 string `json:"collision_field,required"`
 }
 
+// ToWire translates a StructCollision struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *StructCollision) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -725,6 +911,23 @@ func (v *StructCollision) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a StructCollision struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a StructCollision struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v StructCollision
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *StructCollision) FromWire(w wire.Value) error {
 	var err error
 
@@ -763,6 +966,8 @@ func (v *StructCollision) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a StructCollision
+// struct.
 func (v *StructCollision) String() string {
 	if v == nil {
 		return "<nil>"
@@ -778,6 +983,10 @@ func (v *StructCollision) String() string {
 	return fmt.Sprintf("StructCollision{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this StructCollision match the
+// provided StructCollision.
+//
+// This function performs a deep comparison.
 func (v *StructCollision) Equals(rhs *StructCollision) bool {
 	if !(v.CollisionField == rhs.CollisionField) {
 		return false
@@ -794,6 +1003,21 @@ type UnionCollision struct {
 	CollisionField2 *string `json:"collision_field,omitempty"`
 }
 
+// ToWire translates a UnionCollision struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *UnionCollision) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -826,6 +1050,23 @@ func (v *UnionCollision) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a UnionCollision struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a UnionCollision struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v UnionCollision
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *UnionCollision) FromWire(w wire.Value) error {
 	var err error
 
@@ -868,6 +1109,8 @@ func (v *UnionCollision) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a UnionCollision
+// struct.
 func (v *UnionCollision) String() string {
 	if v == nil {
 		return "<nil>"
@@ -897,6 +1140,10 @@ func _Bool_EqualsPtr(lhs, rhs *bool) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this UnionCollision match the
+// provided UnionCollision.
+//
+// This function performs a deep comparison.
 func (v *UnionCollision) Equals(rhs *UnionCollision) bool {
 	if !_Bool_EqualsPtr(v.CollisionField, rhs.CollisionField) {
 		return false
@@ -908,6 +1155,8 @@ func (v *UnionCollision) Equals(rhs *UnionCollision) bool {
 	return true
 }
 
+// GetCollisionField returns the value of CollisionField if it is set or its
+// zero value if it is unset.
 func (v *UnionCollision) GetCollisionField() (o bool) {
 	if v.CollisionField != nil {
 		return *v.CollisionField
@@ -916,6 +1165,8 @@ func (v *UnionCollision) GetCollisionField() (o bool) {
 	return
 }
 
+// GetCollisionField2 returns the value of CollisionField2 if it is set or its
+// zero value if it is unset.
 func (v *UnionCollision) GetCollisionField2() (o string) {
 	if v.CollisionField2 != nil {
 		return *v.CollisionField2
@@ -928,6 +1179,21 @@ type WithDefault struct {
 	Pouet *StructCollision2 `json:"pouet,omitempty"`
 }
 
+// ToWire translates a WithDefault struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *WithDefault) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -960,6 +1226,23 @@ func _StructCollision_Read(w wire.Value) (*StructCollision2, error) {
 	return &v, err
 }
 
+// FromWire deserializes a WithDefault struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a WithDefault struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v WithDefault
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *WithDefault) FromWire(w wire.Value) error {
 	var err error
 
@@ -986,6 +1269,8 @@ func (v *WithDefault) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a WithDefault
+// struct.
 func (v *WithDefault) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1001,6 +1286,10 @@ func (v *WithDefault) String() string {
 	return fmt.Sprintf("WithDefault{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this WithDefault match the
+// provided WithDefault.
+//
+// This function performs a deep comparison.
 func (v *WithDefault) Equals(rhs *WithDefault) bool {
 	if !((v.Pouet == nil && rhs.Pouet == nil) || (v.Pouet != nil && rhs.Pouet != nil && v.Pouet.Equals(rhs.Pouet))) {
 		return false
@@ -1011,22 +1300,31 @@ func (v *WithDefault) Equals(rhs *WithDefault) bool {
 
 type LittlePotatoe2 float64
 
+// ToWire translates LittlePotatoe2 into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v LittlePotatoe2) ToWire() (wire.Value, error) {
 	x := (float64)(v)
 	return wire.NewValueDouble(x), error(nil)
 }
 
+// String returns a readable string representation of LittlePotatoe2.
 func (v LittlePotatoe2) String() string {
 	x := (float64)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes LittlePotatoe2 from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *LittlePotatoe2) FromWire(w wire.Value) error {
 	x, err := w.GetDouble(), error(nil)
 	*v = (LittlePotatoe2)(x)
 	return err
 }
 
+// Equals returns true if this LittlePotatoe2 is equal to the provided
+// LittlePotatoe2.
 func (lhs LittlePotatoe2) Equals(rhs LittlePotatoe2) bool {
 	return (lhs == rhs)
 }
@@ -1039,6 +1337,7 @@ const (
 	MyEnum2Z MyEnum2 = 56
 )
 
+// MyEnum2_Values returns all recognized values of MyEnum2.
 func MyEnum2_Values() []MyEnum2 {
 	return []MyEnum2{
 		MyEnum2X,
@@ -1047,6 +1346,11 @@ func MyEnum2_Values() []MyEnum2 {
 	}
 }
 
+// UnmarshalText tries to decode MyEnum2 from a byte slice
+// containing its name.
+//
+//   var v MyEnum2
+//   err := v.UnmarshalText([]byte("X"))
 func (v *MyEnum2) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "X":
@@ -1063,15 +1367,34 @@ func (v *MyEnum2) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates MyEnum2 into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v MyEnum2) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes MyEnum2 from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return MyEnum2(0), err
+//   }
+//
+//   var v MyEnum2
+//   if err := v.FromWire(x); err != nil {
+//     return MyEnum2(0), err
+//   }
+//   return v, nil
 func (v *MyEnum2) FromWire(w wire.Value) error {
 	*v = (MyEnum2)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of MyEnum2.
 func (v MyEnum2) String() string {
 	w := int32(v)
 	switch w {
@@ -1085,10 +1408,18 @@ func (v MyEnum2) String() string {
 	return fmt.Sprintf("MyEnum2(%d)", w)
 }
 
+// Equals returns true if this MyEnum2 value matches the provided
+// value.
 func (v MyEnum2) Equals(rhs MyEnum2) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes MyEnum2 into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v MyEnum2) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 12:
@@ -1101,6 +1432,13 @@ func (v MyEnum2) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode MyEnum2 from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *MyEnum2) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -1135,6 +1473,21 @@ type StructCollision2 struct {
 	CollisionField2 string `json:"collision_field,required"`
 }
 
+// ToWire translates a StructCollision2 struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *StructCollision2) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1160,6 +1513,23 @@ func (v *StructCollision2) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a StructCollision2 struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a StructCollision2 struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v StructCollision2
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *StructCollision2) FromWire(w wire.Value) error {
 	var err error
 
@@ -1198,6 +1568,8 @@ func (v *StructCollision2) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a StructCollision2
+// struct.
 func (v *StructCollision2) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1213,6 +1585,10 @@ func (v *StructCollision2) String() string {
 	return fmt.Sprintf("StructCollision2{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this StructCollision2 match the
+// provided StructCollision2.
+//
+// This function performs a deep comparison.
 func (v *StructCollision2) Equals(rhs *StructCollision2) bool {
 	if !(v.CollisionField == rhs.CollisionField) {
 		return false
@@ -1229,6 +1605,21 @@ type UnionCollision2 struct {
 	CollisionField2 *string `json:"collision_field,omitempty"`
 }
 
+// ToWire translates a UnionCollision2 struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *UnionCollision2) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1261,6 +1652,23 @@ func (v *UnionCollision2) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a UnionCollision2 struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a UnionCollision2 struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v UnionCollision2
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *UnionCollision2) FromWire(w wire.Value) error {
 	var err error
 
@@ -1303,6 +1711,8 @@ func (v *UnionCollision2) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a UnionCollision2
+// struct.
 func (v *UnionCollision2) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1322,6 +1732,10 @@ func (v *UnionCollision2) String() string {
 	return fmt.Sprintf("UnionCollision2{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this UnionCollision2 match the
+// provided UnionCollision2.
+//
+// This function performs a deep comparison.
 func (v *UnionCollision2) Equals(rhs *UnionCollision2) bool {
 	if !_Bool_EqualsPtr(v.CollisionField, rhs.CollisionField) {
 		return false
@@ -1333,6 +1747,8 @@ func (v *UnionCollision2) Equals(rhs *UnionCollision2) bool {
 	return true
 }
 
+// GetCollisionField returns the value of CollisionField if it is set or its
+// zero value if it is unset.
 func (v *UnionCollision2) GetCollisionField() (o bool) {
 	if v.CollisionField != nil {
 		return *v.CollisionField
@@ -1341,6 +1757,8 @@ func (v *UnionCollision2) GetCollisionField() (o bool) {
 	return
 }
 
+// GetCollisionField2 returns the value of CollisionField2 if it is set or its
+// zero value if it is unset.
 func (v *UnionCollision2) GetCollisionField2() (o string) {
 	if v.CollisionField2 != nil {
 		return *v.CollisionField2

--- a/gen/testdata/containers/types.go
+++ b/gen/testdata/containers/types.go
@@ -606,6 +606,21 @@ func (_Map_Set_I32_List_Double_MapItemList) ValueType() wire.Type {
 
 func (_Map_Set_I32_List_Double_MapItemList) Close() {}
 
+// ToWire translates a ContainersOfContainers struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 	var (
 		fields [9]wire.Field
@@ -1107,6 +1122,23 @@ func _Map_Set_I32_List_Double_Read(m wire.MapItemList) ([]struct {
 	return o, err
 }
 
+// FromWire deserializes a ContainersOfContainers struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ContainersOfContainers struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ContainersOfContainers
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ContainersOfContainers) FromWire(w wire.Value) error {
 	var err error
 
@@ -1190,6 +1222,8 @@ func (v *ContainersOfContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ContainersOfContainers
+// struct.
 func (v *ContainersOfContainers) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1582,6 +1616,10 @@ func _Map_Set_I32_List_Double_Equals(lhs, rhs []struct {
 	return true
 }
 
+// Equals returns true if all the fields of this ContainersOfContainers match the
+// provided ContainersOfContainers.
+//
+// This function performs a deep comparison.
 func (v *ContainersOfContainers) Equals(rhs *ContainersOfContainers) bool {
 	if !((v.ListOfLists == nil && rhs.ListOfLists == nil) || (v.ListOfLists != nil && rhs.ListOfLists != nil && _List_List_I32_Equals(v.ListOfLists, rhs.ListOfLists))) {
 		return false
@@ -1707,6 +1745,21 @@ func (_Map_EnumWithDuplicateValues_I32_MapItemList) ValueType() wire.Type {
 
 func (_Map_EnumWithDuplicateValues_I32_MapItemList) Close() {}
 
+// ToWire translates a EnumContainers struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *EnumContainers) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -1826,6 +1879,23 @@ func _Map_EnumWithDuplicateValues_I32_Read(m wire.MapItemList) (map[enums.EnumWi
 	return o, err
 }
 
+// FromWire deserializes a EnumContainers struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a EnumContainers struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v EnumContainers
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *EnumContainers) FromWire(w wire.Value) error {
 	var err error
 
@@ -1861,6 +1931,8 @@ func (v *EnumContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a EnumContainers
+// struct.
 func (v *EnumContainers) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1930,6 +2002,10 @@ func _Map_EnumWithDuplicateValues_I32_Equals(lhs, rhs map[enums.EnumWithDuplicat
 	return true
 }
 
+// Equals returns true if all the fields of this EnumContainers match the
+// provided EnumContainers.
+//
+// This function performs a deep comparison.
 func (v *EnumContainers) Equals(rhs *EnumContainers) bool {
 	if !((v.ListOfEnums == nil && rhs.ListOfEnums == nil) || (v.ListOfEnums != nil && rhs.ListOfEnums != nil && _List_EnumDefault_Equals(v.ListOfEnums, rhs.ListOfEnums))) {
 		return false
@@ -2001,6 +2077,21 @@ func (_List_RecordType_1_ValueList) ValueType() wire.Type {
 
 func (_List_RecordType_1_ValueList) Close() {}
 
+// ToWire translates a ListOfConflictingEnums struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ListOfConflictingEnums) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2079,6 +2170,23 @@ func _List_RecordType_1_Read(l wire.ValueList) ([]enums.RecordType, error) {
 	return o, err
 }
 
+// FromWire deserializes a ListOfConflictingEnums struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ListOfConflictingEnums struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ListOfConflictingEnums
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ListOfConflictingEnums) FromWire(w wire.Value) error {
 	var err error
 
@@ -2117,6 +2225,8 @@ func (v *ListOfConflictingEnums) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ListOfConflictingEnums
+// struct.
 func (v *ListOfConflictingEnums) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2162,6 +2272,10 @@ func _List_RecordType_1_Equals(lhs, rhs []enums.RecordType) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this ListOfConflictingEnums match the
+// provided ListOfConflictingEnums.
+//
+// This function performs a deep comparison.
 func (v *ListOfConflictingEnums) Equals(rhs *ListOfConflictingEnums) bool {
 	if !_List_RecordType_Equals(v.Records, rhs.Records) {
 		return false
@@ -2233,6 +2347,21 @@ func (_List_UUID_1_ValueList) ValueType() wire.Type {
 
 func (_List_UUID_1_ValueList) Close() {}
 
+// ToWire translates a ListOfConflictingUUIDs struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ListOfConflictingUUIDs) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2311,6 +2440,23 @@ func _List_UUID_1_Read(l wire.ValueList) ([]uuid_conflict.UUID, error) {
 	return o, err
 }
 
+// FromWire deserializes a ListOfConflictingUUIDs struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ListOfConflictingUUIDs struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ListOfConflictingUUIDs
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ListOfConflictingUUIDs) FromWire(w wire.Value) error {
 	var err error
 
@@ -2349,6 +2495,8 @@ func (v *ListOfConflictingUUIDs) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ListOfConflictingUUIDs
+// struct.
 func (v *ListOfConflictingUUIDs) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2394,6 +2542,10 @@ func _List_UUID_1_Equals(lhs, rhs []uuid_conflict.UUID) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this ListOfConflictingUUIDs match the
+// provided ListOfConflictingUUIDs.
+//
+// This function performs a deep comparison.
 func (v *ListOfConflictingUUIDs) Equals(rhs *ListOfConflictingUUIDs) bool {
 	if !_List_UUID_Equals(v.Uuids, rhs.Uuids) {
 		return false
@@ -2494,6 +2646,21 @@ func (_Map_String_Binary_MapItemList) ValueType() wire.Type {
 
 func (_Map_String_Binary_MapItemList) Close() {}
 
+// ToWire translates a MapOfBinaryAndString struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *MapOfBinaryAndString) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2587,6 +2754,23 @@ func _Map_String_Binary_Read(m wire.MapItemList) (map[string][]byte, error) {
 	return o, err
 }
 
+// FromWire deserializes a MapOfBinaryAndString struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a MapOfBinaryAndString struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v MapOfBinaryAndString
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
 	var err error
 
@@ -2614,6 +2798,8 @@ func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a MapOfBinaryAndString
+// struct.
 func (v *MapOfBinaryAndString) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2683,6 +2869,10 @@ func _Map_String_Binary_Equals(lhs, rhs map[string][]byte) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this MapOfBinaryAndString match the
+// provided MapOfBinaryAndString.
+//
+// This function performs a deep comparison.
 func (v *MapOfBinaryAndString) Equals(rhs *MapOfBinaryAndString) bool {
 	if !((v.BinaryToString == nil && rhs.BinaryToString == nil) || (v.BinaryToString != nil && rhs.BinaryToString != nil && _Map_Binary_String_Equals(v.BinaryToString, rhs.BinaryToString))) {
 		return false
@@ -2854,6 +3044,21 @@ func (_Map_String_Bool_MapItemList) ValueType() wire.Type {
 
 func (_Map_String_Bool_MapItemList) Close() {}
 
+// ToWire translates a PrimitiveContainers struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 	var (
 		fields [6]wire.Field
@@ -3025,6 +3230,23 @@ func _Map_String_Bool_Read(m wire.MapItemList) (map[string]bool, error) {
 	return o, err
 }
 
+// FromWire deserializes a PrimitiveContainers struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a PrimitiveContainers struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v PrimitiveContainers
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	var err error
 
@@ -3084,6 +3306,8 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a PrimitiveContainers
+// struct.
 func (v *PrimitiveContainers) String() string {
 	if v == nil {
 		return "<nil>"
@@ -3197,6 +3421,10 @@ func _Map_String_Bool_Equals(lhs, rhs map[string]bool) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this PrimitiveContainers match the
+// provided PrimitiveContainers.
+//
+// This function performs a deep comparison.
 func (v *PrimitiveContainers) Equals(rhs *PrimitiveContainers) bool {
 	if !((v.ListOfBinary == nil && rhs.ListOfBinary == nil) || (v.ListOfBinary != nil && rhs.ListOfBinary != nil && _List_Binary_Equals(v.ListOfBinary, rhs.ListOfBinary))) {
 		return false
@@ -3261,6 +3489,21 @@ func (_Map_I64_Double_MapItemList) ValueType() wire.Type {
 
 func (_Map_I64_Double_MapItemList) Close() {}
 
+// ToWire translates a PrimitiveContainersRequired struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *PrimitiveContainersRequired) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -3328,6 +3571,23 @@ func _Map_I64_Double_Read(m wire.MapItemList) (map[int64]float64, error) {
 	return o, err
 }
 
+// FromWire deserializes a PrimitiveContainersRequired struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a PrimitiveContainersRequired struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v PrimitiveContainersRequired
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *PrimitiveContainersRequired) FromWire(w wire.Value) error {
 	var err error
 
@@ -3379,6 +3639,8 @@ func (v *PrimitiveContainersRequired) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a PrimitiveContainersRequired
+// struct.
 func (v *PrimitiveContainersRequired) String() string {
 	if v == nil {
 		return "<nil>"
@@ -3413,6 +3675,10 @@ func _Map_I64_Double_Equals(lhs, rhs map[int64]float64) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this PrimitiveContainersRequired match the
+// provided PrimitiveContainersRequired.
+//
+// This function performs a deep comparison.
 func (v *PrimitiveContainersRequired) Equals(rhs *PrimitiveContainersRequired) bool {
 	if !_List_String_Equals(v.ListOfStrings, rhs.ListOfStrings) {
 		return false

--- a/gen/testdata/enum_conflict/types.go
+++ b/gen/testdata/enum_conflict/types.go
@@ -21,6 +21,7 @@ const (
 	RecordTypeEmail RecordType = 1
 )
 
+// RecordType_Values returns all recognized values of RecordType.
 func RecordType_Values() []RecordType {
 	return []RecordType{
 		RecordTypeName,
@@ -28,6 +29,11 @@ func RecordType_Values() []RecordType {
 	}
 }
 
+// UnmarshalText tries to decode RecordType from a byte slice
+// containing its name.
+//
+//   var v RecordType
+//   err := v.UnmarshalText([]byte("Name"))
 func (v *RecordType) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "Name":
@@ -41,15 +47,34 @@ func (v *RecordType) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates RecordType into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v RecordType) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes RecordType from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return RecordType(0), err
+//   }
+//
+//   var v RecordType
+//   if err := v.FromWire(x); err != nil {
+//     return RecordType(0), err
+//   }
+//   return v, nil
 func (v *RecordType) FromWire(w wire.Value) error {
 	*v = (RecordType)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of RecordType.
 func (v RecordType) String() string {
 	w := int32(v)
 	switch w {
@@ -61,10 +86,18 @@ func (v RecordType) String() string {
 	return fmt.Sprintf("RecordType(%d)", w)
 }
 
+// Equals returns true if this RecordType value matches the provided
+// value.
 func (v RecordType) Equals(rhs RecordType) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes RecordType into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v RecordType) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 0:
@@ -75,6 +108,13 @@ func (v RecordType) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode RecordType from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *RecordType) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -117,6 +157,21 @@ func _RecordType_1_ptr(v enums.RecordType) *enums.RecordType {
 	return &v
 }
 
+// ToWire translates a Records struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Records) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -163,6 +218,23 @@ func _RecordType_1_Read(w wire.Value) (enums.RecordType, error) {
 	return v, err
 }
 
+// FromWire deserializes a Records struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Records struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Records
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Records) FromWire(w wire.Value) error {
 	var err error
 
@@ -202,6 +274,8 @@ func (v *Records) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Records
+// struct.
 func (v *Records) String() string {
 	if v == nil {
 		return "<nil>"
@@ -241,6 +315,10 @@ func _RecordType_1_EqualsPtr(lhs, rhs *enums.RecordType) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this Records match the
+// provided Records.
+//
+// This function performs a deep comparison.
 func (v *Records) Equals(rhs *Records) bool {
 	if !_RecordType_EqualsPtr(v.RecordType, rhs.RecordType) {
 		return false
@@ -252,6 +330,8 @@ func (v *Records) Equals(rhs *Records) bool {
 	return true
 }
 
+// GetRecordType returns the value of RecordType if it is set or its
+// zero value if it is unset.
 func (v *Records) GetRecordType() (o RecordType) {
 	if v.RecordType != nil {
 		return *v.RecordType
@@ -260,6 +340,8 @@ func (v *Records) GetRecordType() (o RecordType) {
 	return
 }
 
+// GetOtherRecordType returns the value of OtherRecordType if it is set or its
+// zero value if it is unset.
 func (v *Records) GetOtherRecordType() (o enums.RecordType) {
 	if v.OtherRecordType != nil {
 		return *v.OtherRecordType

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -15,6 +15,8 @@ import (
 
 type EmptyEnum int32
 
+// UnmarshalText tries to decode EmptyEnum from a byte slice
+// containing its name.
 func (v *EmptyEnum) UnmarshalText(value []byte) error {
 	switch string(value) {
 	default:
@@ -22,28 +24,62 @@ func (v *EmptyEnum) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates EmptyEnum into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v EmptyEnum) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes EmptyEnum from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return EmptyEnum(0), err
+//   }
+//
+//   var v EmptyEnum
+//   if err := v.FromWire(x); err != nil {
+//     return EmptyEnum(0), err
+//   }
+//   return v, nil
 func (v *EmptyEnum) FromWire(w wire.Value) error {
 	*v = (EmptyEnum)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of EmptyEnum.
 func (v EmptyEnum) String() string {
 	w := int32(v)
 	return fmt.Sprintf("EmptyEnum(%d)", w)
 }
 
+// Equals returns true if this EmptyEnum value matches the provided
+// value.
 func (v EmptyEnum) Equals(rhs EmptyEnum) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes EmptyEnum into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v EmptyEnum) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode EmptyEnum from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *EmptyEnum) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -81,6 +117,7 @@ const (
 	EnumDefaultBaz EnumDefault = 2
 )
 
+// EnumDefault_Values returns all recognized values of EnumDefault.
 func EnumDefault_Values() []EnumDefault {
 	return []EnumDefault{
 		EnumDefaultFoo,
@@ -89,6 +126,11 @@ func EnumDefault_Values() []EnumDefault {
 	}
 }
 
+// UnmarshalText tries to decode EnumDefault from a byte slice
+// containing its name.
+//
+//   var v EnumDefault
+//   err := v.UnmarshalText([]byte("Foo"))
 func (v *EnumDefault) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "Foo":
@@ -105,15 +147,34 @@ func (v *EnumDefault) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates EnumDefault into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v EnumDefault) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes EnumDefault from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return EnumDefault(0), err
+//   }
+//
+//   var v EnumDefault
+//   if err := v.FromWire(x); err != nil {
+//     return EnumDefault(0), err
+//   }
+//   return v, nil
 func (v *EnumDefault) FromWire(w wire.Value) error {
 	*v = (EnumDefault)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of EnumDefault.
 func (v EnumDefault) String() string {
 	w := int32(v)
 	switch w {
@@ -127,10 +188,18 @@ func (v EnumDefault) String() string {
 	return fmt.Sprintf("EnumDefault(%d)", w)
 }
 
+// Equals returns true if this EnumDefault value matches the provided
+// value.
 func (v EnumDefault) Equals(rhs EnumDefault) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes EnumDefault into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v EnumDefault) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 0:
@@ -143,6 +212,13 @@ func (v EnumDefault) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode EnumDefault from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *EnumDefault) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -186,6 +262,7 @@ const (
 	EnumWithDuplicateNameZ EnumWithDuplicateName = 8
 )
 
+// EnumWithDuplicateName_Values returns all recognized values of EnumWithDuplicateName.
 func EnumWithDuplicateName_Values() []EnumWithDuplicateName {
 	return []EnumWithDuplicateName{
 		EnumWithDuplicateNameA,
@@ -200,6 +277,11 @@ func EnumWithDuplicateName_Values() []EnumWithDuplicateName {
 	}
 }
 
+// UnmarshalText tries to decode EnumWithDuplicateName from a byte slice
+// containing its name.
+//
+//   var v EnumWithDuplicateName
+//   err := v.UnmarshalText([]byte("A"))
 func (v *EnumWithDuplicateName) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "A":
@@ -234,15 +316,34 @@ func (v *EnumWithDuplicateName) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates EnumWithDuplicateName into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v EnumWithDuplicateName) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes EnumWithDuplicateName from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return EnumWithDuplicateName(0), err
+//   }
+//
+//   var v EnumWithDuplicateName
+//   if err := v.FromWire(x); err != nil {
+//     return EnumWithDuplicateName(0), err
+//   }
+//   return v, nil
 func (v *EnumWithDuplicateName) FromWire(w wire.Value) error {
 	*v = (EnumWithDuplicateName)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of EnumWithDuplicateName.
 func (v EnumWithDuplicateName) String() string {
 	w := int32(v)
 	switch w {
@@ -268,10 +369,18 @@ func (v EnumWithDuplicateName) String() string {
 	return fmt.Sprintf("EnumWithDuplicateName(%d)", w)
 }
 
+// Equals returns true if this EnumWithDuplicateName value matches the provided
+// value.
 func (v EnumWithDuplicateName) Equals(rhs EnumWithDuplicateName) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes EnumWithDuplicateName into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v EnumWithDuplicateName) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 0:
@@ -296,6 +405,13 @@ func (v EnumWithDuplicateName) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode EnumWithDuplicateName from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *EnumWithDuplicateName) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -333,6 +449,7 @@ const (
 	EnumWithDuplicateValuesR EnumWithDuplicateValues = 0
 )
 
+// EnumWithDuplicateValues_Values returns all recognized values of EnumWithDuplicateValues.
 func EnumWithDuplicateValues_Values() []EnumWithDuplicateValues {
 	return []EnumWithDuplicateValues{
 		EnumWithDuplicateValuesP,
@@ -341,6 +458,11 @@ func EnumWithDuplicateValues_Values() []EnumWithDuplicateValues {
 	}
 }
 
+// UnmarshalText tries to decode EnumWithDuplicateValues from a byte slice
+// containing its name.
+//
+//   var v EnumWithDuplicateValues
+//   err := v.UnmarshalText([]byte("P"))
 func (v *EnumWithDuplicateValues) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "P":
@@ -357,15 +479,34 @@ func (v *EnumWithDuplicateValues) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates EnumWithDuplicateValues into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v EnumWithDuplicateValues) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes EnumWithDuplicateValues from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return EnumWithDuplicateValues(0), err
+//   }
+//
+//   var v EnumWithDuplicateValues
+//   if err := v.FromWire(x); err != nil {
+//     return EnumWithDuplicateValues(0), err
+//   }
+//   return v, nil
 func (v *EnumWithDuplicateValues) FromWire(w wire.Value) error {
 	*v = (EnumWithDuplicateValues)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of EnumWithDuplicateValues.
 func (v EnumWithDuplicateValues) String() string {
 	w := int32(v)
 	switch w {
@@ -377,10 +518,18 @@ func (v EnumWithDuplicateValues) String() string {
 	return fmt.Sprintf("EnumWithDuplicateValues(%d)", w)
 }
 
+// Equals returns true if this EnumWithDuplicateValues value matches the provided
+// value.
 func (v EnumWithDuplicateValues) Equals(rhs EnumWithDuplicateValues) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes EnumWithDuplicateValues into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v EnumWithDuplicateValues) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 0:
@@ -391,6 +540,13 @@ func (v EnumWithDuplicateValues) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode EnumWithDuplicateValues from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *EnumWithDuplicateValues) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -428,6 +584,7 @@ const (
 	EnumWithValuesZ EnumWithValues = 789
 )
 
+// EnumWithValues_Values returns all recognized values of EnumWithValues.
 func EnumWithValues_Values() []EnumWithValues {
 	return []EnumWithValues{
 		EnumWithValuesX,
@@ -436,6 +593,11 @@ func EnumWithValues_Values() []EnumWithValues {
 	}
 }
 
+// UnmarshalText tries to decode EnumWithValues from a byte slice
+// containing its name.
+//
+//   var v EnumWithValues
+//   err := v.UnmarshalText([]byte("X"))
 func (v *EnumWithValues) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "X":
@@ -452,15 +614,34 @@ func (v *EnumWithValues) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates EnumWithValues into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v EnumWithValues) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes EnumWithValues from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return EnumWithValues(0), err
+//   }
+//
+//   var v EnumWithValues
+//   if err := v.FromWire(x); err != nil {
+//     return EnumWithValues(0), err
+//   }
+//   return v, nil
 func (v *EnumWithValues) FromWire(w wire.Value) error {
 	*v = (EnumWithValues)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of EnumWithValues.
 func (v EnumWithValues) String() string {
 	w := int32(v)
 	switch w {
@@ -474,10 +655,18 @@ func (v EnumWithValues) String() string {
 	return fmt.Sprintf("EnumWithValues(%d)", w)
 }
 
+// Equals returns true if this EnumWithValues value matches the provided
+// value.
 func (v EnumWithValues) Equals(rhs EnumWithValues) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes EnumWithValues into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v EnumWithValues) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 123:
@@ -490,6 +679,13 @@ func (v EnumWithValues) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode EnumWithValues from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *EnumWithValues) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -535,6 +731,7 @@ const (
 	RecordTypeWorkAddress RecordType = 2
 )
 
+// RecordType_Values returns all recognized values of RecordType.
 func RecordType_Values() []RecordType {
 	return []RecordType{
 		RecordTypeName,
@@ -543,6 +740,11 @@ func RecordType_Values() []RecordType {
 	}
 }
 
+// UnmarshalText tries to decode RecordType from a byte slice
+// containing its name.
+//
+//   var v RecordType
+//   err := v.UnmarshalText([]byte("NAME"))
 func (v *RecordType) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "NAME":
@@ -559,15 +761,34 @@ func (v *RecordType) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates RecordType into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v RecordType) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes RecordType from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return RecordType(0), err
+//   }
+//
+//   var v RecordType
+//   if err := v.FromWire(x); err != nil {
+//     return RecordType(0), err
+//   }
+//   return v, nil
 func (v *RecordType) FromWire(w wire.Value) error {
 	*v = (RecordType)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of RecordType.
 func (v RecordType) String() string {
 	w := int32(v)
 	switch w {
@@ -581,10 +802,18 @@ func (v RecordType) String() string {
 	return fmt.Sprintf("RecordType(%d)", w)
 }
 
+// Equals returns true if this RecordType value matches the provided
+// value.
 func (v RecordType) Equals(rhs RecordType) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes RecordType into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v RecordType) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 0:
@@ -597,6 +826,13 @@ func (v RecordType) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode RecordType from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *RecordType) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -633,6 +869,7 @@ const (
 	RecordTypeValuesBar RecordTypeValues = 1
 )
 
+// RecordTypeValues_Values returns all recognized values of RecordTypeValues.
 func RecordTypeValues_Values() []RecordTypeValues {
 	return []RecordTypeValues{
 		RecordTypeValuesFoo,
@@ -640,6 +877,11 @@ func RecordTypeValues_Values() []RecordTypeValues {
 	}
 }
 
+// UnmarshalText tries to decode RecordTypeValues from a byte slice
+// containing its name.
+//
+//   var v RecordTypeValues
+//   err := v.UnmarshalText([]byte("FOO"))
 func (v *RecordTypeValues) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "FOO":
@@ -653,15 +895,34 @@ func (v *RecordTypeValues) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates RecordTypeValues into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v RecordTypeValues) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes RecordTypeValues from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return RecordTypeValues(0), err
+//   }
+//
+//   var v RecordTypeValues
+//   if err := v.FromWire(x); err != nil {
+//     return RecordTypeValues(0), err
+//   }
+//   return v, nil
 func (v *RecordTypeValues) FromWire(w wire.Value) error {
 	*v = (RecordTypeValues)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of RecordTypeValues.
 func (v RecordTypeValues) String() string {
 	w := int32(v)
 	switch w {
@@ -673,10 +934,18 @@ func (v RecordTypeValues) String() string {
 	return fmt.Sprintf("RecordTypeValues(%d)", w)
 }
 
+// Equals returns true if this RecordTypeValues value matches the provided
+// value.
 func (v RecordTypeValues) Equals(rhs RecordTypeValues) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes RecordTypeValues into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v RecordTypeValues) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 0:
@@ -687,6 +956,13 @@ func (v RecordTypeValues) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode RecordTypeValues from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *RecordTypeValues) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -720,6 +996,21 @@ type StructWithOptionalEnum struct {
 	E *EnumDefault `json:"e,omitempty"`
 }
 
+// ToWire translates a StructWithOptionalEnum struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *StructWithOptionalEnum) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -746,6 +1037,23 @@ func _EnumDefault_Read(w wire.Value) (EnumDefault, error) {
 	return v, err
 }
 
+// FromWire deserializes a StructWithOptionalEnum struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a StructWithOptionalEnum struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v StructWithOptionalEnum
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *StructWithOptionalEnum) FromWire(w wire.Value) error {
 	var err error
 
@@ -767,6 +1075,8 @@ func (v *StructWithOptionalEnum) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a StructWithOptionalEnum
+// struct.
 func (v *StructWithOptionalEnum) String() string {
 	if v == nil {
 		return "<nil>"
@@ -792,6 +1102,10 @@ func _EnumDefault_EqualsPtr(lhs, rhs *EnumDefault) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this StructWithOptionalEnum match the
+// provided StructWithOptionalEnum.
+//
+// This function performs a deep comparison.
 func (v *StructWithOptionalEnum) Equals(rhs *StructWithOptionalEnum) bool {
 	if !_EnumDefault_EqualsPtr(v.E, rhs.E) {
 		return false
@@ -800,6 +1114,8 @@ func (v *StructWithOptionalEnum) Equals(rhs *StructWithOptionalEnum) bool {
 	return true
 }
 
+// GetE returns the value of E if it is set or its
+// zero value if it is unset.
 func (v *StructWithOptionalEnum) GetE() (o EnumDefault) {
 	if v.E != nil {
 		return *v.E
@@ -816,6 +1132,7 @@ const (
 	LowerCaseEnumItems      LowerCaseEnum = 2
 )
 
+// LowerCaseEnum_Values returns all recognized values of LowerCaseEnum.
 func LowerCaseEnum_Values() []LowerCaseEnum {
 	return []LowerCaseEnum{
 		LowerCaseEnumContaining,
@@ -824,6 +1141,11 @@ func LowerCaseEnum_Values() []LowerCaseEnum {
 	}
 }
 
+// UnmarshalText tries to decode LowerCaseEnum from a byte slice
+// containing its name.
+//
+//   var v LowerCaseEnum
+//   err := v.UnmarshalText([]byte("containing"))
 func (v *LowerCaseEnum) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "containing":
@@ -840,15 +1162,34 @@ func (v *LowerCaseEnum) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates LowerCaseEnum into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v LowerCaseEnum) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes LowerCaseEnum from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return LowerCaseEnum(0), err
+//   }
+//
+//   var v LowerCaseEnum
+//   if err := v.FromWire(x); err != nil {
+//     return LowerCaseEnum(0), err
+//   }
+//   return v, nil
 func (v *LowerCaseEnum) FromWire(w wire.Value) error {
 	*v = (LowerCaseEnum)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of LowerCaseEnum.
 func (v LowerCaseEnum) String() string {
 	w := int32(v)
 	switch w {
@@ -862,10 +1203,18 @@ func (v LowerCaseEnum) String() string {
 	return fmt.Sprintf("LowerCaseEnum(%d)", w)
 }
 
+// Equals returns true if this LowerCaseEnum value matches the provided
+// value.
 func (v LowerCaseEnum) Equals(rhs LowerCaseEnum) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes LowerCaseEnum into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v LowerCaseEnum) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 0:
@@ -878,6 +1227,13 @@ func (v LowerCaseEnum) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode LowerCaseEnum from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *LowerCaseEnum) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()

--- a/gen/testdata/exceptions/types.go
+++ b/gen/testdata/exceptions/types.go
@@ -17,6 +17,21 @@ type DoesNotExistException struct {
 	Error2 *string `json:"Error,omitempty"`
 }
 
+// ToWire translates a DoesNotExistException struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *DoesNotExistException) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -43,6 +58,23 @@ func (v *DoesNotExistException) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a DoesNotExistException struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a DoesNotExistException struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v DoesNotExistException
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *DoesNotExistException) FromWire(w wire.Value) error {
 	var err error
 
@@ -78,6 +110,8 @@ func (v *DoesNotExistException) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a DoesNotExistException
+// struct.
 func (v *DoesNotExistException) String() string {
 	if v == nil {
 		return "<nil>"
@@ -105,6 +139,10 @@ func _String_EqualsPtr(lhs, rhs *string) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this DoesNotExistException match the
+// provided DoesNotExistException.
+//
+// This function performs a deep comparison.
 func (v *DoesNotExistException) Equals(rhs *DoesNotExistException) bool {
 	if !(v.Key == rhs.Key) {
 		return false
@@ -116,6 +154,8 @@ func (v *DoesNotExistException) Equals(rhs *DoesNotExistException) bool {
 	return true
 }
 
+// GetError2 returns the value of Error2 if it is set or its
+// zero value if it is unset.
 func (v *DoesNotExistException) GetError2() (o string) {
 	if v.Error2 != nil {
 		return *v.Error2
@@ -131,6 +171,21 @@ func (v *DoesNotExistException) Error() string {
 type EmptyException struct {
 }
 
+// ToWire translates a EmptyException struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *EmptyException) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -140,6 +195,23 @@ func (v *EmptyException) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a EmptyException struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a EmptyException struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v EmptyException
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *EmptyException) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -150,6 +222,8 @@ func (v *EmptyException) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a EmptyException
+// struct.
 func (v *EmptyException) String() string {
 	if v == nil {
 		return "<nil>"
@@ -161,6 +235,10 @@ func (v *EmptyException) String() string {
 	return fmt.Sprintf("EmptyException{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this EmptyException match the
+// provided EmptyException.
+//
+// This function performs a deep comparison.
 func (v *EmptyException) Equals(rhs *EmptyException) bool {
 
 	return true

--- a/gen/testdata/services/cache_clear.go
+++ b/gen/testdata/services/cache_clear.go
@@ -9,9 +9,27 @@ import (
 	"strings"
 )
 
+// Cache_Clear_Args represents the arguments for the Cache.clear function.
+//
+// The arguments for clear are sent and received over the wire as this struct.
 type Cache_Clear_Args struct {
 }
 
+// ToWire translates a Cache_Clear_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Cache_Clear_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -21,6 +39,23 @@ func (v *Cache_Clear_Args) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a Cache_Clear_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Cache_Clear_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Cache_Clear_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Cache_Clear_Args) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -31,6 +66,8 @@ func (v *Cache_Clear_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Cache_Clear_Args
+// struct.
 func (v *Cache_Clear_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -42,20 +79,36 @@ func (v *Cache_Clear_Args) String() string {
 	return fmt.Sprintf("Cache_Clear_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Cache_Clear_Args match the
+// provided Cache_Clear_Args.
+//
+// This function performs a deep comparison.
 func (v *Cache_Clear_Args) Equals(rhs *Cache_Clear_Args) bool {
 
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "clear" for this struct.
 func (v *Cache_Clear_Args) MethodName() string {
 	return "clear"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be OneWay for this struct.
 func (v *Cache_Clear_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.OneWay
 }
 
+// Cache_Clear_Helper provides functions that aid in handling the
+// parameters and return values of the Cache.clear
+// function.
 var Cache_Clear_Helper = struct {
+	// Args accepts the parameters of clear in-order and returns
+	// the arguments struct for the function.
 	Args func() *Cache_Clear_Args
 }{}
 

--- a/gen/testdata/services/cache_clearafter.go
+++ b/gen/testdata/services/cache_clearafter.go
@@ -9,10 +9,28 @@ import (
 	"strings"
 )
 
+// Cache_ClearAfter_Args represents the arguments for the Cache.clearAfter function.
+//
+// The arguments for clearAfter are sent and received over the wire as this struct.
 type Cache_ClearAfter_Args struct {
 	DurationMS *int64 `json:"durationMS,omitempty"`
 }
 
+// ToWire translates a Cache_ClearAfter_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Cache_ClearAfter_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -33,6 +51,23 @@ func (v *Cache_ClearAfter_Args) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a Cache_ClearAfter_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Cache_ClearAfter_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Cache_ClearAfter_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Cache_ClearAfter_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -54,6 +89,8 @@ func (v *Cache_ClearAfter_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Cache_ClearAfter_Args
+// struct.
 func (v *Cache_ClearAfter_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -79,6 +116,10 @@ func _I64_EqualsPtr(lhs, rhs *int64) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this Cache_ClearAfter_Args match the
+// provided Cache_ClearAfter_Args.
+//
+// This function performs a deep comparison.
 func (v *Cache_ClearAfter_Args) Equals(rhs *Cache_ClearAfter_Args) bool {
 	if !_I64_EqualsPtr(v.DurationMS, rhs.DurationMS) {
 		return false
@@ -87,6 +128,8 @@ func (v *Cache_ClearAfter_Args) Equals(rhs *Cache_ClearAfter_Args) bool {
 	return true
 }
 
+// GetDurationMS returns the value of DurationMS if it is set or its
+// zero value if it is unset.
 func (v *Cache_ClearAfter_Args) GetDurationMS() (o int64) {
 	if v.DurationMS != nil {
 		return *v.DurationMS
@@ -95,15 +138,27 @@ func (v *Cache_ClearAfter_Args) GetDurationMS() (o int64) {
 	return
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "clearAfter" for this struct.
 func (v *Cache_ClearAfter_Args) MethodName() string {
 	return "clearAfter"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be OneWay for this struct.
 func (v *Cache_ClearAfter_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.OneWay
 }
 
+// Cache_ClearAfter_Helper provides functions that aid in handling the
+// parameters and return values of the Cache.clearAfter
+// function.
 var Cache_ClearAfter_Helper = struct {
+	// Args accepts the parameters of clearAfter in-order and returns
+	// the arguments struct for the function.
 	Args func(
 		durationMS *int64,
 	) *Cache_ClearAfter_Args

--- a/gen/testdata/services/conflictingnames_setvalue.go
+++ b/gen/testdata/services/conflictingnames_setvalue.go
@@ -9,10 +9,28 @@ import (
 	"strings"
 )
 
+// ConflictingNames_SetValue_Args represents the arguments for the ConflictingNames.setValue function.
+//
+// The arguments for setValue are sent and received over the wire as this struct.
 type ConflictingNames_SetValue_Args struct {
 	Request *ConflictingNamesSetValueArgs `json:"request,omitempty"`
 }
 
+// ToWire translates a ConflictingNames_SetValue_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ConflictingNames_SetValue_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -39,6 +57,23 @@ func _ConflictingNamesSetValueArgs_Read(w wire.Value) (*ConflictingNamesSetValue
 	return &v, err
 }
 
+// FromWire deserializes a ConflictingNames_SetValue_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ConflictingNames_SetValue_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ConflictingNames_SetValue_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ConflictingNames_SetValue_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -58,6 +93,8 @@ func (v *ConflictingNames_SetValue_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ConflictingNames_SetValue_Args
+// struct.
 func (v *ConflictingNames_SetValue_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -73,6 +110,10 @@ func (v *ConflictingNames_SetValue_Args) String() string {
 	return fmt.Sprintf("ConflictingNames_SetValue_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this ConflictingNames_SetValue_Args match the
+// provided ConflictingNames_SetValue_Args.
+//
+// This function performs a deep comparison.
 func (v *ConflictingNames_SetValue_Args) Equals(rhs *ConflictingNames_SetValue_Args) bool {
 	if !((v.Request == nil && rhs.Request == nil) || (v.Request != nil && rhs.Request != nil && v.Request.Equals(rhs.Request))) {
 		return false
@@ -81,22 +122,64 @@ func (v *ConflictingNames_SetValue_Args) Equals(rhs *ConflictingNames_SetValue_A
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "setValue" for this struct.
 func (v *ConflictingNames_SetValue_Args) MethodName() string {
 	return "setValue"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *ConflictingNames_SetValue_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// ConflictingNames_SetValue_Helper provides functions that aid in handling the
+// parameters and return values of the ConflictingNames.setValue
+// function.
 var ConflictingNames_SetValue_Helper = struct {
+	// Args accepts the parameters of setValue in-order and returns
+	// the arguments struct for the function.
 	Args func(
 		request *ConflictingNamesSetValueArgs,
 	) *ConflictingNames_SetValue_Args
 
+	// IsException returns true if the given error can be thrown
+	// by setValue.
+	//
+	// An error can be thrown by setValue only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(error) (*ConflictingNames_SetValue_Result, error)
+	// WrapResponse returns the result struct for setValue
+	// given the error returned by it. The provided error may
+	// be nil if setValue did not fail.
+	//
+	// This allows mapping errors returned by setValue into a
+	// serializable result struct. WrapResponse returns a
+	// non-nil error if the provided error cannot be thrown by
+	// setValue
+	//
+	//   err := setValue(args)
+	//   result, err := ConflictingNames_SetValue_Helper.WrapResponse(err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from setValue: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(error) (*ConflictingNames_SetValue_Result, error)
+
+	// UnwrapResponse takes the result struct for setValue
+	// and returns the erorr returned by it (if any).
+	//
+	// The error is non-nil only if setValue threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   err := ConflictingNames_SetValue_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*ConflictingNames_SetValue_Result) error
 }{}
 
@@ -129,9 +212,27 @@ func init() {
 
 }
 
+// ConflictingNames_SetValue_Result represents the result of a ConflictingNames.setValue function call.
+//
+// The result of a setValue execution is sent and received over the wire as this struct.
 type ConflictingNames_SetValue_Result struct {
 }
 
+// ToWire translates a ConflictingNames_SetValue_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ConflictingNames_SetValue_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -141,6 +242,23 @@ func (v *ConflictingNames_SetValue_Result) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a ConflictingNames_SetValue_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ConflictingNames_SetValue_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ConflictingNames_SetValue_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ConflictingNames_SetValue_Result) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -151,6 +269,8 @@ func (v *ConflictingNames_SetValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ConflictingNames_SetValue_Result
+// struct.
 func (v *ConflictingNames_SetValue_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -162,15 +282,26 @@ func (v *ConflictingNames_SetValue_Result) String() string {
 	return fmt.Sprintf("ConflictingNames_SetValue_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this ConflictingNames_SetValue_Result match the
+// provided ConflictingNames_SetValue_Result.
+//
+// This function performs a deep comparison.
 func (v *ConflictingNames_SetValue_Result) Equals(rhs *ConflictingNames_SetValue_Result) bool {
 
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "setValue" for this struct.
 func (v *ConflictingNames_SetValue_Result) MethodName() string {
 	return "setValue"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *ConflictingNames_SetValue_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/gen/testdata/services/keyvalue_deletevalue.go
+++ b/gen/testdata/services/keyvalue_deletevalue.go
@@ -11,10 +11,28 @@ import (
 	"strings"
 )
 
+// KeyValue_DeleteValue_Args represents the arguments for the KeyValue.deleteValue function.
+//
+// The arguments for deleteValue are sent and received over the wire as this struct.
 type KeyValue_DeleteValue_Args struct {
 	Key *Key `json:"key,omitempty"`
 }
 
+// ToWire translates a KeyValue_DeleteValue_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_DeleteValue_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -41,6 +59,23 @@ func _Key_Read(w wire.Value) (Key, error) {
 	return x, err
 }
 
+// FromWire deserializes a KeyValue_DeleteValue_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_DeleteValue_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_DeleteValue_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_DeleteValue_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -62,6 +97,8 @@ func (v *KeyValue_DeleteValue_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_DeleteValue_Args
+// struct.
 func (v *KeyValue_DeleteValue_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -87,6 +124,10 @@ func _Key_EqualsPtr(lhs, rhs *Key) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this KeyValue_DeleteValue_Args match the
+// provided KeyValue_DeleteValue_Args.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_DeleteValue_Args) Equals(rhs *KeyValue_DeleteValue_Args) bool {
 	if !_Key_EqualsPtr(v.Key, rhs.Key) {
 		return false
@@ -95,6 +136,8 @@ func (v *KeyValue_DeleteValue_Args) Equals(rhs *KeyValue_DeleteValue_Args) bool 
 	return true
 }
 
+// GetKey returns the value of Key if it is set or its
+// zero value if it is unset.
 func (v *KeyValue_DeleteValue_Args) GetKey() (o Key) {
 	if v.Key != nil {
 		return *v.Key
@@ -103,22 +146,64 @@ func (v *KeyValue_DeleteValue_Args) GetKey() (o Key) {
 	return
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "deleteValue" for this struct.
 func (v *KeyValue_DeleteValue_Args) MethodName() string {
 	return "deleteValue"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *KeyValue_DeleteValue_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// KeyValue_DeleteValue_Helper provides functions that aid in handling the
+// parameters and return values of the KeyValue.deleteValue
+// function.
 var KeyValue_DeleteValue_Helper = struct {
+	// Args accepts the parameters of deleteValue in-order and returns
+	// the arguments struct for the function.
 	Args func(
 		key *Key,
 	) *KeyValue_DeleteValue_Args
 
+	// IsException returns true if the given error can be thrown
+	// by deleteValue.
+	//
+	// An error can be thrown by deleteValue only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(error) (*KeyValue_DeleteValue_Result, error)
+	// WrapResponse returns the result struct for deleteValue
+	// given the error returned by it. The provided error may
+	// be nil if deleteValue did not fail.
+	//
+	// This allows mapping errors returned by deleteValue into a
+	// serializable result struct. WrapResponse returns a
+	// non-nil error if the provided error cannot be thrown by
+	// deleteValue
+	//
+	//   err := deleteValue(args)
+	//   result, err := KeyValue_DeleteValue_Helper.WrapResponse(err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from deleteValue: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(error) (*KeyValue_DeleteValue_Result, error)
+
+	// UnwrapResponse takes the result struct for deleteValue
+	// and returns the erorr returned by it (if any).
+	//
+	// The error is non-nil only if deleteValue threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   err := KeyValue_DeleteValue_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*KeyValue_DeleteValue_Result) error
 }{}
 
@@ -176,12 +261,30 @@ func init() {
 
 }
 
+// KeyValue_DeleteValue_Result represents the result of a KeyValue.deleteValue function call.
+//
+// The result of a deleteValue execution is sent and received over the wire as this struct.
 type KeyValue_DeleteValue_Result struct {
 	// Raised if a value with the given key doesn't exist.
 	DoesNotExist  *exceptions.DoesNotExistException `json:"doesNotExist,omitempty"`
 	InternalError *InternalError                    `json:"internalError,omitempty"`
 }
 
+// ToWire translates a KeyValue_DeleteValue_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_DeleteValue_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -226,6 +329,23 @@ func _InternalError_Read(w wire.Value) (*InternalError, error) {
 	return &v, err
 }
 
+// FromWire deserializes a KeyValue_DeleteValue_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_DeleteValue_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_DeleteValue_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -264,6 +384,8 @@ func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_DeleteValue_Result
+// struct.
 func (v *KeyValue_DeleteValue_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -283,6 +405,10 @@ func (v *KeyValue_DeleteValue_Result) String() string {
 	return fmt.Sprintf("KeyValue_DeleteValue_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this KeyValue_DeleteValue_Result match the
+// provided KeyValue_DeleteValue_Result.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_DeleteValue_Result) Equals(rhs *KeyValue_DeleteValue_Result) bool {
 	if !((v.DoesNotExist == nil && rhs.DoesNotExist == nil) || (v.DoesNotExist != nil && rhs.DoesNotExist != nil && v.DoesNotExist.Equals(rhs.DoesNotExist))) {
 		return false
@@ -294,10 +420,17 @@ func (v *KeyValue_DeleteValue_Result) Equals(rhs *KeyValue_DeleteValue_Result) b
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "deleteValue" for this struct.
 func (v *KeyValue_DeleteValue_Result) MethodName() string {
 	return "deleteValue"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *KeyValue_DeleteValue_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/gen/testdata/services/keyvalue_getmanyvalues.go
+++ b/gen/testdata/services/keyvalue_getmanyvalues.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 )
 
+// KeyValue_GetManyValues_Args represents the arguments for the KeyValue.getManyValues function.
+//
+// The arguments for getManyValues are sent and received over the wire as this struct.
 type KeyValue_GetManyValues_Args struct {
 	Range []Key `json:"range"`
 }
@@ -42,6 +45,21 @@ func (_List_Key_ValueList) ValueType() wire.Type {
 
 func (_List_Key_ValueList) Close() {}
 
+// ToWire translates a KeyValue_GetManyValues_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_GetManyValues_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -80,6 +98,23 @@ func _List_Key_Read(l wire.ValueList) ([]Key, error) {
 	return o, err
 }
 
+// FromWire deserializes a KeyValue_GetManyValues_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_GetManyValues_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_GetManyValues_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_GetManyValues_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -99,6 +134,8 @@ func (v *KeyValue_GetManyValues_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_GetManyValues_Args
+// struct.
 func (v *KeyValue_GetManyValues_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -129,6 +166,10 @@ func _List_Key_Equals(lhs, rhs []Key) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this KeyValue_GetManyValues_Args match the
+// provided KeyValue_GetManyValues_Args.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_GetManyValues_Args) Equals(rhs *KeyValue_GetManyValues_Args) bool {
 	if !((v.Range == nil && rhs.Range == nil) || (v.Range != nil && rhs.Range != nil && _List_Key_Equals(v.Range, rhs.Range))) {
 		return false
@@ -137,22 +178,63 @@ func (v *KeyValue_GetManyValues_Args) Equals(rhs *KeyValue_GetManyValues_Args) b
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "getManyValues" for this struct.
 func (v *KeyValue_GetManyValues_Args) MethodName() string {
 	return "getManyValues"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *KeyValue_GetManyValues_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// KeyValue_GetManyValues_Helper provides functions that aid in handling the
+// parameters and return values of the KeyValue.getManyValues
+// function.
 var KeyValue_GetManyValues_Helper = struct {
+	// Args accepts the parameters of getManyValues in-order and returns
+	// the arguments struct for the function.
 	Args func(
 		range2 []Key,
 	) *KeyValue_GetManyValues_Args
 
+	// IsException returns true if the given error can be thrown
+	// by getManyValues.
+	//
+	// An error can be thrown by getManyValues only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func([]*unions.ArbitraryValue, error) (*KeyValue_GetManyValues_Result, error)
+	// WrapResponse returns the result struct for getManyValues
+	// given its return value and error.
+	//
+	// This allows mapping values and errors returned by
+	// getManyValues into a serializable result struct.
+	// WrapResponse returns a non-nil error if the provided
+	// error cannot be thrown by getManyValues
+	//
+	//   value, err := getManyValues(args)
+	//   result, err := KeyValue_GetManyValues_Helper.WrapResponse(value, err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from getManyValues: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func([]*unions.ArbitraryValue, error) (*KeyValue_GetManyValues_Result, error)
+
+	// UnwrapResponse takes the result struct for getManyValues
+	// and returns the value or error returned by it.
+	//
+	// The error is non-nil only if getManyValues threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   value, err := KeyValue_GetManyValues_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*KeyValue_GetManyValues_Result) ([]*unions.ArbitraryValue, error)
 }{}
 
@@ -206,7 +288,13 @@ func init() {
 
 }
 
+// KeyValue_GetManyValues_Result represents the result of a KeyValue.getManyValues function call.
+//
+// The result of a getManyValues execution is sent and received over the wire as this struct.
+//
+// Success is set only if the function did not throw an exception.
 type KeyValue_GetManyValues_Result struct {
+	// Value returned by getManyValues after a successful execution.
 	Success      []*unions.ArbitraryValue          `json:"success"`
 	DoesNotExist *exceptions.DoesNotExistException `json:"doesNotExist,omitempty"`
 }
@@ -240,6 +328,21 @@ func (_List_ArbitraryValue_ValueList) ValueType() wire.Type {
 
 func (_List_ArbitraryValue_ValueList) Close() {}
 
+// ToWire translates a KeyValue_GetManyValues_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_GetManyValues_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -296,6 +399,23 @@ func _List_ArbitraryValue_Read(l wire.ValueList) ([]*unions.ArbitraryValue, erro
 	return o, err
 }
 
+// FromWire deserializes a KeyValue_GetManyValues_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_GetManyValues_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_GetManyValues_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -334,6 +454,8 @@ func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_GetManyValues_Result
+// struct.
 func (v *KeyValue_GetManyValues_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -368,6 +490,10 @@ func _List_ArbitraryValue_Equals(lhs, rhs []*unions.ArbitraryValue) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this KeyValue_GetManyValues_Result match the
+// provided KeyValue_GetManyValues_Result.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_GetManyValues_Result) Equals(rhs *KeyValue_GetManyValues_Result) bool {
 	if !((v.Success == nil && rhs.Success == nil) || (v.Success != nil && rhs.Success != nil && _List_ArbitraryValue_Equals(v.Success, rhs.Success))) {
 		return false
@@ -379,10 +505,17 @@ func (v *KeyValue_GetManyValues_Result) Equals(rhs *KeyValue_GetManyValues_Resul
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "getManyValues" for this struct.
 func (v *KeyValue_GetManyValues_Result) MethodName() string {
 	return "getManyValues"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *KeyValue_GetManyValues_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/gen/testdata/services/keyvalue_getvalue.go
+++ b/gen/testdata/services/keyvalue_getvalue.go
@@ -12,10 +12,28 @@ import (
 	"strings"
 )
 
+// KeyValue_GetValue_Args represents the arguments for the KeyValue.getValue function.
+//
+// The arguments for getValue are sent and received over the wire as this struct.
 type KeyValue_GetValue_Args struct {
 	Key *Key `json:"key,omitempty"`
 }
 
+// ToWire translates a KeyValue_GetValue_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_GetValue_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -36,6 +54,23 @@ func (v *KeyValue_GetValue_Args) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a KeyValue_GetValue_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_GetValue_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_GetValue_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_GetValue_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -57,6 +92,8 @@ func (v *KeyValue_GetValue_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_GetValue_Args
+// struct.
 func (v *KeyValue_GetValue_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -72,6 +109,10 @@ func (v *KeyValue_GetValue_Args) String() string {
 	return fmt.Sprintf("KeyValue_GetValue_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this KeyValue_GetValue_Args match the
+// provided KeyValue_GetValue_Args.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_GetValue_Args) Equals(rhs *KeyValue_GetValue_Args) bool {
 	if !_Key_EqualsPtr(v.Key, rhs.Key) {
 		return false
@@ -80,6 +121,8 @@ func (v *KeyValue_GetValue_Args) Equals(rhs *KeyValue_GetValue_Args) bool {
 	return true
 }
 
+// GetKey returns the value of Key if it is set or its
+// zero value if it is unset.
 func (v *KeyValue_GetValue_Args) GetKey() (o Key) {
 	if v.Key != nil {
 		return *v.Key
@@ -88,22 +131,63 @@ func (v *KeyValue_GetValue_Args) GetKey() (o Key) {
 	return
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "getValue" for this struct.
 func (v *KeyValue_GetValue_Args) MethodName() string {
 	return "getValue"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *KeyValue_GetValue_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// KeyValue_GetValue_Helper provides functions that aid in handling the
+// parameters and return values of the KeyValue.getValue
+// function.
 var KeyValue_GetValue_Helper = struct {
+	// Args accepts the parameters of getValue in-order and returns
+	// the arguments struct for the function.
 	Args func(
 		key *Key,
 	) *KeyValue_GetValue_Args
 
+	// IsException returns true if the given error can be thrown
+	// by getValue.
+	//
+	// An error can be thrown by getValue only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(*unions.ArbitraryValue, error) (*KeyValue_GetValue_Result, error)
+	// WrapResponse returns the result struct for getValue
+	// given its return value and error.
+	//
+	// This allows mapping values and errors returned by
+	// getValue into a serializable result struct.
+	// WrapResponse returns a non-nil error if the provided
+	// error cannot be thrown by getValue
+	//
+	//   value, err := getValue(args)
+	//   result, err := KeyValue_GetValue_Helper.WrapResponse(value, err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from getValue: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(*unions.ArbitraryValue, error) (*KeyValue_GetValue_Result, error)
+
+	// UnwrapResponse takes the result struct for getValue
+	// and returns the value or error returned by it.
+	//
+	// The error is non-nil only if getValue threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   value, err := KeyValue_GetValue_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*KeyValue_GetValue_Result) (*unions.ArbitraryValue, error)
 }{}
 
@@ -157,11 +241,32 @@ func init() {
 
 }
 
+// KeyValue_GetValue_Result represents the result of a KeyValue.getValue function call.
+//
+// The result of a getValue execution is sent and received over the wire as this struct.
+//
+// Success is set only if the function did not throw an exception.
 type KeyValue_GetValue_Result struct {
+	// Value returned by getValue after a successful execution.
 	Success      *unions.ArbitraryValue            `json:"success,omitempty"`
 	DoesNotExist *exceptions.DoesNotExistException `json:"doesNotExist,omitempty"`
 }
 
+// ToWire translates a KeyValue_GetValue_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_GetValue_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -194,6 +299,23 @@ func (v *KeyValue_GetValue_Result) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a KeyValue_GetValue_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_GetValue_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_GetValue_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -232,6 +354,8 @@ func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_GetValue_Result
+// struct.
 func (v *KeyValue_GetValue_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -251,6 +375,10 @@ func (v *KeyValue_GetValue_Result) String() string {
 	return fmt.Sprintf("KeyValue_GetValue_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this KeyValue_GetValue_Result match the
+// provided KeyValue_GetValue_Result.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_GetValue_Result) Equals(rhs *KeyValue_GetValue_Result) bool {
 	if !((v.Success == nil && rhs.Success == nil) || (v.Success != nil && rhs.Success != nil && v.Success.Equals(rhs.Success))) {
 		return false
@@ -262,10 +390,17 @@ func (v *KeyValue_GetValue_Result) Equals(rhs *KeyValue_GetValue_Result) bool {
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "getValue" for this struct.
 func (v *KeyValue_GetValue_Result) MethodName() string {
 	return "getValue"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *KeyValue_GetValue_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/gen/testdata/services/keyvalue_setvalue.go
+++ b/gen/testdata/services/keyvalue_setvalue.go
@@ -10,11 +10,29 @@ import (
 	"strings"
 )
 
+// KeyValue_SetValue_Args represents the arguments for the KeyValue.setValue function.
+//
+// The arguments for setValue are sent and received over the wire as this struct.
 type KeyValue_SetValue_Args struct {
 	Key   *Key                   `json:"key,omitempty"`
 	Value *unions.ArbitraryValue `json:"value,omitempty"`
 }
 
+// ToWire translates a KeyValue_SetValue_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_SetValue_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -43,6 +61,23 @@ func (v *KeyValue_SetValue_Args) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a KeyValue_SetValue_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_SetValue_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_SetValue_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -72,6 +107,8 @@ func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_SetValue_Args
+// struct.
 func (v *KeyValue_SetValue_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -91,6 +128,10 @@ func (v *KeyValue_SetValue_Args) String() string {
 	return fmt.Sprintf("KeyValue_SetValue_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this KeyValue_SetValue_Args match the
+// provided KeyValue_SetValue_Args.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_SetValue_Args) Equals(rhs *KeyValue_SetValue_Args) bool {
 	if !_Key_EqualsPtr(v.Key, rhs.Key) {
 		return false
@@ -102,6 +143,8 @@ func (v *KeyValue_SetValue_Args) Equals(rhs *KeyValue_SetValue_Args) bool {
 	return true
 }
 
+// GetKey returns the value of Key if it is set or its
+// zero value if it is unset.
 func (v *KeyValue_SetValue_Args) GetKey() (o Key) {
 	if v.Key != nil {
 		return *v.Key
@@ -110,23 +153,65 @@ func (v *KeyValue_SetValue_Args) GetKey() (o Key) {
 	return
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "setValue" for this struct.
 func (v *KeyValue_SetValue_Args) MethodName() string {
 	return "setValue"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *KeyValue_SetValue_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// KeyValue_SetValue_Helper provides functions that aid in handling the
+// parameters and return values of the KeyValue.setValue
+// function.
 var KeyValue_SetValue_Helper = struct {
+	// Args accepts the parameters of setValue in-order and returns
+	// the arguments struct for the function.
 	Args func(
 		key *Key,
 		value *unions.ArbitraryValue,
 	) *KeyValue_SetValue_Args
 
+	// IsException returns true if the given error can be thrown
+	// by setValue.
+	//
+	// An error can be thrown by setValue only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(error) (*KeyValue_SetValue_Result, error)
+	// WrapResponse returns the result struct for setValue
+	// given the error returned by it. The provided error may
+	// be nil if setValue did not fail.
+	//
+	// This allows mapping errors returned by setValue into a
+	// serializable result struct. WrapResponse returns a
+	// non-nil error if the provided error cannot be thrown by
+	// setValue
+	//
+	//   err := setValue(args)
+	//   result, err := KeyValue_SetValue_Helper.WrapResponse(err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from setValue: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(error) (*KeyValue_SetValue_Result, error)
+
+	// UnwrapResponse takes the result struct for setValue
+	// and returns the erorr returned by it (if any).
+	//
+	// The error is non-nil only if setValue threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   err := KeyValue_SetValue_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*KeyValue_SetValue_Result) error
 }{}
 
@@ -161,9 +246,27 @@ func init() {
 
 }
 
+// KeyValue_SetValue_Result represents the result of a KeyValue.setValue function call.
+//
+// The result of a setValue execution is sent and received over the wire as this struct.
 type KeyValue_SetValue_Result struct {
 }
 
+// ToWire translates a KeyValue_SetValue_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_SetValue_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -173,6 +276,23 @@ func (v *KeyValue_SetValue_Result) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a KeyValue_SetValue_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_SetValue_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_SetValue_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_SetValue_Result) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -183,6 +303,8 @@ func (v *KeyValue_SetValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_SetValue_Result
+// struct.
 func (v *KeyValue_SetValue_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -194,15 +316,26 @@ func (v *KeyValue_SetValue_Result) String() string {
 	return fmt.Sprintf("KeyValue_SetValue_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this KeyValue_SetValue_Result match the
+// provided KeyValue_SetValue_Result.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_SetValue_Result) Equals(rhs *KeyValue_SetValue_Result) bool {
 
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "setValue" for this struct.
 func (v *KeyValue_SetValue_Result) MethodName() string {
 	return "setValue"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *KeyValue_SetValue_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/gen/testdata/services/keyvalue_setvaluev2.go
+++ b/gen/testdata/services/keyvalue_setvaluev2.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 )
 
+// KeyValue_SetValueV2_Args represents the arguments for the KeyValue.setValueV2 function.
+//
+// The arguments for setValueV2 are sent and received over the wire as this struct.
 type KeyValue_SetValueV2_Args struct {
 	// Key to change.
 	Key Key `json:"key,required"`
@@ -20,6 +23,21 @@ type KeyValue_SetValueV2_Args struct {
 	Value *unions.ArbitraryValue `json:"value,required"`
 }
 
+// ToWire translates a KeyValue_SetValueV2_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_SetValueV2_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -47,6 +65,23 @@ func (v *KeyValue_SetValueV2_Args) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a KeyValue_SetValueV2_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_SetValueV2_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_SetValueV2_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -85,6 +120,8 @@ func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_SetValueV2_Args
+// struct.
 func (v *KeyValue_SetValueV2_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -100,6 +137,10 @@ func (v *KeyValue_SetValueV2_Args) String() string {
 	return fmt.Sprintf("KeyValue_SetValueV2_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this KeyValue_SetValueV2_Args match the
+// provided KeyValue_SetValueV2_Args.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_SetValueV2_Args) Equals(rhs *KeyValue_SetValueV2_Args) bool {
 	if !(v.Key == rhs.Key) {
 		return false
@@ -111,23 +152,65 @@ func (v *KeyValue_SetValueV2_Args) Equals(rhs *KeyValue_SetValueV2_Args) bool {
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "setValueV2" for this struct.
 func (v *KeyValue_SetValueV2_Args) MethodName() string {
 	return "setValueV2"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *KeyValue_SetValueV2_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// KeyValue_SetValueV2_Helper provides functions that aid in handling the
+// parameters and return values of the KeyValue.setValueV2
+// function.
 var KeyValue_SetValueV2_Helper = struct {
+	// Args accepts the parameters of setValueV2 in-order and returns
+	// the arguments struct for the function.
 	Args func(
 		key Key,
 		value *unions.ArbitraryValue,
 	) *KeyValue_SetValueV2_Args
 
+	// IsException returns true if the given error can be thrown
+	// by setValueV2.
+	//
+	// An error can be thrown by setValueV2 only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(error) (*KeyValue_SetValueV2_Result, error)
+	// WrapResponse returns the result struct for setValueV2
+	// given the error returned by it. The provided error may
+	// be nil if setValueV2 did not fail.
+	//
+	// This allows mapping errors returned by setValueV2 into a
+	// serializable result struct. WrapResponse returns a
+	// non-nil error if the provided error cannot be thrown by
+	// setValueV2
+	//
+	//   err := setValueV2(args)
+	//   result, err := KeyValue_SetValueV2_Helper.WrapResponse(err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from setValueV2: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(error) (*KeyValue_SetValueV2_Result, error)
+
+	// UnwrapResponse takes the result struct for setValueV2
+	// and returns the erorr returned by it (if any).
+	//
+	// The error is non-nil only if setValueV2 threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   err := KeyValue_SetValueV2_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*KeyValue_SetValueV2_Result) error
 }{}
 
@@ -162,9 +245,27 @@ func init() {
 
 }
 
+// KeyValue_SetValueV2_Result represents the result of a KeyValue.setValueV2 function call.
+//
+// The result of a setValueV2 execution is sent and received over the wire as this struct.
 type KeyValue_SetValueV2_Result struct {
 }
 
+// ToWire translates a KeyValue_SetValueV2_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_SetValueV2_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -174,6 +275,23 @@ func (v *KeyValue_SetValueV2_Result) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a KeyValue_SetValueV2_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_SetValueV2_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_SetValueV2_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_SetValueV2_Result) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -184,6 +302,8 @@ func (v *KeyValue_SetValueV2_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_SetValueV2_Result
+// struct.
 func (v *KeyValue_SetValueV2_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -195,15 +315,26 @@ func (v *KeyValue_SetValueV2_Result) String() string {
 	return fmt.Sprintf("KeyValue_SetValueV2_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this KeyValue_SetValueV2_Result match the
+// provided KeyValue_SetValueV2_Result.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_SetValueV2_Result) Equals(rhs *KeyValue_SetValueV2_Result) bool {
 
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "setValueV2" for this struct.
 func (v *KeyValue_SetValueV2_Result) MethodName() string {
 	return "setValueV2"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *KeyValue_SetValueV2_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/gen/testdata/services/keyvalue_size.go
+++ b/gen/testdata/services/keyvalue_size.go
@@ -10,9 +10,27 @@ import (
 	"strings"
 )
 
+// KeyValue_Size_Args represents the arguments for the KeyValue.size function.
+//
+// The arguments for size are sent and received over the wire as this struct.
 type KeyValue_Size_Args struct {
 }
 
+// ToWire translates a KeyValue_Size_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_Size_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -22,6 +40,23 @@ func (v *KeyValue_Size_Args) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a KeyValue_Size_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_Size_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_Size_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_Size_Args) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -32,6 +67,8 @@ func (v *KeyValue_Size_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_Size_Args
+// struct.
 func (v *KeyValue_Size_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -43,25 +80,70 @@ func (v *KeyValue_Size_Args) String() string {
 	return fmt.Sprintf("KeyValue_Size_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this KeyValue_Size_Args match the
+// provided KeyValue_Size_Args.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_Size_Args) Equals(rhs *KeyValue_Size_Args) bool {
 
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "size" for this struct.
 func (v *KeyValue_Size_Args) MethodName() string {
 	return "size"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *KeyValue_Size_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// KeyValue_Size_Helper provides functions that aid in handling the
+// parameters and return values of the KeyValue.size
+// function.
 var KeyValue_Size_Helper = struct {
+	// Args accepts the parameters of size in-order and returns
+	// the arguments struct for the function.
 	Args func() *KeyValue_Size_Args
 
+	// IsException returns true if the given error can be thrown
+	// by size.
+	//
+	// An error can be thrown by size only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(int64, error) (*KeyValue_Size_Result, error)
+	// WrapResponse returns the result struct for size
+	// given its return value and error.
+	//
+	// This allows mapping values and errors returned by
+	// size into a serializable result struct.
+	// WrapResponse returns a non-nil error if the provided
+	// error cannot be thrown by size
+	//
+	//   value, err := size(args)
+	//   result, err := KeyValue_Size_Helper.WrapResponse(value, err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from size: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(int64, error) (*KeyValue_Size_Result, error)
+
+	// UnwrapResponse takes the result struct for size
+	// and returns the value or error returned by it.
+	//
+	// The error is non-nil only if size threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   value, err := KeyValue_Size_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*KeyValue_Size_Result) (int64, error)
 }{}
 
@@ -97,10 +179,31 @@ func init() {
 
 }
 
+// KeyValue_Size_Result represents the result of a KeyValue.size function call.
+//
+// The result of a size execution is sent and received over the wire as this struct.
+//
+// Success is set only if the function did not throw an exception.
 type KeyValue_Size_Result struct {
+	// Value returned by size after a successful execution.
 	Success *int64 `json:"success,omitempty"`
 }
 
+// ToWire translates a KeyValue_Size_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *KeyValue_Size_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -125,6 +228,23 @@ func (v *KeyValue_Size_Result) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a KeyValue_Size_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a KeyValue_Size_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v KeyValue_Size_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *KeyValue_Size_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -154,6 +274,8 @@ func (v *KeyValue_Size_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a KeyValue_Size_Result
+// struct.
 func (v *KeyValue_Size_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -169,6 +291,10 @@ func (v *KeyValue_Size_Result) String() string {
 	return fmt.Sprintf("KeyValue_Size_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this KeyValue_Size_Result match the
+// provided KeyValue_Size_Result.
+//
+// This function performs a deep comparison.
 func (v *KeyValue_Size_Result) Equals(rhs *KeyValue_Size_Result) bool {
 	if !_I64_EqualsPtr(v.Success, rhs.Success) {
 		return false
@@ -177,6 +303,8 @@ func (v *KeyValue_Size_Result) Equals(rhs *KeyValue_Size_Result) bool {
 	return true
 }
 
+// GetSuccess returns the value of Success if it is set or its
+// zero value if it is unset.
 func (v *KeyValue_Size_Result) GetSuccess() (o int64) {
 	if v.Success != nil {
 		return *v.Success
@@ -185,10 +313,17 @@ func (v *KeyValue_Size_Result) GetSuccess() (o int64) {
 	return
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "size" for this struct.
 func (v *KeyValue_Size_Result) MethodName() string {
 	return "size"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *KeyValue_Size_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/gen/testdata/services/non_standard_service_name_non_standard_function_name.go
+++ b/gen/testdata/services/non_standard_service_name_non_standard_function_name.go
@@ -9,9 +9,27 @@ import (
 	"strings"
 )
 
+// NonStandardServiceName_NonStandardFunctionName_Args represents the arguments for the non_standard_service_name.non_standard_function_name function.
+//
+// The arguments for non_standard_function_name are sent and received over the wire as this struct.
 type NonStandardServiceName_NonStandardFunctionName_Args struct {
 }
 
+// ToWire translates a NonStandardServiceName_NonStandardFunctionName_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -21,6 +39,23 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) ToWire() (wire.Val
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a NonStandardServiceName_NonStandardFunctionName_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a NonStandardServiceName_NonStandardFunctionName_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v NonStandardServiceName_NonStandardFunctionName_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -31,6 +66,8 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) FromWire(w wire.Va
 	return nil
 }
 
+// String returns a readable string representation of a NonStandardServiceName_NonStandardFunctionName_Args
+// struct.
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -42,25 +79,71 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) String() string {
 	return fmt.Sprintf("NonStandardServiceName_NonStandardFunctionName_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this NonStandardServiceName_NonStandardFunctionName_Args match the
+// provided NonStandardServiceName_NonStandardFunctionName_Args.
+//
+// This function performs a deep comparison.
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) Equals(rhs *NonStandardServiceName_NonStandardFunctionName_Args) bool {
 
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "non_standard_function_name" for this struct.
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) MethodName() string {
 	return "non_standard_function_name"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// NonStandardServiceName_NonStandardFunctionName_Helper provides functions that aid in handling the
+// parameters and return values of the non_standard_service_name.non_standard_function_name
+// function.
 var NonStandardServiceName_NonStandardFunctionName_Helper = struct {
+	// Args accepts the parameters of non_standard_function_name in-order and returns
+	// the arguments struct for the function.
 	Args func() *NonStandardServiceName_NonStandardFunctionName_Args
 
+	// IsException returns true if the given error can be thrown
+	// by non_standard_function_name.
+	//
+	// An error can be thrown by non_standard_function_name only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(error) (*NonStandardServiceName_NonStandardFunctionName_Result, error)
+	// WrapResponse returns the result struct for non_standard_function_name
+	// given the error returned by it. The provided error may
+	// be nil if non_standard_function_name did not fail.
+	//
+	// This allows mapping errors returned by non_standard_function_name into a
+	// serializable result struct. WrapResponse returns a
+	// non-nil error if the provided error cannot be thrown by
+	// non_standard_function_name
+	//
+	//   err := non_standard_function_name(args)
+	//   result, err := NonStandardServiceName_NonStandardFunctionName_Helper.WrapResponse(err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from non_standard_function_name: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(error) (*NonStandardServiceName_NonStandardFunctionName_Result, error)
+
+	// UnwrapResponse takes the result struct for non_standard_function_name
+	// and returns the erorr returned by it (if any).
+	//
+	// The error is non-nil only if non_standard_function_name threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   err := NonStandardServiceName_NonStandardFunctionName_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*NonStandardServiceName_NonStandardFunctionName_Result) error
 }{}
 
@@ -89,9 +172,27 @@ func init() {
 
 }
 
+// NonStandardServiceName_NonStandardFunctionName_Result represents the result of a non_standard_service_name.non_standard_function_name function call.
+//
+// The result of a non_standard_function_name execution is sent and received over the wire as this struct.
 type NonStandardServiceName_NonStandardFunctionName_Result struct {
 }
 
+// ToWire translates a NonStandardServiceName_NonStandardFunctionName_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -101,6 +202,23 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) ToWire() (wire.V
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a NonStandardServiceName_NonStandardFunctionName_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a NonStandardServiceName_NonStandardFunctionName_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v NonStandardServiceName_NonStandardFunctionName_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -111,6 +229,8 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) FromWire(w wire.
 	return nil
 }
 
+// String returns a readable string representation of a NonStandardServiceName_NonStandardFunctionName_Result
+// struct.
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -122,15 +242,26 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) String() string 
 	return fmt.Sprintf("NonStandardServiceName_NonStandardFunctionName_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this NonStandardServiceName_NonStandardFunctionName_Result match the
+// provided NonStandardServiceName_NonStandardFunctionName_Result.
+//
+// This function performs a deep comparison.
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) Equals(rhs *NonStandardServiceName_NonStandardFunctionName_Result) bool {
 
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "non_standard_function_name" for this struct.
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) MethodName() string {
 	return "non_standard_function_name"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/gen/testdata/services/types.go
+++ b/gen/testdata/services/types.go
@@ -16,6 +16,21 @@ type ConflictingNamesSetValueArgs struct {
 	Value []byte `json:"value,required"`
 }
 
+// ToWire translates a ConflictingNamesSetValueArgs struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ConflictingNamesSetValueArgs) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -43,6 +58,23 @@ func (v *ConflictingNamesSetValueArgs) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a ConflictingNamesSetValueArgs struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ConflictingNamesSetValueArgs struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ConflictingNamesSetValueArgs
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ConflictingNamesSetValueArgs) FromWire(w wire.Value) error {
 	var err error
 
@@ -81,6 +113,8 @@ func (v *ConflictingNamesSetValueArgs) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ConflictingNamesSetValueArgs
+// struct.
 func (v *ConflictingNamesSetValueArgs) String() string {
 	if v == nil {
 		return "<nil>"
@@ -96,6 +130,10 @@ func (v *ConflictingNamesSetValueArgs) String() string {
 	return fmt.Sprintf("ConflictingNamesSetValueArgs{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this ConflictingNamesSetValueArgs match the
+// provided ConflictingNamesSetValueArgs.
+//
+// This function performs a deep comparison.
 func (v *ConflictingNamesSetValueArgs) Equals(rhs *ConflictingNamesSetValueArgs) bool {
 	if !(v.Key == rhs.Key) {
 		return false
@@ -111,6 +149,21 @@ type InternalError struct {
 	Message *string `json:"message,omitempty"`
 }
 
+// ToWire translates a InternalError struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *InternalError) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -131,6 +184,23 @@ func (v *InternalError) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a InternalError struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a InternalError struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v InternalError
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *InternalError) FromWire(w wire.Value) error {
 	var err error
 
@@ -152,6 +222,8 @@ func (v *InternalError) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a InternalError
+// struct.
 func (v *InternalError) String() string {
 	if v == nil {
 		return "<nil>"
@@ -177,6 +249,10 @@ func _String_EqualsPtr(lhs, rhs *string) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this InternalError match the
+// provided InternalError.
+//
+// This function performs a deep comparison.
 func (v *InternalError) Equals(rhs *InternalError) bool {
 	if !_String_EqualsPtr(v.Message, rhs.Message) {
 		return false
@@ -185,6 +261,8 @@ func (v *InternalError) Equals(rhs *InternalError) bool {
 	return true
 }
 
+// GetMessage returns the value of Message if it is set or its
+// zero value if it is unset.
 func (v *InternalError) GetMessage() (o string) {
 	if v.Message != nil {
 		return *v.Message
@@ -199,22 +277,31 @@ func (v *InternalError) Error() string {
 
 type Key string
 
+// ToWire translates Key into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v Key) ToWire() (wire.Value, error) {
 	x := (string)(v)
 	return wire.NewValueString(x), error(nil)
 }
 
+// String returns a readable string representation of Key.
 func (v Key) String() string {
 	x := (string)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes Key from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *Key) FromWire(w wire.Value) error {
 	x, err := w.GetString(), error(nil)
 	*v = (Key)(x)
 	return err
 }
 
+// Equals returns true if this Key is equal to the provided
+// Key.
 func (lhs Key) Equals(rhs Key) bool {
 	return (lhs == rhs)
 }

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -17,6 +17,21 @@ type ContactInfo struct {
 	EmailAddress string `json:"emailAddress,required"`
 }
 
+// ToWire translates a ContactInfo struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ContactInfo) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -35,6 +50,23 @@ func (v *ContactInfo) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a ContactInfo struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ContactInfo struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ContactInfo
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ContactInfo) FromWire(w wire.Value) error {
 	var err error
 
@@ -60,6 +92,8 @@ func (v *ContactInfo) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ContactInfo
+// struct.
 func (v *ContactInfo) String() string {
 	if v == nil {
 		return "<nil>"
@@ -73,6 +107,10 @@ func (v *ContactInfo) String() string {
 	return fmt.Sprintf("ContactInfo{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this ContactInfo match the
+// provided ContactInfo.
+//
+// This function performs a deep comparison.
 func (v *ContactInfo) Equals(rhs *ContactInfo) bool {
 	if !(v.EmailAddress == rhs.EmailAddress) {
 		return false
@@ -148,6 +186,21 @@ func (_List_Double_ValueList) ValueType() wire.Type {
 
 func (_List_Double_ValueList) Close() {}
 
+// ToWire translates a DefaultsStruct struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [8]wire.Field
@@ -327,6 +380,23 @@ func _Edge_Read(w wire.Value) (*Edge, error) {
 	return &v, err
 }
 
+// FromWire deserializes a DefaultsStruct struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a DefaultsStruct struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v DefaultsStruct
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *DefaultsStruct) FromWire(w wire.Value) error {
 	var err error
 
@@ -467,6 +537,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a DefaultsStruct
+// struct.
 func (v *DefaultsStruct) String() string {
 	if v == nil {
 		return "<nil>"
@@ -560,6 +632,10 @@ func _List_Double_Equals(lhs, rhs []float64) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this DefaultsStruct match the
+// provided DefaultsStruct.
+//
+// This function performs a deep comparison.
 func (v *DefaultsStruct) Equals(rhs *DefaultsStruct) bool {
 	if !_I32_EqualsPtr(v.RequiredPrimitive, rhs.RequiredPrimitive) {
 		return false
@@ -589,6 +665,8 @@ func (v *DefaultsStruct) Equals(rhs *DefaultsStruct) bool {
 	return true
 }
 
+// GetRequiredPrimitive returns the value of RequiredPrimitive if it is set or its
+// zero value if it is unset.
 func (v *DefaultsStruct) GetRequiredPrimitive() (o int32) {
 	if v.RequiredPrimitive != nil {
 		return *v.RequiredPrimitive
@@ -597,6 +675,8 @@ func (v *DefaultsStruct) GetRequiredPrimitive() (o int32) {
 	return
 }
 
+// GetOptionalPrimitive returns the value of OptionalPrimitive if it is set or its
+// zero value if it is unset.
 func (v *DefaultsStruct) GetOptionalPrimitive() (o int32) {
 	if v.OptionalPrimitive != nil {
 		return *v.OptionalPrimitive
@@ -605,6 +685,8 @@ func (v *DefaultsStruct) GetOptionalPrimitive() (o int32) {
 	return
 }
 
+// GetRequiredEnum returns the value of RequiredEnum if it is set or its
+// zero value if it is unset.
 func (v *DefaultsStruct) GetRequiredEnum() (o enums.EnumDefault) {
 	if v.RequiredEnum != nil {
 		return *v.RequiredEnum
@@ -613,6 +695,8 @@ func (v *DefaultsStruct) GetRequiredEnum() (o enums.EnumDefault) {
 	return
 }
 
+// GetOptionalEnum returns the value of OptionalEnum if it is set or its
+// zero value if it is unset.
 func (v *DefaultsStruct) GetOptionalEnum() (o enums.EnumDefault) {
 	if v.OptionalEnum != nil {
 		return *v.OptionalEnum
@@ -626,6 +710,21 @@ type Edge struct {
 	EndPoint   *Point `json:"endPoint,required"`
 }
 
+// ToWire translates a Edge struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Edge) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -662,6 +761,23 @@ func _Point_Read(w wire.Value) (*Point, error) {
 	return &v, err
 }
 
+// FromWire deserializes a Edge struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Edge struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Edge
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Edge) FromWire(w wire.Value) error {
 	var err error
 
@@ -700,6 +816,8 @@ func (v *Edge) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Edge
+// struct.
 func (v *Edge) String() string {
 	if v == nil {
 		return "<nil>"
@@ -715,6 +833,10 @@ func (v *Edge) String() string {
 	return fmt.Sprintf("Edge{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Edge match the
+// provided Edge.
+//
+// This function performs a deep comparison.
 func (v *Edge) Equals(rhs *Edge) bool {
 	if !v.StartPoint.Equals(rhs.StartPoint) {
 		return false
@@ -729,6 +851,21 @@ func (v *Edge) Equals(rhs *Edge) bool {
 type EmptyStruct struct {
 }
 
+// ToWire translates a EmptyStruct struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *EmptyStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -738,6 +875,23 @@ func (v *EmptyStruct) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a EmptyStruct struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a EmptyStruct struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v EmptyStruct
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *EmptyStruct) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -748,6 +902,8 @@ func (v *EmptyStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a EmptyStruct
+// struct.
 func (v *EmptyStruct) String() string {
 	if v == nil {
 		return "<nil>"
@@ -759,6 +915,10 @@ func (v *EmptyStruct) String() string {
 	return fmt.Sprintf("EmptyStruct{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this EmptyStruct match the
+// provided EmptyStruct.
+//
+// This function performs a deep comparison.
 func (v *EmptyStruct) Equals(rhs *EmptyStruct) bool {
 
 	return true
@@ -769,6 +929,21 @@ type Frame struct {
 	Size    *Size  `json:"size,required"`
 }
 
+// ToWire translates a Frame struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Frame) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -805,6 +980,23 @@ func _Size_Read(w wire.Value) (*Size, error) {
 	return &v, err
 }
 
+// FromWire deserializes a Frame struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Frame struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Frame
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Frame) FromWire(w wire.Value) error {
 	var err error
 
@@ -843,6 +1035,8 @@ func (v *Frame) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Frame
+// struct.
 func (v *Frame) String() string {
 	if v == nil {
 		return "<nil>"
@@ -858,6 +1052,10 @@ func (v *Frame) String() string {
 	return fmt.Sprintf("Frame{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Frame match the
+// provided Frame.
+//
+// This function performs a deep comparison.
 func (v *Frame) Equals(rhs *Frame) bool {
 	if !v.TopLeft.Equals(rhs.TopLeft) {
 		return false
@@ -878,6 +1076,21 @@ type GoTags struct {
 	FooBarWithRequired  string  `json:"foobarWithRequired,required"`
 }
 
+// ToWire translates a GoTags struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *GoTags) ToWire() (wire.Value, error) {
 	var (
 		fields [6]wire.Field
@@ -933,6 +1146,23 @@ func (v *GoTags) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a GoTags struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a GoTags struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v GoTags
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *GoTags) FromWire(w wire.Value) error {
 	var err error
 
@@ -1019,6 +1249,8 @@ func (v *GoTags) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a GoTags
+// struct.
 func (v *GoTags) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1056,6 +1288,10 @@ func _String_EqualsPtr(lhs, rhs *string) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this GoTags match the
+// provided GoTags.
+//
+// This function performs a deep comparison.
 func (v *GoTags) Equals(rhs *GoTags) bool {
 	if !(v.Foo == rhs.Foo) {
 		return false
@@ -1079,6 +1315,8 @@ func (v *GoTags) Equals(rhs *GoTags) bool {
 	return true
 }
 
+// GetBar returns the value of Bar if it is set or its
+// zero value if it is unset.
 func (v *GoTags) GetBar() (o string) {
 	if v.Bar != nil {
 		return *v.Bar
@@ -1087,6 +1325,8 @@ func (v *GoTags) GetBar() (o string) {
 	return
 }
 
+// GetFooBarWithOmitEmpty returns the value of FooBarWithOmitEmpty if it is set or its
+// zero value if it is unset.
 func (v *GoTags) GetFooBarWithOmitEmpty() (o string) {
 	if v.FooBarWithOmitEmpty != nil {
 		return *v.FooBarWithOmitEmpty
@@ -1132,6 +1372,21 @@ func (_List_Edge_ValueList) ValueType() wire.Type {
 
 func (_List_Edge_ValueList) Close() {}
 
+// ToWire translates a Graph struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Graph) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -1171,6 +1426,23 @@ func _List_Edge_Read(l wire.ValueList) ([]*Edge, error) {
 	return o, err
 }
 
+// FromWire deserializes a Graph struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Graph struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Graph
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Graph) FromWire(w wire.Value) error {
 	var err error
 
@@ -1196,6 +1468,8 @@ func (v *Graph) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Graph
+// struct.
 func (v *Graph) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1224,6 +1498,10 @@ func _List_Edge_Equals(lhs, rhs []*Edge) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this Graph match the
+// provided Graph.
+//
+// This function performs a deep comparison.
 func (v *Graph) Equals(rhs *Graph) bool {
 	if !_List_Edge_Equals(v.Edges, rhs.Edges) {
 		return false
@@ -1234,20 +1512,29 @@ func (v *Graph) Equals(rhs *Graph) bool {
 
 type List Node
 
+// ToWire translates List into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v *List) ToWire() (wire.Value, error) {
 	x := (*Node)(v)
 	return x.ToWire()
 }
 
+// String returns a readable string representation of List.
 func (v *List) String() string {
 	x := (*Node)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes List from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *List) FromWire(w wire.Value) error {
 	return (*Node)(v).FromWire(w)
 }
 
+// Equals returns true if this List is equal to the provided
+// List.
 func (lhs *List) Equals(rhs *List) bool {
 	return (*Node)(lhs).Equals((*Node)(rhs))
 }
@@ -1259,6 +1546,21 @@ type Node struct {
 	Tail  *List `json:"tail,omitempty"`
 }
 
+// ToWire translates a Node struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Node) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1291,6 +1593,23 @@ func _List_Read(w wire.Value) (*List, error) {
 	return &x, err
 }
 
+// FromWire deserializes a Node struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Node struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Node
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Node) FromWire(w wire.Value) error {
 	var err error
 
@@ -1324,6 +1643,8 @@ func (v *Node) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Node
+// struct.
 func (v *Node) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1341,6 +1662,10 @@ func (v *Node) String() string {
 	return fmt.Sprintf("Node{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Node match the
+// provided Node.
+//
+// This function performs a deep comparison.
 func (v *Node) Equals(rhs *Node) bool {
 	if !(v.Value == rhs.Value) {
 		return false
@@ -1357,6 +1682,21 @@ type Omit struct {
 	Hidden     string `json:"-"`
 }
 
+// ToWire translates a Omit struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Omit) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1382,6 +1722,23 @@ func (v *Omit) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a Omit struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Omit struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Omit
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Omit) FromWire(w wire.Value) error {
 	var err error
 
@@ -1420,6 +1777,8 @@ func (v *Omit) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Omit
+// struct.
 func (v *Omit) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1435,6 +1794,10 @@ func (v *Omit) String() string {
 	return fmt.Sprintf("Omit{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Omit match the
+// provided Omit.
+//
+// This function performs a deep comparison.
 func (v *Omit) Equals(rhs *Omit) bool {
 	if !(v.Serialized == rhs.Serialized) {
 		return false
@@ -1452,6 +1815,21 @@ type Point struct {
 	Y float64 `json:"y,required"`
 }
 
+// ToWire translates a Point struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Point) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1477,6 +1855,23 @@ func (v *Point) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a Point struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Point struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Point
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Point) FromWire(w wire.Value) error {
 	var err error
 
@@ -1515,6 +1910,8 @@ func (v *Point) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Point
+// struct.
 func (v *Point) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1530,6 +1927,10 @@ func (v *Point) String() string {
 	return fmt.Sprintf("Point{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Point match the
+// provided Point.
+//
+// This function performs a deep comparison.
 func (v *Point) Equals(rhs *Point) bool {
 	if !(v.X == rhs.X) {
 		return false
@@ -1555,6 +1956,21 @@ type PrimitiveOptionalStruct struct {
 	BinaryField []byte   `json:"binaryField"`
 }
 
+// ToWire translates a PrimitiveOptionalStruct struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *PrimitiveOptionalStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [8]wire.Field
@@ -1631,6 +2047,23 @@ func (v *PrimitiveOptionalStruct) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a PrimitiveOptionalStruct struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a PrimitiveOptionalStruct struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v PrimitiveOptionalStruct
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 	var err error
 
@@ -1720,6 +2153,8 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a PrimitiveOptionalStruct
+// struct.
 func (v *PrimitiveOptionalStruct) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1813,6 +2248,10 @@ func _Double_EqualsPtr(lhs, rhs *float64) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this PrimitiveOptionalStruct match the
+// provided PrimitiveOptionalStruct.
+//
+// This function performs a deep comparison.
 func (v *PrimitiveOptionalStruct) Equals(rhs *PrimitiveOptionalStruct) bool {
 	if !_Bool_EqualsPtr(v.BoolField, rhs.BoolField) {
 		return false
@@ -1842,6 +2281,8 @@ func (v *PrimitiveOptionalStruct) Equals(rhs *PrimitiveOptionalStruct) bool {
 	return true
 }
 
+// GetBoolField returns the value of BoolField if it is set or its
+// zero value if it is unset.
 func (v *PrimitiveOptionalStruct) GetBoolField() (o bool) {
 	if v.BoolField != nil {
 		return *v.BoolField
@@ -1850,6 +2291,8 @@ func (v *PrimitiveOptionalStruct) GetBoolField() (o bool) {
 	return
 }
 
+// GetByteField returns the value of ByteField if it is set or its
+// zero value if it is unset.
 func (v *PrimitiveOptionalStruct) GetByteField() (o int8) {
 	if v.ByteField != nil {
 		return *v.ByteField
@@ -1858,6 +2301,8 @@ func (v *PrimitiveOptionalStruct) GetByteField() (o int8) {
 	return
 }
 
+// GetInt16Field returns the value of Int16Field if it is set or its
+// zero value if it is unset.
 func (v *PrimitiveOptionalStruct) GetInt16Field() (o int16) {
 	if v.Int16Field != nil {
 		return *v.Int16Field
@@ -1866,6 +2311,8 @@ func (v *PrimitiveOptionalStruct) GetInt16Field() (o int16) {
 	return
 }
 
+// GetInt32Field returns the value of Int32Field if it is set or its
+// zero value if it is unset.
 func (v *PrimitiveOptionalStruct) GetInt32Field() (o int32) {
 	if v.Int32Field != nil {
 		return *v.Int32Field
@@ -1874,6 +2321,8 @@ func (v *PrimitiveOptionalStruct) GetInt32Field() (o int32) {
 	return
 }
 
+// GetInt64Field returns the value of Int64Field if it is set or its
+// zero value if it is unset.
 func (v *PrimitiveOptionalStruct) GetInt64Field() (o int64) {
 	if v.Int64Field != nil {
 		return *v.Int64Field
@@ -1882,6 +2331,8 @@ func (v *PrimitiveOptionalStruct) GetInt64Field() (o int64) {
 	return
 }
 
+// GetDoubleField returns the value of DoubleField if it is set or its
+// zero value if it is unset.
 func (v *PrimitiveOptionalStruct) GetDoubleField() (o float64) {
 	if v.DoubleField != nil {
 		return *v.DoubleField
@@ -1890,6 +2341,8 @@ func (v *PrimitiveOptionalStruct) GetDoubleField() (o float64) {
 	return
 }
 
+// GetStringField returns the value of StringField if it is set or its
+// zero value if it is unset.
 func (v *PrimitiveOptionalStruct) GetStringField() (o string) {
 	if v.StringField != nil {
 		return *v.StringField
@@ -1912,6 +2365,21 @@ type PrimitiveRequiredStruct struct {
 	BinaryField []byte  `json:"binaryField,required"`
 }
 
+// ToWire translates a PrimitiveRequiredStruct struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *PrimitiveRequiredStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [8]wire.Field
@@ -1981,6 +2449,23 @@ func (v *PrimitiveRequiredStruct) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a PrimitiveRequiredStruct struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a PrimitiveRequiredStruct struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v PrimitiveRequiredStruct
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	var err error
 
@@ -2097,6 +2582,8 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a PrimitiveRequiredStruct
+// struct.
 func (v *PrimitiveRequiredStruct) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2124,6 +2611,10 @@ func (v *PrimitiveRequiredStruct) String() string {
 	return fmt.Sprintf("PrimitiveRequiredStruct{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this PrimitiveRequiredStruct match the
+// provided PrimitiveRequiredStruct.
+//
+// This function performs a deep comparison.
 func (v *PrimitiveRequiredStruct) Equals(rhs *PrimitiveRequiredStruct) bool {
 	if !(v.BoolField == rhs.BoolField) {
 		return false
@@ -2158,6 +2649,21 @@ type Rename struct {
 	CamelCase string `json:"snake_case,required"`
 }
 
+// ToWire translates a Rename struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Rename) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2183,6 +2689,23 @@ func (v *Rename) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a Rename struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Rename struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Rename
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Rename) FromWire(w wire.Value) error {
 	var err error
 
@@ -2221,6 +2744,8 @@ func (v *Rename) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Rename
+// struct.
 func (v *Rename) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2236,6 +2761,10 @@ func (v *Rename) String() string {
 	return fmt.Sprintf("Rename{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Rename match the
+// provided Rename.
+//
+// This function performs a deep comparison.
 func (v *Rename) Equals(rhs *Rename) bool {
 	if !(v.Default == rhs.Default) {
 		return false
@@ -2255,6 +2784,21 @@ type Size struct {
 	Height float64 `json:"height,required"`
 }
 
+// ToWire translates a Size struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Size) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2280,6 +2824,23 @@ func (v *Size) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a Size struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Size struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Size
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Size) FromWire(w wire.Value) error {
 	var err error
 
@@ -2318,6 +2879,8 @@ func (v *Size) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Size
+// struct.
 func (v *Size) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2333,6 +2896,10 @@ func (v *Size) String() string {
 	return fmt.Sprintf("Size{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Size match the
+// provided Size.
+//
+// This function performs a deep comparison.
 func (v *Size) Equals(rhs *Size) bool {
 	if !(v.Width == rhs.Width) {
 		return false
@@ -2349,6 +2916,21 @@ type User struct {
 	Contact *ContactInfo `json:"contact,omitempty"`
 }
 
+// ToWire translates a User struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *User) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2381,6 +2963,23 @@ func _ContactInfo_Read(w wire.Value) (*ContactInfo, error) {
 	return &v, err
 }
 
+// FromWire deserializes a User struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a User struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v User
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *User) FromWire(w wire.Value) error {
 	var err error
 
@@ -2414,6 +3013,8 @@ func (v *User) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a User
+// struct.
 func (v *User) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2431,6 +3032,10 @@ func (v *User) String() string {
 	return fmt.Sprintf("User{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this User match the
+// provided User.
+//
+// This function performs a deep comparison.
 func (v *User) Equals(rhs *User) bool {
 	if !(v.Name == rhs.Name) {
 		return false

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -84,22 +84,31 @@ func _Set_Binary_Equals(lhs, rhs [][]byte) bool {
 
 type BinarySet [][]byte
 
+// ToWire translates BinarySet into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v BinarySet) ToWire() (wire.Value, error) {
 	x := ([][]byte)(v)
 	return wire.NewValueSet(_Set_Binary_ValueList(x)), error(nil)
 }
 
+// String returns a readable string representation of BinarySet.
 func (v BinarySet) String() string {
 	x := ([][]byte)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes BinarySet from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *BinarySet) FromWire(w wire.Value) error {
 	x, err := _Set_Binary_Read(w.GetSet())
 	*v = (BinarySet)(x)
 	return err
 }
 
+// Equals returns true if this BinarySet is equal to the provided
+// BinarySet.
 func (lhs BinarySet) Equals(rhs BinarySet) bool {
 	return _Set_Binary_Equals(lhs, rhs)
 }
@@ -112,6 +121,21 @@ func _State_ptr(v State) *State {
 	return &v
 }
 
+// ToWire translates a DefaultPrimitiveTypedef struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *DefaultPrimitiveTypedef) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -141,6 +165,23 @@ func _State_Read(w wire.Value) (State, error) {
 	return x, err
 }
 
+// FromWire deserializes a DefaultPrimitiveTypedef struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a DefaultPrimitiveTypedef struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v DefaultPrimitiveTypedef
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *DefaultPrimitiveTypedef) FromWire(w wire.Value) error {
 	var err error
 
@@ -166,6 +207,8 @@ func (v *DefaultPrimitiveTypedef) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a DefaultPrimitiveTypedef
+// struct.
 func (v *DefaultPrimitiveTypedef) String() string {
 	if v == nil {
 		return "<nil>"
@@ -191,6 +234,10 @@ func _State_EqualsPtr(lhs, rhs *State) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this DefaultPrimitiveTypedef match the
+// provided DefaultPrimitiveTypedef.
+//
+// This function performs a deep comparison.
 func (v *DefaultPrimitiveTypedef) Equals(rhs *DefaultPrimitiveTypedef) bool {
 	if !_State_EqualsPtr(v.State, rhs.State) {
 		return false
@@ -199,6 +246,8 @@ func (v *DefaultPrimitiveTypedef) Equals(rhs *DefaultPrimitiveTypedef) bool {
 	return true
 }
 
+// GetState returns the value of State if it is set or its
+// zero value if it is unset.
 func (v *DefaultPrimitiveTypedef) GetState() (o State) {
 	if v.State != nil {
 		return *v.State
@@ -334,6 +383,9 @@ type EdgeMap []struct {
 	Value *structs.Edge
 }
 
+// ToWire translates EdgeMap into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v EdgeMap) ToWire() (wire.Value, error) {
 	x := ([]struct {
 		Key   *structs.Edge
@@ -342,6 +394,7 @@ func (v EdgeMap) ToWire() (wire.Value, error) {
 	return wire.NewValueMap(_Map_Edge_Edge_MapItemList(x)), error(nil)
 }
 
+// String returns a readable string representation of EdgeMap.
 func (v EdgeMap) String() string {
 	x := ([]struct {
 		Key   *structs.Edge
@@ -350,12 +403,17 @@ func (v EdgeMap) String() string {
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes EdgeMap from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *EdgeMap) FromWire(w wire.Value) error {
 	x, err := _Map_Edge_Edge_Read(w.GetMap())
 	*v = (EdgeMap)(x)
 	return err
 }
 
+// Equals returns true if this EdgeMap is equal to the provided
+// EdgeMap.
 func (lhs EdgeMap) Equals(rhs EdgeMap) bool {
 	return _Map_Edge_Edge_Equals(lhs, rhs)
 }
@@ -365,6 +423,21 @@ type Event struct {
 	Time *Timestamp `json:"time,omitempty"`
 }
 
+// ToWire translates a Event struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Event) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -406,6 +479,23 @@ func _Timestamp_Read(w wire.Value) (Timestamp, error) {
 	return x, err
 }
 
+// FromWire deserializes a Event struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Event struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Event
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Event) FromWire(w wire.Value) error {
 	var err error
 
@@ -441,6 +531,8 @@ func (v *Event) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Event
+// struct.
 func (v *Event) String() string {
 	if v == nil {
 		return "<nil>"
@@ -468,6 +560,10 @@ func _Timestamp_EqualsPtr(lhs, rhs *Timestamp) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this Event match the
+// provided Event.
+//
+// This function performs a deep comparison.
 func (v *Event) Equals(rhs *Event) bool {
 	if !v.UUID.Equals(rhs.UUID) {
 		return false
@@ -479,6 +575,8 @@ func (v *Event) Equals(rhs *Event) bool {
 	return true
 }
 
+// GetTime returns the value of Time if it is set or its
+// zero value if it is unset.
 func (v *Event) GetTime() (o Timestamp) {
 	if v.Time != nil {
 		return *v.Time
@@ -557,22 +655,31 @@ func _List_Event_Equals(lhs, rhs []*Event) bool {
 
 type EventGroup []*Event
 
+// ToWire translates EventGroup into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v EventGroup) ToWire() (wire.Value, error) {
 	x := ([]*Event)(v)
 	return wire.NewValueList(_List_Event_ValueList(x)), error(nil)
 }
 
+// String returns a readable string representation of EventGroup.
 func (v EventGroup) String() string {
 	x := ([]*Event)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes EventGroup from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *EventGroup) FromWire(w wire.Value) error {
 	x, err := _List_Event_Read(w.GetList())
 	*v = (EventGroup)(x)
 	return err
 }
 
+// Equals returns true if this EventGroup is equal to the provided
+// EventGroup.
 func (lhs EventGroup) Equals(rhs EventGroup) bool {
 	return _List_Event_Equals(lhs, rhs)
 }
@@ -654,22 +761,31 @@ func _Set_Frame_Equals(lhs, rhs []*structs.Frame) bool {
 
 type FrameGroup []*structs.Frame
 
+// ToWire translates FrameGroup into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v FrameGroup) ToWire() (wire.Value, error) {
 	x := ([]*structs.Frame)(v)
 	return wire.NewValueSet(_Set_Frame_ValueList(x)), error(nil)
 }
 
+// String returns a readable string representation of FrameGroup.
 func (v FrameGroup) String() string {
 	x := ([]*structs.Frame)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes FrameGroup from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *FrameGroup) FromWire(w wire.Value) error {
 	x, err := _Set_Frame_Read(w.GetSet())
 	*v = (FrameGroup)(x)
 	return err
 }
 
+// Equals returns true if this FrameGroup is equal to the provided
+// FrameGroup.
 func (lhs FrameGroup) Equals(rhs FrameGroup) bool {
 	return _Set_Frame_Equals(lhs, rhs)
 }
@@ -682,44 +798,62 @@ func _EnumWithValues_Read(w wire.Value) (enums.EnumWithValues, error) {
 
 type MyEnum enums.EnumWithValues
 
+// ToWire translates MyEnum into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v MyEnum) ToWire() (wire.Value, error) {
 	x := (enums.EnumWithValues)(v)
 	return x.ToWire()
 }
 
+// String returns a readable string representation of MyEnum.
 func (v MyEnum) String() string {
 	x := (enums.EnumWithValues)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes MyEnum from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *MyEnum) FromWire(w wire.Value) error {
 	x, err := _EnumWithValues_Read(w)
 	*v = (MyEnum)(x)
 	return err
 }
 
+// Equals returns true if this MyEnum is equal to the provided
+// MyEnum.
 func (lhs MyEnum) Equals(rhs MyEnum) bool {
 	return lhs.Equals(rhs)
 }
 
 type PDF []byte
 
+// ToWire translates PDF into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v PDF) ToWire() (wire.Value, error) {
 	x := ([]byte)(v)
 	return wire.NewValueBinary(x), error(nil)
 }
 
+// String returns a readable string representation of PDF.
 func (v PDF) String() string {
 	x := ([]byte)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes PDF from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *PDF) FromWire(w wire.Value) error {
 	x, err := w.GetBinary(), error(nil)
 	*v = (PDF)(x)
 	return err
 }
 
+// Equals returns true if this PDF is equal to the provided
+// PDF.
 func (lhs PDF) Equals(rhs PDF) bool {
 	return bytes.Equal(lhs, rhs)
 }
@@ -851,6 +985,9 @@ type PointMap []struct {
 	Value *structs.Point
 }
 
+// ToWire translates PointMap into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v PointMap) ToWire() (wire.Value, error) {
 	x := ([]struct {
 		Key   *structs.Point
@@ -859,6 +996,7 @@ func (v PointMap) ToWire() (wire.Value, error) {
 	return wire.NewValueMap(_Map_Point_Point_MapItemList(x)), error(nil)
 }
 
+// String returns a readable string representation of PointMap.
 func (v PointMap) String() string {
 	x := ([]struct {
 		Key   *structs.Point
@@ -867,34 +1005,48 @@ func (v PointMap) String() string {
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes PointMap from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *PointMap) FromWire(w wire.Value) error {
 	x, err := _Map_Point_Point_Read(w.GetMap())
 	*v = (PointMap)(x)
 	return err
 }
 
+// Equals returns true if this PointMap is equal to the provided
+// PointMap.
 func (lhs PointMap) Equals(rhs PointMap) bool {
 	return _Map_Point_Point_Equals(lhs, rhs)
 }
 
 type State string
 
+// ToWire translates State into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v State) ToWire() (wire.Value, error) {
 	x := (string)(v)
 	return wire.NewValueString(x), error(nil)
 }
 
+// String returns a readable string representation of State.
 func (v State) String() string {
 	x := (string)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes State from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *State) FromWire(w wire.Value) error {
 	x, err := w.GetString(), error(nil)
 	*v = (State)(x)
 	return err
 }
 
+// Equals returns true if this State is equal to the provided
+// State.
 func (lhs State) Equals(rhs State) bool {
 	return (lhs == rhs)
 }
@@ -904,22 +1056,31 @@ func (lhs State) Equals(rhs State) bool {
 // Deprecated: Use ISOTime instead.
 type Timestamp int64
 
+// ToWire translates Timestamp into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v Timestamp) ToWire() (wire.Value, error) {
 	x := (int64)(v)
 	return wire.NewValueI64(x), error(nil)
 }
 
+// String returns a readable string representation of Timestamp.
 func (v Timestamp) String() string {
 	x := (int64)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes Timestamp from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *Timestamp) FromWire(w wire.Value) error {
 	x, err := w.GetI64(), error(nil)
 	*v = (Timestamp)(x)
 	return err
 }
 
+// Equals returns true if this Timestamp is equal to the provided
+// Timestamp.
 func (lhs Timestamp) Equals(rhs Timestamp) bool {
 	return (lhs == rhs)
 }
@@ -930,6 +1091,21 @@ type Transition struct {
 	Events    EventGroup `json:"events"`
 }
 
+// ToWire translates a Transition struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Transition) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -969,6 +1145,23 @@ func _EventGroup_Read(w wire.Value) (EventGroup, error) {
 	return x, err
 }
 
+// FromWire deserializes a Transition struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Transition struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Transition
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Transition) FromWire(w wire.Value) error {
 	var err error
 
@@ -1015,6 +1208,8 @@ func (v *Transition) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Transition
+// struct.
 func (v *Transition) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1034,6 +1229,10 @@ func (v *Transition) String() string {
 	return fmt.Sprintf("Transition{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Transition match the
+// provided Transition.
+//
+// This function performs a deep comparison.
 func (v *Transition) Equals(rhs *Transition) bool {
 	if !(v.FromState == rhs.FromState) {
 		return false
@@ -1050,20 +1249,29 @@ func (v *Transition) Equals(rhs *Transition) bool {
 
 type UUID I128
 
+// ToWire translates UUID into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v *UUID) ToWire() (wire.Value, error) {
 	x := (*I128)(v)
 	return x.ToWire()
 }
 
+// String returns a readable string representation of UUID.
 func (v *UUID) String() string {
 	x := (*I128)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes UUID from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *UUID) FromWire(w wire.Value) error {
 	return (*I128)(v).FromWire(w)
 }
 
+// Equals returns true if this UUID is equal to the provided
+// UUID.
 func (lhs *UUID) Equals(rhs *UUID) bool {
 	return (*I128)(lhs).Equals((*I128)(rhs))
 }
@@ -1073,6 +1281,21 @@ type I128 struct {
 	Low  int64 `json:"low,required"`
 }
 
+// ToWire translates a I128 struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *I128) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1098,6 +1321,23 @@ func (v *I128) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a I128 struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a I128 struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v I128
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *I128) FromWire(w wire.Value) error {
 	var err error
 
@@ -1136,6 +1376,8 @@ func (v *I128) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a I128
+// struct.
 func (v *I128) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1151,6 +1393,10 @@ func (v *I128) String() string {
 	return fmt.Sprintf("I128{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this I128 match the
+// provided I128.
+//
+// This function performs a deep comparison.
 func (v *I128) Equals(rhs *I128) bool {
 	if !(v.High == rhs.High) {
 		return false

--- a/gen/testdata/unions/types.go
+++ b/gen/testdata/unions/types.go
@@ -94,6 +94,21 @@ func (_Map_String_ArbitraryValue_MapItemList) ValueType() wire.Type {
 
 func (_Map_String_ArbitraryValue_MapItemList) Close() {}
 
+// ToWire translates a ArbitraryValue struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ArbitraryValue) ToWire() (wire.Value, error) {
 	var (
 		fields [5]wire.Field
@@ -202,6 +217,23 @@ func _Map_String_ArbitraryValue_Read(m wire.MapItemList) (map[string]*ArbitraryV
 	return o, err
 }
 
+// FromWire deserializes a ArbitraryValue struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ArbitraryValue struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ArbitraryValue
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ArbitraryValue) FromWire(w wire.Value) error {
 	var err error
 
@@ -279,6 +311,8 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ArbitraryValue
+// struct.
 func (v *ArbitraryValue) String() string {
 	if v == nil {
 		return "<nil>"
@@ -372,6 +406,10 @@ func _Map_String_ArbitraryValue_Equals(lhs, rhs map[string]*ArbitraryValue) bool
 	return true
 }
 
+// Equals returns true if all the fields of this ArbitraryValue match the
+// provided ArbitraryValue.
+//
+// This function performs a deep comparison.
 func (v *ArbitraryValue) Equals(rhs *ArbitraryValue) bool {
 	if !_Bool_EqualsPtr(v.BoolValue, rhs.BoolValue) {
 		return false
@@ -392,6 +430,8 @@ func (v *ArbitraryValue) Equals(rhs *ArbitraryValue) bool {
 	return true
 }
 
+// GetBoolValue returns the value of BoolValue if it is set or its
+// zero value if it is unset.
 func (v *ArbitraryValue) GetBoolValue() (o bool) {
 	if v.BoolValue != nil {
 		return *v.BoolValue
@@ -400,6 +440,8 @@ func (v *ArbitraryValue) GetBoolValue() (o bool) {
 	return
 }
 
+// GetInt64Value returns the value of Int64Value if it is set or its
+// zero value if it is unset.
 func (v *ArbitraryValue) GetInt64Value() (o int64) {
 	if v.Int64Value != nil {
 		return *v.Int64Value
@@ -408,6 +450,8 @@ func (v *ArbitraryValue) GetInt64Value() (o int64) {
 	return
 }
 
+// GetStringValue returns the value of StringValue if it is set or its
+// zero value if it is unset.
 func (v *ArbitraryValue) GetStringValue() (o string) {
 	if v.StringValue != nil {
 		return *v.StringValue
@@ -421,6 +465,21 @@ type Document struct {
 	PlainText *string      `json:"plainText,omitempty"`
 }
 
+// ToWire translates a Document struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Document) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -459,6 +518,23 @@ func _PDF_Read(w wire.Value) (typedefs.PDF, error) {
 	return x, err
 }
 
+// FromWire deserializes a Document struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Document struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Document
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Document) FromWire(w wire.Value) error {
 	var err error
 
@@ -499,6 +575,8 @@ func (v *Document) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Document
+// struct.
 func (v *Document) String() string {
 	if v == nil {
 		return "<nil>"
@@ -518,6 +596,10 @@ func (v *Document) String() string {
 	return fmt.Sprintf("Document{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Document match the
+// provided Document.
+//
+// This function performs a deep comparison.
 func (v *Document) Equals(rhs *Document) bool {
 	if !((v.Pdf == nil && rhs.Pdf == nil) || (v.Pdf != nil && rhs.Pdf != nil && v.Pdf.Equals(rhs.Pdf))) {
 		return false
@@ -529,6 +611,8 @@ func (v *Document) Equals(rhs *Document) bool {
 	return true
 }
 
+// GetPlainText returns the value of PlainText if it is set or its
+// zero value if it is unset.
 func (v *Document) GetPlainText() (o string) {
 	if v.PlainText != nil {
 		return *v.PlainText
@@ -540,6 +624,21 @@ func (v *Document) GetPlainText() (o string) {
 type EmptyUnion struct {
 }
 
+// ToWire translates a EmptyUnion struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *EmptyUnion) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -549,6 +648,23 @@ func (v *EmptyUnion) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a EmptyUnion struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a EmptyUnion struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v EmptyUnion
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *EmptyUnion) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -559,6 +675,8 @@ func (v *EmptyUnion) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a EmptyUnion
+// struct.
 func (v *EmptyUnion) String() string {
 	if v == nil {
 		return "<nil>"
@@ -570,6 +688,10 @@ func (v *EmptyUnion) String() string {
 	return fmt.Sprintf("EmptyUnion{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this EmptyUnion match the
+// provided EmptyUnion.
+//
+// This function performs a deep comparison.
 func (v *EmptyUnion) Equals(rhs *EmptyUnion) bool {
 
 	return true

--- a/gen/testdata/uuid_conflict/types.go
+++ b/gen/testdata/uuid_conflict/types.go
@@ -13,22 +13,31 @@ import (
 
 type UUID string
 
+// ToWire translates UUID into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v UUID) ToWire() (wire.Value, error) {
 	x := (string)(v)
 	return wire.NewValueString(x), error(nil)
 }
 
+// String returns a readable string representation of UUID.
 func (v UUID) String() string {
 	x := (string)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes UUID from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *UUID) FromWire(w wire.Value) error {
 	x, err := w.GetString(), error(nil)
 	*v = (UUID)(x)
 	return err
 }
 
+// Equals returns true if this UUID is equal to the provided
+// UUID.
 func (lhs UUID) Equals(rhs UUID) bool {
 	return (lhs == rhs)
 }
@@ -38,6 +47,21 @@ type UUIDConflict struct {
 	ImportedUUID *typedefs.UUID `json:"importedUUID,required"`
 }
 
+// ToWire translates a UUIDConflict struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *UUIDConflict) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -77,6 +101,23 @@ func _UUID_1_Read(w wire.Value) (*typedefs.UUID, error) {
 	return &x, err
 }
 
+// FromWire deserializes a UUIDConflict struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a UUIDConflict struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v UUIDConflict
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *UUIDConflict) FromWire(w wire.Value) error {
 	var err error
 
@@ -115,6 +156,8 @@ func (v *UUIDConflict) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a UUIDConflict
+// struct.
 func (v *UUIDConflict) String() string {
 	if v == nil {
 		return "<nil>"
@@ -130,6 +173,10 @@ func (v *UUIDConflict) String() string {
 	return fmt.Sprintf("UUIDConflict{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this UUIDConflict match the
+// provided UUIDConflict.
+//
+// This function performs a deep comparison.
 func (v *UUIDConflict) Equals(rhs *UUIDConflict) bool {
 	if !(v.LocalUUID == rhs.LocalUUID) {
 		return false

--- a/gen/typedef.go
+++ b/gen/typedef.go
@@ -64,17 +64,24 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 
 		<$v := newVar "v">
 		<$x := newVar "x">
+		// ToWire translates <typeName .> into a Thrift-level intermediate
+		// representation. This intermediate representation may be serialized
+		// into bytes using a ThriftRW protocol implementation.
 		func (<$v> <$typedefType>) ToWire() (<$wire>.Value, error) {
 			<$x> := (<typeReference .Target>)(<$v>)
 			return <toWire .Target $x>
 		}
 
+		// String returns a readable string representation of <typeName .>.
 		func (<$v> <$typedefType>) String() string {
 			<$x> := (<typeReference .Target>)(<$v>)
 			return <$fmt>.Sprint(<$x>)
 		}
 
 		<$w := newVar "w">
+		// FromWire deserializes <typeName .> from its Thrift-level
+		// representation. The Thrift-level representation may be obtained
+		// from a ThriftRW protocol implementation.
 		func (<$v> *<typeName .>) FromWire(<$w> <$wire>.Value) error {
 			<if isStructType . ->
 				return (<typeReference .Target>)(<$v>).FromWire(<$w>)
@@ -87,6 +94,8 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 
 		<$lhs := newVar "lhs">
 		<$rhs := newVar "rhs">
+		// Equals returns true if this <typeName .> is equal to the provided
+		// <typeName .>.
 		func (<$lhs> <$typedefType>) Equals(<$rhs> <$typedefType>) bool {
 			<if isStructType . ->
 				return (<typeReference .Target>)(<$lhs>).Equals((<typeReference .Target>)(<$rhs>))

--- a/internal/envelope/exception/types.go
+++ b/internal/envelope/exception/types.go
@@ -49,6 +49,7 @@ const (
 	ExceptionTypeUnsupportedClientType ExceptionType = 10
 )
 
+// ExceptionType_Values returns all recognized values of ExceptionType.
 func ExceptionType_Values() []ExceptionType {
 	return []ExceptionType{
 		ExceptionTypeUnknown,
@@ -65,6 +66,11 @@ func ExceptionType_Values() []ExceptionType {
 	}
 }
 
+// UnmarshalText tries to decode ExceptionType from a byte slice
+// containing its name.
+//
+//   var v ExceptionType
+//   err := v.UnmarshalText([]byte("UNKNOWN"))
 func (v *ExceptionType) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "UNKNOWN":
@@ -105,15 +111,34 @@ func (v *ExceptionType) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates ExceptionType into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v ExceptionType) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes ExceptionType from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return ExceptionType(0), err
+//   }
+//
+//   var v ExceptionType
+//   if err := v.FromWire(x); err != nil {
+//     return ExceptionType(0), err
+//   }
+//   return v, nil
 func (v *ExceptionType) FromWire(w wire.Value) error {
 	*v = (ExceptionType)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of ExceptionType.
 func (v ExceptionType) String() string {
 	w := int32(v)
 	switch w {
@@ -143,10 +168,18 @@ func (v ExceptionType) String() string {
 	return fmt.Sprintf("ExceptionType(%d)", w)
 }
 
+// Equals returns true if this ExceptionType value matches the provided
+// value.
 func (v ExceptionType) Equals(rhs ExceptionType) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes ExceptionType into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v ExceptionType) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 0:
@@ -175,6 +208,13 @@ func (v ExceptionType) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode ExceptionType from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *ExceptionType) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -209,6 +249,21 @@ type TApplicationException struct {
 	Type    *ExceptionType `json:"type,omitempty"`
 }
 
+// ToWire translates a TApplicationException struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *TApplicationException) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -243,6 +298,23 @@ func _ExceptionType_Read(w wire.Value) (ExceptionType, error) {
 	return v, err
 }
 
+// FromWire deserializes a TApplicationException struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a TApplicationException struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v TApplicationException
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *TApplicationException) FromWire(w wire.Value) error {
 	var err error
 
@@ -274,6 +346,8 @@ func (v *TApplicationException) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a TApplicationException
+// struct.
 func (v *TApplicationException) String() string {
 	if v == nil {
 		return "<nil>"
@@ -313,6 +387,10 @@ func _ExceptionType_EqualsPtr(lhs, rhs *ExceptionType) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this TApplicationException match the
+// provided TApplicationException.
+//
+// This function performs a deep comparison.
 func (v *TApplicationException) Equals(rhs *TApplicationException) bool {
 	if !_String_EqualsPtr(v.Message, rhs.Message) {
 		return false
@@ -324,6 +402,8 @@ func (v *TApplicationException) Equals(rhs *TApplicationException) bool {
 	return true
 }
 
+// GetMessage returns the value of Message if it is set or its
+// zero value if it is unset.
 func (v *TApplicationException) GetMessage() (o string) {
 	if v.Message != nil {
 		return *v.Message
@@ -332,6 +412,8 @@ func (v *TApplicationException) GetMessage() (o string) {
 	return
 }
 
+// GetType returns the value of Type if it is set or its
+// zero value if it is unset.
 func (v *TApplicationException) GetType() (o ExceptionType) {
 	if v.Type != nil {
 		return *v.Type

--- a/plugin/api/plugin_goodbye.go
+++ b/plugin/api/plugin_goodbye.go
@@ -29,9 +29,27 @@ import (
 	"strings"
 )
 
+// Plugin_Goodbye_Args represents the arguments for the Plugin.goodbye function.
+//
+// The arguments for goodbye are sent and received over the wire as this struct.
 type Plugin_Goodbye_Args struct {
 }
 
+// ToWire translates a Plugin_Goodbye_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Plugin_Goodbye_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -41,6 +59,23 @@ func (v *Plugin_Goodbye_Args) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a Plugin_Goodbye_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Plugin_Goodbye_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Plugin_Goodbye_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Plugin_Goodbye_Args) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -51,6 +86,8 @@ func (v *Plugin_Goodbye_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Plugin_Goodbye_Args
+// struct.
 func (v *Plugin_Goodbye_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -62,25 +99,71 @@ func (v *Plugin_Goodbye_Args) String() string {
 	return fmt.Sprintf("Plugin_Goodbye_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Plugin_Goodbye_Args match the
+// provided Plugin_Goodbye_Args.
+//
+// This function performs a deep comparison.
 func (v *Plugin_Goodbye_Args) Equals(rhs *Plugin_Goodbye_Args) bool {
 
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "goodbye" for this struct.
 func (v *Plugin_Goodbye_Args) MethodName() string {
 	return "goodbye"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *Plugin_Goodbye_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// Plugin_Goodbye_Helper provides functions that aid in handling the
+// parameters and return values of the Plugin.goodbye
+// function.
 var Plugin_Goodbye_Helper = struct {
+	// Args accepts the parameters of goodbye in-order and returns
+	// the arguments struct for the function.
 	Args func() *Plugin_Goodbye_Args
 
+	// IsException returns true if the given error can be thrown
+	// by goodbye.
+	//
+	// An error can be thrown by goodbye only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(error) (*Plugin_Goodbye_Result, error)
+	// WrapResponse returns the result struct for goodbye
+	// given the error returned by it. The provided error may
+	// be nil if goodbye did not fail.
+	//
+	// This allows mapping errors returned by goodbye into a
+	// serializable result struct. WrapResponse returns a
+	// non-nil error if the provided error cannot be thrown by
+	// goodbye
+	//
+	//   err := goodbye(args)
+	//   result, err := Plugin_Goodbye_Helper.WrapResponse(err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from goodbye: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(error) (*Plugin_Goodbye_Result, error)
+
+	// UnwrapResponse takes the result struct for goodbye
+	// and returns the erorr returned by it (if any).
+	//
+	// The error is non-nil only if goodbye threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   err := Plugin_Goodbye_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*Plugin_Goodbye_Result) error
 }{}
 
@@ -109,9 +192,27 @@ func init() {
 
 }
 
+// Plugin_Goodbye_Result represents the result of a Plugin.goodbye function call.
+//
+// The result of a goodbye execution is sent and received over the wire as this struct.
 type Plugin_Goodbye_Result struct {
 }
 
+// ToWire translates a Plugin_Goodbye_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Plugin_Goodbye_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -121,6 +222,23 @@ func (v *Plugin_Goodbye_Result) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a Plugin_Goodbye_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Plugin_Goodbye_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Plugin_Goodbye_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Plugin_Goodbye_Result) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -131,6 +249,8 @@ func (v *Plugin_Goodbye_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Plugin_Goodbye_Result
+// struct.
 func (v *Plugin_Goodbye_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -142,15 +262,26 @@ func (v *Plugin_Goodbye_Result) String() string {
 	return fmt.Sprintf("Plugin_Goodbye_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Plugin_Goodbye_Result match the
+// provided Plugin_Goodbye_Result.
+//
+// This function performs a deep comparison.
 func (v *Plugin_Goodbye_Result) Equals(rhs *Plugin_Goodbye_Result) bool {
 
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "goodbye" for this struct.
 func (v *Plugin_Goodbye_Result) MethodName() string {
 	return "goodbye"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *Plugin_Goodbye_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/plugin/api/plugin_handshake.go
+++ b/plugin/api/plugin_handshake.go
@@ -30,10 +30,28 @@ import (
 	"strings"
 )
 
+// Plugin_Handshake_Args represents the arguments for the Plugin.handshake function.
+//
+// The arguments for handshake are sent and received over the wire as this struct.
 type Plugin_Handshake_Args struct {
 	Request *HandshakeRequest `json:"request,omitempty"`
 }
 
+// ToWire translates a Plugin_Handshake_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Plugin_Handshake_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -60,6 +78,23 @@ func _HandshakeRequest_Read(w wire.Value) (*HandshakeRequest, error) {
 	return &v, err
 }
 
+// FromWire deserializes a Plugin_Handshake_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Plugin_Handshake_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Plugin_Handshake_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Plugin_Handshake_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -79,6 +114,8 @@ func (v *Plugin_Handshake_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Plugin_Handshake_Args
+// struct.
 func (v *Plugin_Handshake_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -94,6 +131,10 @@ func (v *Plugin_Handshake_Args) String() string {
 	return fmt.Sprintf("Plugin_Handshake_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Plugin_Handshake_Args match the
+// provided Plugin_Handshake_Args.
+//
+// This function performs a deep comparison.
 func (v *Plugin_Handshake_Args) Equals(rhs *Plugin_Handshake_Args) bool {
 	if !((v.Request == nil && rhs.Request == nil) || (v.Request != nil && rhs.Request != nil && v.Request.Equals(rhs.Request))) {
 		return false
@@ -102,22 +143,63 @@ func (v *Plugin_Handshake_Args) Equals(rhs *Plugin_Handshake_Args) bool {
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "handshake" for this struct.
 func (v *Plugin_Handshake_Args) MethodName() string {
 	return "handshake"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *Plugin_Handshake_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// Plugin_Handshake_Helper provides functions that aid in handling the
+// parameters and return values of the Plugin.handshake
+// function.
 var Plugin_Handshake_Helper = struct {
+	// Args accepts the parameters of handshake in-order and returns
+	// the arguments struct for the function.
 	Args func(
 		request *HandshakeRequest,
 	) *Plugin_Handshake_Args
 
+	// IsException returns true if the given error can be thrown
+	// by handshake.
+	//
+	// An error can be thrown by handshake only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(*HandshakeResponse, error) (*Plugin_Handshake_Result, error)
+	// WrapResponse returns the result struct for handshake
+	// given its return value and error.
+	//
+	// This allows mapping values and errors returned by
+	// handshake into a serializable result struct.
+	// WrapResponse returns a non-nil error if the provided
+	// error cannot be thrown by handshake
+	//
+	//   value, err := handshake(args)
+	//   result, err := Plugin_Handshake_Helper.WrapResponse(value, err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from handshake: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(*HandshakeResponse, error) (*Plugin_Handshake_Result, error)
+
+	// UnwrapResponse takes the result struct for handshake
+	// and returns the value or error returned by it.
+	//
+	// The error is non-nil only if handshake threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   value, err := Plugin_Handshake_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*Plugin_Handshake_Result) (*HandshakeResponse, error)
 }{}
 
@@ -157,10 +239,31 @@ func init() {
 
 }
 
+// Plugin_Handshake_Result represents the result of a Plugin.handshake function call.
+//
+// The result of a handshake execution is sent and received over the wire as this struct.
+//
+// Success is set only if the function did not throw an exception.
 type Plugin_Handshake_Result struct {
+	// Value returned by handshake after a successful execution.
 	Success *HandshakeResponse `json:"success,omitempty"`
 }
 
+// ToWire translates a Plugin_Handshake_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Plugin_Handshake_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -191,6 +294,23 @@ func _HandshakeResponse_Read(w wire.Value) (*HandshakeResponse, error) {
 	return &v, err
 }
 
+// FromWire deserializes a Plugin_Handshake_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Plugin_Handshake_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Plugin_Handshake_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Plugin_Handshake_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -218,6 +338,8 @@ func (v *Plugin_Handshake_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Plugin_Handshake_Result
+// struct.
 func (v *Plugin_Handshake_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -233,6 +355,10 @@ func (v *Plugin_Handshake_Result) String() string {
 	return fmt.Sprintf("Plugin_Handshake_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Plugin_Handshake_Result match the
+// provided Plugin_Handshake_Result.
+//
+// This function performs a deep comparison.
 func (v *Plugin_Handshake_Result) Equals(rhs *Plugin_Handshake_Result) bool {
 	if !((v.Success == nil && rhs.Success == nil) || (v.Success != nil && rhs.Success != nil && v.Success.Equals(rhs.Success))) {
 		return false
@@ -241,10 +367,17 @@ func (v *Plugin_Handshake_Result) Equals(rhs *Plugin_Handshake_Result) bool {
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "handshake" for this struct.
 func (v *Plugin_Handshake_Result) MethodName() string {
 	return "handshake"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *Plugin_Handshake_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/plugin/api/servicegenerator_generate.go
+++ b/plugin/api/servicegenerator_generate.go
@@ -30,10 +30,28 @@ import (
 	"strings"
 )
 
+// ServiceGenerator_Generate_Args represents the arguments for the ServiceGenerator.generate function.
+//
+// The arguments for generate are sent and received over the wire as this struct.
 type ServiceGenerator_Generate_Args struct {
 	Request *GenerateServiceRequest `json:"request,omitempty"`
 }
 
+// ToWire translates a ServiceGenerator_Generate_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ServiceGenerator_Generate_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -60,6 +78,23 @@ func _GenerateServiceRequest_Read(w wire.Value) (*GenerateServiceRequest, error)
 	return &v, err
 }
 
+// FromWire deserializes a ServiceGenerator_Generate_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ServiceGenerator_Generate_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ServiceGenerator_Generate_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ServiceGenerator_Generate_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -79,6 +114,8 @@ func (v *ServiceGenerator_Generate_Args) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ServiceGenerator_Generate_Args
+// struct.
 func (v *ServiceGenerator_Generate_Args) String() string {
 	if v == nil {
 		return "<nil>"
@@ -94,6 +131,10 @@ func (v *ServiceGenerator_Generate_Args) String() string {
 	return fmt.Sprintf("ServiceGenerator_Generate_Args{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this ServiceGenerator_Generate_Args match the
+// provided ServiceGenerator_Generate_Args.
+//
+// This function performs a deep comparison.
 func (v *ServiceGenerator_Generate_Args) Equals(rhs *ServiceGenerator_Generate_Args) bool {
 	if !((v.Request == nil && rhs.Request == nil) || (v.Request != nil && rhs.Request != nil && v.Request.Equals(rhs.Request))) {
 		return false
@@ -102,22 +143,63 @@ func (v *ServiceGenerator_Generate_Args) Equals(rhs *ServiceGenerator_Generate_A
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "generate" for this struct.
 func (v *ServiceGenerator_Generate_Args) MethodName() string {
 	return "generate"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
 func (v *ServiceGenerator_Generate_Args) EnvelopeType() wire.EnvelopeType {
 	return wire.Call
 }
 
+// ServiceGenerator_Generate_Helper provides functions that aid in handling the
+// parameters and return values of the ServiceGenerator.generate
+// function.
 var ServiceGenerator_Generate_Helper = struct {
+	// Args accepts the parameters of generate in-order and returns
+	// the arguments struct for the function.
 	Args func(
 		request *GenerateServiceRequest,
 	) *ServiceGenerator_Generate_Args
 
+	// IsException returns true if the given error can be thrown
+	// by generate.
+	//
+	// An error can be thrown by generate only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
 	IsException func(error) bool
 
-	WrapResponse   func(*GenerateServiceResponse, error) (*ServiceGenerator_Generate_Result, error)
+	// WrapResponse returns the result struct for generate
+	// given its return value and error.
+	//
+	// This allows mapping values and errors returned by
+	// generate into a serializable result struct.
+	// WrapResponse returns a non-nil error if the provided
+	// error cannot be thrown by generate
+	//
+	//   value, err := generate(args)
+	//   result, err := ServiceGenerator_Generate_Helper.WrapResponse(value, err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from generate: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(*GenerateServiceResponse, error) (*ServiceGenerator_Generate_Result, error)
+
+	// UnwrapResponse takes the result struct for generate
+	// and returns the value or error returned by it.
+	//
+	// The error is non-nil only if generate threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   value, err := ServiceGenerator_Generate_Helper.UnwrapResponse(result)
 	UnwrapResponse func(*ServiceGenerator_Generate_Result) (*GenerateServiceResponse, error)
 }{}
 
@@ -157,10 +239,31 @@ func init() {
 
 }
 
+// ServiceGenerator_Generate_Result represents the result of a ServiceGenerator.generate function call.
+//
+// The result of a generate execution is sent and received over the wire as this struct.
+//
+// Success is set only if the function did not throw an exception.
 type ServiceGenerator_Generate_Result struct {
+	// Value returned by generate after a successful execution.
 	Success *GenerateServiceResponse `json:"success,omitempty"`
 }
 
+// ToWire translates a ServiceGenerator_Generate_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *ServiceGenerator_Generate_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -191,6 +294,23 @@ func _GenerateServiceResponse_Read(w wire.Value) (*GenerateServiceResponse, erro
 	return &v, err
 }
 
+// FromWire deserializes a ServiceGenerator_Generate_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a ServiceGenerator_Generate_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v ServiceGenerator_Generate_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *ServiceGenerator_Generate_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -218,6 +338,8 @@ func (v *ServiceGenerator_Generate_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a ServiceGenerator_Generate_Result
+// struct.
 func (v *ServiceGenerator_Generate_Result) String() string {
 	if v == nil {
 		return "<nil>"
@@ -233,6 +355,10 @@ func (v *ServiceGenerator_Generate_Result) String() string {
 	return fmt.Sprintf("ServiceGenerator_Generate_Result{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this ServiceGenerator_Generate_Result match the
+// provided ServiceGenerator_Generate_Result.
+//
+// This function performs a deep comparison.
 func (v *ServiceGenerator_Generate_Result) Equals(rhs *ServiceGenerator_Generate_Result) bool {
 	if !((v.Success == nil && rhs.Success == nil) || (v.Success != nil && rhs.Success != nil && v.Success.Equals(rhs.Success))) {
 		return false
@@ -241,10 +367,17 @@ func (v *ServiceGenerator_Generate_Result) Equals(rhs *ServiceGenerator_Generate
 	return true
 }
 
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "generate" for this struct.
 func (v *ServiceGenerator_Generate_Result) MethodName() string {
 	return "generate"
 }
 
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
 func (v *ServiceGenerator_Generate_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -52,6 +52,21 @@ type Argument struct {
 	Type *Type `json:"type,required"`
 }
 
+// ToWire translates a Argument struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Argument) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -85,6 +100,23 @@ func _Type_Read(w wire.Value) (*Type, error) {
 	return &v, err
 }
 
+// FromWire deserializes a Argument struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Argument struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Argument
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Argument) FromWire(w wire.Value) error {
 	var err error
 
@@ -123,6 +155,8 @@ func (v *Argument) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Argument
+// struct.
 func (v *Argument) String() string {
 	if v == nil {
 		return "<nil>"
@@ -138,6 +172,10 @@ func (v *Argument) String() string {
 	return fmt.Sprintf("Argument{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Argument match the
+// provided Argument.
+//
+// This function performs a deep comparison.
 func (v *Argument) Equals(rhs *Argument) bool {
 	if !(v.Name == rhs.Name) {
 		return false
@@ -161,12 +199,18 @@ const (
 	FeatureServiceGenerator Feature = 1
 )
 
+// Feature_Values returns all recognized values of Feature.
 func Feature_Values() []Feature {
 	return []Feature{
 		FeatureServiceGenerator,
 	}
 }
 
+// UnmarshalText tries to decode Feature from a byte slice
+// containing its name.
+//
+//   var v Feature
+//   err := v.UnmarshalText([]byte("SERVICE_GENERATOR"))
 func (v *Feature) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "SERVICE_GENERATOR":
@@ -177,15 +221,34 @@ func (v *Feature) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates Feature into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v Feature) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes Feature from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return Feature(0), err
+//   }
+//
+//   var v Feature
+//   if err := v.FromWire(x); err != nil {
+//     return Feature(0), err
+//   }
+//   return v, nil
 func (v *Feature) FromWire(w wire.Value) error {
 	*v = (Feature)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of Feature.
 func (v Feature) String() string {
 	w := int32(v)
 	switch w {
@@ -195,10 +258,18 @@ func (v Feature) String() string {
 	return fmt.Sprintf("Feature(%d)", w)
 }
 
+// Equals returns true if this Feature value matches the provided
+// value.
 func (v Feature) Equals(rhs Feature) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes Feature into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v Feature) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 1:
@@ -207,6 +278,13 @@ func (v Feature) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode Feature from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *Feature) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -288,6 +366,21 @@ func (_List_Argument_ValueList) ValueType() wire.Type {
 
 func (_List_Argument_ValueList) Close() {}
 
+// ToWire translates a Function struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Function) ToWire() (wire.Value, error) {
 	var (
 		fields [6]wire.Field
@@ -370,6 +463,23 @@ func _List_Argument_Read(l wire.ValueList) ([]*Argument, error) {
 	return o, err
 }
 
+// FromWire deserializes a Function struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Function struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Function
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Function) FromWire(w wire.Value) error {
 	var err error
 
@@ -447,6 +557,8 @@ func (v *Function) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Function
+// struct.
 func (v *Function) String() string {
 	if v == nil {
 		return "<nil>"
@@ -501,6 +613,10 @@ func _Bool_EqualsPtr(lhs, rhs *bool) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this Function match the
+// provided Function.
+//
+// This function performs a deep comparison.
 func (v *Function) Equals(rhs *Function) bool {
 	if !(v.Name == rhs.Name) {
 		return false
@@ -524,6 +640,8 @@ func (v *Function) Equals(rhs *Function) bool {
 	return true
 }
 
+// GetOneWay returns the value of OneWay if it is set or its
+// zero value if it is unset.
 func (v *Function) GetOneWay() (o bool) {
 	if v.OneWay != nil {
 		return *v.OneWay
@@ -656,6 +774,21 @@ func (_Map_ModuleID_Module_MapItemList) ValueType() wire.Type {
 
 func (_Map_ModuleID_Module_MapItemList) Close() {}
 
+// ToWire translates a GenerateServiceRequest struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *GenerateServiceRequest) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -793,6 +926,23 @@ func _Map_ModuleID_Module_Read(m wire.MapItemList) (map[ModuleID]*Module, error)
 	return o, err
 }
 
+// FromWire deserializes a GenerateServiceRequest struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a GenerateServiceRequest struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v GenerateServiceRequest
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *GenerateServiceRequest) FromWire(w wire.Value) error {
 	var err error
 
@@ -844,6 +994,8 @@ func (v *GenerateServiceRequest) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a GenerateServiceRequest
+// struct.
 func (v *GenerateServiceRequest) String() string {
 	if v == nil {
 		return "<nil>"
@@ -910,6 +1062,10 @@ func _Map_ModuleID_Module_Equals(lhs, rhs map[ModuleID]*Module) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this GenerateServiceRequest match the
+// provided GenerateServiceRequest.
+//
+// This function performs a deep comparison.
 func (v *GenerateServiceRequest) Equals(rhs *GenerateServiceRequest) bool {
 	if !_List_ServiceID_Equals(v.RootServices, rhs.RootServices) {
 		return false
@@ -974,6 +1130,21 @@ func (_Map_String_Binary_MapItemList) ValueType() wire.Type {
 
 func (_Map_String_Binary_MapItemList) Close() {}
 
+// ToWire translates a GenerateServiceResponse struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *GenerateServiceResponse) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -1022,6 +1193,23 @@ func _Map_String_Binary_Read(m wire.MapItemList) (map[string][]byte, error) {
 	return o, err
 }
 
+// FromWire deserializes a GenerateServiceResponse struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a GenerateServiceResponse struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v GenerateServiceResponse
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *GenerateServiceResponse) FromWire(w wire.Value) error {
 	var err error
 
@@ -1041,6 +1229,8 @@ func (v *GenerateServiceResponse) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a GenerateServiceResponse
+// struct.
 func (v *GenerateServiceResponse) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1073,6 +1263,10 @@ func _Map_String_Binary_Equals(lhs, rhs map[string][]byte) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this GenerateServiceResponse match the
+// provided GenerateServiceResponse.
+//
+// This function performs a deep comparison.
 func (v *GenerateServiceResponse) Equals(rhs *GenerateServiceResponse) bool {
 	if !((v.Files == nil && rhs.Files == nil) || (v.Files != nil && rhs.Files != nil && _Map_String_Binary_Equals(v.Files, rhs.Files))) {
 		return false
@@ -1086,6 +1280,21 @@ func (v *GenerateServiceResponse) Equals(rhs *GenerateServiceResponse) bool {
 type HandshakeRequest struct {
 }
 
+// ToWire translates a HandshakeRequest struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *HandshakeRequest) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -1095,6 +1304,23 @@ func (v *HandshakeRequest) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a HandshakeRequest struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a HandshakeRequest struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v HandshakeRequest
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *HandshakeRequest) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -1105,6 +1331,8 @@ func (v *HandshakeRequest) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a HandshakeRequest
+// struct.
 func (v *HandshakeRequest) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1116,6 +1344,10 @@ func (v *HandshakeRequest) String() string {
 	return fmt.Sprintf("HandshakeRequest{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this HandshakeRequest match the
+// provided HandshakeRequest.
+//
+// This function performs a deep comparison.
 func (v *HandshakeRequest) Equals(rhs *HandshakeRequest) bool {
 
 	return true
@@ -1165,6 +1397,21 @@ func (_List_Feature_ValueList) ValueType() wire.Type {
 
 func (_List_Feature_ValueList) Close() {}
 
+// ToWire translates a HandshakeResponse struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *HandshakeResponse) ToWire() (wire.Value, error) {
 	var (
 		fields [4]wire.Field
@@ -1231,6 +1478,23 @@ func _List_Feature_Read(l wire.ValueList) ([]Feature, error) {
 	return o, err
 }
 
+// FromWire deserializes a HandshakeResponse struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a HandshakeResponse struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v HandshakeResponse
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *HandshakeResponse) FromWire(w wire.Value) error {
 	var err error
 
@@ -1292,6 +1556,8 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a HandshakeResponse
+// struct.
 func (v *HandshakeResponse) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1338,6 +1604,10 @@ func _String_EqualsPtr(lhs, rhs *string) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this HandshakeResponse match the
+// provided HandshakeResponse.
+//
+// This function performs a deep comparison.
 func (v *HandshakeResponse) Equals(rhs *HandshakeResponse) bool {
 	if !(v.Name == rhs.Name) {
 		return false
@@ -1355,6 +1625,8 @@ func (v *HandshakeResponse) Equals(rhs *HandshakeResponse) bool {
 	return true
 }
 
+// GetLibraryVersion returns the value of LibraryVersion if it is set or its
+// zero value if it is unset.
 func (v *HandshakeResponse) GetLibraryVersion() (o string) {
 	if v.LibraryVersion != nil {
 		return *v.LibraryVersion
@@ -1377,6 +1649,21 @@ type Module struct {
 	Directory string `json:"directory,required"`
 }
 
+// ToWire translates a Module struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Module) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1402,6 +1689,23 @@ func (v *Module) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a Module struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Module struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Module
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Module) FromWire(w wire.Value) error {
 	var err error
 
@@ -1440,6 +1744,8 @@ func (v *Module) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Module
+// struct.
 func (v *Module) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1455,6 +1761,10 @@ func (v *Module) String() string {
 	return fmt.Sprintf("Module{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this Module match the
+// provided Module.
+//
+// This function performs a deep comparison.
 func (v *Module) Equals(rhs *Module) bool {
 	if !(v.ImportPath == rhs.ImportPath) {
 		return false
@@ -1470,22 +1780,31 @@ func (v *Module) Equals(rhs *Module) bool {
 // modules in this request.
 type ModuleID int32
 
+// ToWire translates ModuleID into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v ModuleID) ToWire() (wire.Value, error) {
 	x := (int32)(v)
 	return wire.NewValueI32(x), error(nil)
 }
 
+// String returns a readable string representation of ModuleID.
 func (v ModuleID) String() string {
 	x := (int32)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes ModuleID from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *ModuleID) FromWire(w wire.Value) error {
 	x, err := w.GetI32(), error(nil)
 	*v = (ModuleID)(x)
 	return err
 }
 
+// Equals returns true if this ModuleID is equal to the provided
+// ModuleID.
 func (lhs ModuleID) Equals(rhs ModuleID) bool {
 	return (lhs == rhs)
 }
@@ -1533,6 +1852,21 @@ func (_List_Function_ValueList) ValueType() wire.Type {
 
 func (_List_Function_ValueList) Close() {}
 
+// ToWire translates a Service struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Service) ToWire() (wire.Value, error) {
 	var (
 		fields [5]wire.Field
@@ -1606,6 +1940,23 @@ func _List_Function_Read(l wire.ValueList) ([]*Function, error) {
 	return o, err
 }
 
+// FromWire deserializes a Service struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Service struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Service
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Service) FromWire(w wire.Value) error {
 	var err error
 
@@ -1681,6 +2032,8 @@ func (v *Service) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Service
+// struct.
 func (v *Service) String() string {
 	if v == nil {
 		return "<nil>"
@@ -1729,6 +2082,10 @@ func _List_Function_Equals(lhs, rhs []*Function) bool {
 	return true
 }
 
+// Equals returns true if all the fields of this Service match the
+// provided Service.
+//
+// This function performs a deep comparison.
 func (v *Service) Equals(rhs *Service) bool {
 	if !(v.Name == rhs.Name) {
 		return false
@@ -1749,6 +2106,8 @@ func (v *Service) Equals(rhs *Service) bool {
 	return true
 }
 
+// GetParentID returns the value of ParentID if it is set or its
+// zero value if it is unset.
 func (v *Service) GetParentID() (o ServiceID) {
 	if v.ParentID != nil {
 		return *v.ParentID
@@ -1761,22 +2120,31 @@ func (v *Service) GetParentID() (o ServiceID) {
 // services in this request.
 type ServiceID int32
 
+// ToWire translates ServiceID into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
 func (v ServiceID) ToWire() (wire.Value, error) {
 	x := (int32)(v)
 	return wire.NewValueI32(x), error(nil)
 }
 
+// String returns a readable string representation of ServiceID.
 func (v ServiceID) String() string {
 	x := (int32)(v)
 	return fmt.Sprint(x)
 }
 
+// FromWire deserializes ServiceID from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
 func (v *ServiceID) FromWire(w wire.Value) error {
 	x, err := w.GetI32(), error(nil)
 	*v = (ServiceID)(x)
 	return err
 }
 
+// Equals returns true if this ServiceID is equal to the provided
+// ServiceID.
 func (lhs ServiceID) Equals(rhs ServiceID) bool {
 	return (lhs == rhs)
 }
@@ -1796,6 +2164,7 @@ const (
 	SimpleTypeStructEmpty SimpleType = 9
 )
 
+// SimpleType_Values returns all recognized values of SimpleType.
 func SimpleType_Values() []SimpleType {
 	return []SimpleType{
 		SimpleTypeBool,
@@ -1810,6 +2179,11 @@ func SimpleType_Values() []SimpleType {
 	}
 }
 
+// UnmarshalText tries to decode SimpleType from a byte slice
+// containing its name.
+//
+//   var v SimpleType
+//   err := v.UnmarshalText([]byte("BOOL"))
 func (v *SimpleType) UnmarshalText(value []byte) error {
 	switch string(value) {
 	case "BOOL":
@@ -1844,15 +2218,34 @@ func (v *SimpleType) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToWire translates SimpleType into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// Enums are represented as 32-bit integers over the wire.
 func (v SimpleType) ToWire() (wire.Value, error) {
 	return wire.NewValueI32(int32(v)), nil
 }
 
+// FromWire deserializes SimpleType from its Thrift-level
+// representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TI32)
+//   if err != nil {
+//     return SimpleType(0), err
+//   }
+//
+//   var v SimpleType
+//   if err := v.FromWire(x); err != nil {
+//     return SimpleType(0), err
+//   }
+//   return v, nil
 func (v *SimpleType) FromWire(w wire.Value) error {
 	*v = (SimpleType)(w.GetI32())
 	return nil
 }
 
+// String returns a readable string representation of SimpleType.
 func (v SimpleType) String() string {
 	w := int32(v)
 	switch w {
@@ -1878,10 +2271,18 @@ func (v SimpleType) String() string {
 	return fmt.Sprintf("SimpleType(%d)", w)
 }
 
+// Equals returns true if this SimpleType value matches the provided
+// value.
 func (v SimpleType) Equals(rhs SimpleType) bool {
 	return v == rhs
 }
 
+// MarshalJSON serializes SimpleType into JSON.
+//
+// If the enum value is recognized, its name is returned. Otherwise,
+// its integer value is returned.
+//
+// This implements json.Marshaler.
 func (v SimpleType) MarshalJSON() ([]byte, error) {
 	switch int32(v) {
 	case 1:
@@ -1906,6 +2307,13 @@ func (v SimpleType) MarshalJSON() ([]byte, error) {
 	return ([]byte)(strconv.FormatInt(int64(v), 10)), nil
 }
 
+// UnmarshalJSON attempts to decode SimpleType from its JSON
+// representation.
+//
+// This implementation supports both, numeric and string inputs. If a
+// string is provided, it must be a known enum name.
+//
+// This implements json.Unmarshaler.
 func (v *SimpleType) UnmarshalJSON(text []byte) error {
 	d := json.NewDecoder(bytes.NewReader(text))
 	d.UseNumber()
@@ -1956,6 +2364,21 @@ type Type struct {
 	PointerType *Type `json:"pointerType,omitempty"`
 }
 
+// ToWire translates a Type struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *Type) ToWire() (wire.Value, error) {
 	var (
 		fields [6]wire.Field
@@ -2038,6 +2461,23 @@ func _TypeReference_Read(w wire.Value) (*TypeReference, error) {
 	return &v, err
 }
 
+// FromWire deserializes a Type struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a Type struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v Type
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *Type) FromWire(w wire.Value) error {
 	var err error
 
@@ -2122,6 +2562,8 @@ func (v *Type) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a Type
+// struct.
 func (v *Type) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2167,6 +2609,10 @@ func _SimpleType_EqualsPtr(lhs, rhs *SimpleType) bool {
 	return lhs == nil && rhs == nil
 }
 
+// Equals returns true if all the fields of this Type match the
+// provided Type.
+//
+// This function performs a deep comparison.
 func (v *Type) Equals(rhs *Type) bool {
 	if !_SimpleType_EqualsPtr(v.SimpleType, rhs.SimpleType) {
 		return false
@@ -2190,6 +2636,8 @@ func (v *Type) Equals(rhs *Type) bool {
 	return true
 }
 
+// GetSimpleType returns the value of SimpleType if it is set or its
+// zero value if it is unset.
 func (v *Type) GetSimpleType() (o SimpleType) {
 	if v.SimpleType != nil {
 		return *v.SimpleType
@@ -2204,6 +2652,21 @@ type TypePair struct {
 	Right *Type `json:"right,required"`
 }
 
+// ToWire translates a TypePair struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *TypePair) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2234,6 +2697,23 @@ func (v *TypePair) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a TypePair struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a TypePair struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v TypePair
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *TypePair) FromWire(w wire.Value) error {
 	var err error
 
@@ -2272,6 +2752,8 @@ func (v *TypePair) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a TypePair
+// struct.
 func (v *TypePair) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2287,6 +2769,10 @@ func (v *TypePair) String() string {
 	return fmt.Sprintf("TypePair{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this TypePair match the
+// provided TypePair.
+//
+// This function performs a deep comparison.
 func (v *TypePair) Equals(rhs *TypePair) bool {
 	if !v.Left.Equals(rhs.Left) {
 		return false
@@ -2305,6 +2791,21 @@ type TypeReference struct {
 	ImportPath string `json:"importPath,required"`
 }
 
+// ToWire translates a TypeReference struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
 func (v *TypeReference) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2330,6 +2831,23 @@ func (v *TypeReference) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+// FromWire deserializes a TypeReference struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a TypeReference struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v TypeReference
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
 func (v *TypeReference) FromWire(w wire.Value) error {
 	var err error
 
@@ -2368,6 +2886,8 @@ func (v *TypeReference) FromWire(w wire.Value) error {
 	return nil
 }
 
+// String returns a readable string representation of a TypeReference
+// struct.
 func (v *TypeReference) String() string {
 	if v == nil {
 		return "<nil>"
@@ -2383,6 +2903,10 @@ func (v *TypeReference) String() string {
 	return fmt.Sprintf("TypeReference{%v}", strings.Join(fields[:i], ", "))
 }
 
+// Equals returns true if all the fields of this TypeReference match the
+// provided TypeReference.
+//
+// This function performs a deep comparison.
 func (v *TypeReference) Equals(rhs *TypeReference) bool {
 	if !(v.Name == rhs.Name) {
 		return false


### PR DESCRIPTION
This changes code generation templates to document all top-level
declarations that the users don't have control over.

With this and #328, users now have the ability to get a fully documented
Go package. They can add docstrings to entities in the Thrift file, and
for top-level entities that they don't have control over, we will
generate our own documentation.