### PR TITLE
gen/json: Enable omitempty for optional collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 /cover
 cover.out
 cover.html
+.idea/
 
 # We will explicitly whitelist vendored libraries that we want to check in.
 vendor/*

--- a/compile/container.go
+++ b/compile/container.go
@@ -93,14 +93,11 @@ func (m *MapSpec) TypeCode() wire.Type {
 }
 
 // ForEachTypeReference for MapSpec
-func (m *MapSpec) ForEachTypeReference(f func(TypeSpec) error) (err error) {
-	if err = f(m.KeySpec); err != nil {
+func (m *MapSpec) ForEachTypeReference(f func(TypeSpec) error) error {
+	if err := f(m.KeySpec); err != nil {
 		return err
 	}
-	if err = f(m.ValueSpec); err != nil {
-		return err
-	}
-	return err
+	return f(m.ValueSpec)
 }
 
 // ThriftAnnotations returns all associated annotations.

--- a/compile/container.go
+++ b/compile/container.go
@@ -93,14 +93,14 @@ func (m *MapSpec) TypeCode() wire.Type {
 }
 
 // ForEachTypeReference for MapSpec
-func (m *MapSpec) ForEachTypeReference(f func(TypeSpec) error) error {
-	if err := f(m.KeySpec); err != nil {
+func (m *MapSpec) ForEachTypeReference(f func(TypeSpec) error) (err error) {
+	if err = f(m.KeySpec); err != nil {
 		return err
 	}
-	if err := f(m.ValueSpec); err != nil {
+	if err = f(m.ValueSpec); err != nil {
 		return err
 	}
-	return nil
+	return err
 }
 
 // ThriftAnnotations returns all associated annotations.

--- a/gen/field.go
+++ b/gen/field.go
@@ -70,32 +70,28 @@ func (f fieldGroupGenerator) checkReservedIdentifier(name string) error {
 	return nil
 }
 
-func (f fieldGroupGenerator) Generate(g Generator) (err error) {
-	if err = f.DefineStruct(g); err != nil {
+func (f fieldGroupGenerator) Generate(g Generator) error {
+	if err := f.DefineStruct(g); err != nil {
 		return err
 	}
 
-	if err = f.ToWire(g); err != nil {
+	if err := f.ToWire(g); err != nil {
 		return err
 	}
 
-	if err = f.FromWire(g); err != nil {
+	if err := f.FromWire(g); err != nil {
 		return err
 	}
 
-	if err = f.String(g); err != nil {
+	if err := f.String(g); err != nil {
 		return err
 	}
 
-	if err = f.Equals(g); err != nil {
+	if err := f.Equals(g); err != nil {
 		return err
 	}
 
-	if err = f.PrimitiveAccessors(g); err != nil {
-		return err
-	}
-
-	return err
+	return f.PrimitiveAccessors(g)
 }
 
 func (f fieldGroupGenerator) DefineStruct(g Generator) error {

--- a/gen/field.go
+++ b/gen/field.go
@@ -147,23 +147,24 @@ func generateTags(f *compile.FieldSpec) (string, error) {
 }
 
 func compileJSONTag(f *compile.FieldSpec, name string, opts ...string) *structtag.Tag {
-	// We want to add omitempty if the field is an optional struct or
-	// primitive to reduce "null" noise. We won't add omitempty for
-	// optional collections because omitempty doesn't differentiate
-	// between nil and empty collections.
-
 	t := &structtag.Tag{
 		Key:     jsonTagKey,
 		Name:    name,
 		Options: opts,
 	}
 
+	// If the field name is "-" then it means omit, add no tags
 	if name == "-" {
-		// If the field name is "-" then it means omit, add no tags
 		return t
 	}
 
-	if (isStructType(f.Type) || isPrimitiveType(f.Type)) && !f.Required && !t.HasOption("omitempty") {
+	// We want to add the "omitempty" json tag if the field is an 'optional" to
+	// reduce "null" noise. The "omitempty" json tag specifies that the field
+	// should be omitted from the encoding if the field has an empty value,
+	// defined as false, 0, a nil pointer, a nil interface value, and any empty
+	// array, slice, map, or string.
+	if (isReferenceType(f.Type) || isStructType(f.Type) || isPrimitiveType(f.Type)) &&
+		!f.Required && !t.HasOption("omitempty") {
 		t.Options = append(t.Options, "omitempty")
 	}
 

--- a/gen/field.go
+++ b/gen/field.go
@@ -154,7 +154,7 @@ func compileJSONTag(f *compile.FieldSpec, name string, opts ...string) *structta
 		return t
 	}
 
-	// We want to add the "omitempty" json tag if the field is an 'optional" to
+	// We want to add the "omitempty" JSON tag if the field is an "optional" to
 	// reduce "null" noise. The "omitempty" json tag specifies that the field
 	// should be omitted from the encoding if the field has an empty value,
 	// defined as false, 0, a nil pointer, a nil interface value, and any empty

--- a/gen/field.go
+++ b/gen/field.go
@@ -70,32 +70,32 @@ func (f fieldGroupGenerator) checkReservedIdentifier(name string) error {
 	return nil
 }
 
-func (f fieldGroupGenerator) Generate(g Generator) error {
-	if err := f.DefineStruct(g); err != nil {
+func (f fieldGroupGenerator) Generate(g Generator) (err error) {
+	if err = f.DefineStruct(g); err != nil {
 		return err
 	}
 
-	if err := f.ToWire(g); err != nil {
+	if err = f.ToWire(g); err != nil {
 		return err
 	}
 
-	if err := f.FromWire(g); err != nil {
+	if err = f.FromWire(g); err != nil {
 		return err
 	}
 
-	if err := f.String(g); err != nil {
+	if err = f.String(g); err != nil {
 		return err
 	}
 
-	if err := f.Equals(g); err != nil {
+	if err = f.Equals(g); err != nil {
 		return err
 	}
 
-	if err := f.PrimitiveAccessors(g); err != nil {
+	if err = f.PrimitiveAccessors(g); err != nil {
 		return err
 	}
 
-	return nil
+	return err
 }
 
 func (f fieldGroupGenerator) DefineStruct(g Generator) error {

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -878,112 +878,131 @@ func TestStructWithDefaults(t *testing.T) {
 
 func TestStructJSON(t *testing.T) {
 	tests := []struct {
-		v interface{}
-		j string
+		v, w interface{}
+		j    string
 	}{
-		{&ts.Point{X: 0, Y: 0}, `{"x":0,"y":0}`},
-		{&ts.Point{X: 1, Y: 2}, `{"x":1,"y":2}`},
+		{v: &ts.Point{X: 0, Y: 0}, j: `{"x":0,"y":0}`},
+		{v: &ts.Point{X: 1, Y: 2}, j: `{"x":1,"y":2}`},
 		{
-			&ts.Edge{
+			v: &ts.Edge{
 				StartPoint: &ts.Point{X: 1, Y: 2},
 				EndPoint:   &ts.Point{X: 3, Y: 4},
 			},
-			`{"startPoint":{"x":1,"y":2},"endPoint":{"x":3,"y":4}}`,
+			j: `{"startPoint":{"x":1,"y":2},"endPoint":{"x":3,"y":4}}`,
 		},
 		{
-			&ts.Edge{StartPoint: &ts.Point{X: 1, Y: 1}},
-			`{"startPoint":{"x":1,"y":1},"endPoint":null}`,
+			v: &ts.Edge{StartPoint: &ts.Point{X: 1, Y: 1}},
+			j: `{"startPoint":{"x":1,"y":1},"endPoint":null}`,
 		},
 		{
-			&ts.Edge{
+			v: &ts.Edge{
 				StartPoint: &ts.Point{X: 1, Y: 1},
 				EndPoint:   &ts.Point{X: 1, Y: 1},
 			},
-			`{"startPoint":{"x":1,"y":1},"endPoint":{"x":1,"y":1}}`,
+			j: `{"startPoint":{"x":1,"y":1},"endPoint":{"x":1,"y":1}}`,
 		},
-		{&ts.User{Name: ""}, `{"name":""}`},
-		{&ts.User{Name: "foo"}, `{"name":"foo"}`},
+		{v: &ts.User{Name: ""}, j: `{"name":""}`},
+		{v: &ts.User{Name: "foo"}, j: `{"name":"foo"}`},
 		{
-			&ts.User{
+			v: &ts.User{
 				Name:    "foo",
 				Contact: &ts.ContactInfo{EmailAddress: "bar@example.com"},
 			},
-			`{"name":"foo","contact":{"emailAddress":"bar@example.com"}}`,
+			j: `{"name":"foo","contact":{"emailAddress":"bar@example.com"}}`,
 		},
 		{
-			&ts.User{
+			v: &ts.User{
 				Name:    "foo",
 				Contact: &ts.ContactInfo{EmailAddress: ""},
 			},
-			`{"name":"foo","contact":{"emailAddress":""}}`,
+			j: `{"name":"foo","contact":{"emailAddress":""}}`,
 		},
-		{&tu.EmptyUnion{}, "{}"},
-		{&tu.Document{Pdf: td.PDF("hello")}, `{"pdf":"aGVsbG8="}`},
-		{&tu.Document{Pdf: td.PDF{}}, `{"pdf":""}`},
+		{v: &tu.EmptyUnion{}, j: "{}"},
+		{v: &tu.Document{Pdf: td.PDF("hello")}, j: `{"pdf":"aGVsbG8="}`},
+		{v: &tu.Document{Pdf: td.PDF{}}, w: &tu.Document{Pdf: nil}, j: `{}`},
+		{v: &tu.Document{Pdf: nil}, j: `{}`},
 		{
-			&tu.Document{PlainText: stringp("hello")},
-			`{"pdf":null,"plainText":"hello"}`,
+			v: &tu.Document{PlainText: stringp("hello")},
+			j: `{"plainText":"hello"}`,
 		},
-		{&tu.Document{PlainText: stringp("")}, `{"pdf":null,"plainText":""}`},
+		{v: &tu.Document{PlainText: stringp("")}, j: `{"plainText":""}`},
 		{
-			&tu.ArbitraryValue{BoolValue: boolp(true)},
-			`{"boolValue":true,"listValue":null,"mapValue":null}`,
-		},
-		{
-			&tu.ArbitraryValue{BoolValue: boolp(false)},
-			`{"boolValue":false,"listValue":null,"mapValue":null}`,
+			v: &tu.ArbitraryValue{BoolValue: boolp(true)},
+			j: `{"boolValue":true}`,
 		},
 		{
-			&tu.ArbitraryValue{Int64Value: int64p(42)},
-			`{"int64Value":42,"listValue":null,"mapValue":null}`,
+			v: &tu.ArbitraryValue{BoolValue: boolp(false)},
+			j: `{"boolValue":false}`,
 		},
 		{
-			&tu.ArbitraryValue{Int64Value: int64p(0)},
-			`{"int64Value":0,"listValue":null,"mapValue":null}`,
+			v: &tu.ArbitraryValue{Int64Value: int64p(42)},
+			j: `{"int64Value":42}`,
 		},
 		{
-			&tu.ArbitraryValue{StringValue: stringp("foo")},
-			`{"stringValue":"foo","listValue":null,"mapValue":null}`,
+			v: &tu.ArbitraryValue{Int64Value: int64p(0)},
+			j: `{"int64Value":0}`,
 		},
 		{
-			&tu.ArbitraryValue{StringValue: stringp("")},
-			`{"stringValue":"","listValue":null,"mapValue":null}`,
+			v: &tu.ArbitraryValue{StringValue: stringp("foo")},
+			j: `{"stringValue":"foo"}`,
 		},
 		{
-			&tu.ArbitraryValue{ListValue: []*tu.ArbitraryValue{
+			v: &tu.ArbitraryValue{StringValue: stringp("")},
+			j: `{"stringValue":""}`,
+		},
+		{
+			v: &tu.ArbitraryValue{ListValue: nil},
+			j: `{}`,
+		},
+		{
+			v: &tu.ArbitraryValue{ListValue: []*tu.ArbitraryValue{}},
+			w: &tu.ArbitraryValue{ListValue: nil},
+			j: `{}`,
+		},
+		{
+			v: &tu.ArbitraryValue{ListValue: []*tu.ArbitraryValue{
 				{BoolValue: boolp(true)},
 				{Int64Value: int64p(42)},
 				{StringValue: stringp("foo")},
 			}},
-			`{"listValue":[` +
-				`{"boolValue":true,"listValue":null,"mapValue":null},` +
-				`{"int64Value":42,"listValue":null,"mapValue":null},` +
-				`{"stringValue":"foo","listValue":null,"mapValue":null}` +
-				`],"mapValue":null}`,
+			j: `{"listValue":[` +
+				`{"boolValue":true},` +
+				`{"int64Value":42},` +
+				`{"stringValue":"foo"}` +
+				`]}`,
 		},
 		{
-			&tu.ArbitraryValue{MapValue: map[string]*tu.ArbitraryValue{
+			v: &tu.ArbitraryValue{MapValue: nil},
+			j: `{}`,
+		},
+		{
+			v: &tu.ArbitraryValue{MapValue: map[string]*tu.ArbitraryValue{}},
+			w: &tu.ArbitraryValue{MapValue: nil},
+			j: `{}`,
+		},
+		{
+			v: &tu.ArbitraryValue{MapValue: map[string]*tu.ArbitraryValue{
 				"bool":   {BoolValue: boolp(true)},
 				"int64":  {Int64Value: int64p(42)},
 				"string": {StringValue: stringp("foo")},
 			}},
-			`{"listValue":null,"mapValue":{` +
-				`"bool":{"boolValue":true,"listValue":null,"mapValue":null},` +
-				`"int64":{"int64Value":42,"listValue":null,"mapValue":null},` +
-				`"string":{"stringValue":"foo","listValue":null,"mapValue":null}` +
+			j: `{"mapValue":{` +
+				`"bool":{"boolValue":true},` +
+				`"int64":{"int64Value":42},` +
+				`"string":{"stringValue":"foo"}` +
 				`}}`,
 		},
 		{
-			&ts.List{Value: 0, Tail: &ts.List{Value: 1}},
-			`{"value":0,"tail":{"value":1}}`,
+			v: &ts.List{Value: 0, Tail: &ts.List{Value: 1}},
+			j: `{"value":0,"tail":{"value":1}}`,
 		},
 		{
-			&ts.Rename{Default: "foo", CamelCase: "bar"},
-			`{"default":"foo","snake_case":"bar"}`,
+			v: &ts.Rename{Default: "foo", CamelCase: "bar"},
+			j: `{"default":"foo","snake_case":"bar"}`,
 		},
 		{
-			&ts.Omit{Serialized: "foo", Hidden: ""},
-			`{"serialized":"foo"}`,
+			v: &ts.Omit{Serialized: "foo", Hidden: ""},
+			j: `{"serialized":"foo"}`,
 		},
 	}
 
@@ -993,10 +1012,13 @@ func TestStructJSON(t *testing.T) {
 			assert.Equal(t, tt.j, string(encoded))
 		}
 
-		v := reflect.New(reflect.TypeOf(tt.v).Elem()).Interface()
+		u := tt.v
+		if tt.w != nil {
+			u = tt.w
+		}
+		v := reflect.New(reflect.TypeOf(u).Elem()).Interface()
 		if assert.NoError(t, json.Unmarshal([]byte(tt.j), v), "failed to decode %q", tt.j) {
-			assert.Equal(t, tt.v, v)
-			assert.Equal(t, tt.v, v)
+			assert.Equal(t, u, v)
 		}
 	}
 }

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -878,131 +878,111 @@ func TestStructWithDefaults(t *testing.T) {
 
 func TestStructJSON(t *testing.T) {
 	tests := []struct {
-		v, w interface{}
-		j    string
+		v interface{}
+		j string
 	}{
-		{v: &ts.Point{X: 0, Y: 0}, j: `{"x":0,"y":0}`},
-		{v: &ts.Point{X: 1, Y: 2}, j: `{"x":1,"y":2}`},
+		{&ts.Point{X: 0, Y: 0}, `{"x":0,"y":0}`},
+		{&ts.Point{X: 1, Y: 2}, `{"x":1,"y":2}`},
 		{
-			v: &ts.Edge{
+			&ts.Edge{
 				StartPoint: &ts.Point{X: 1, Y: 2},
 				EndPoint:   &ts.Point{X: 3, Y: 4},
 			},
-			j: `{"startPoint":{"x":1,"y":2},"endPoint":{"x":3,"y":4}}`,
+			`{"startPoint":{"x":1,"y":2},"endPoint":{"x":3,"y":4}}`,
 		},
 		{
-			v: &ts.Edge{StartPoint: &ts.Point{X: 1, Y: 1}},
-			j: `{"startPoint":{"x":1,"y":1},"endPoint":null}`,
+			&ts.Edge{StartPoint: &ts.Point{X: 1, Y: 1}},
+			`{"startPoint":{"x":1,"y":1},"endPoint":null}`,
 		},
 		{
-			v: &ts.Edge{
+			&ts.Edge{
 				StartPoint: &ts.Point{X: 1, Y: 1},
 				EndPoint:   &ts.Point{X: 1, Y: 1},
 			},
-			j: `{"startPoint":{"x":1,"y":1},"endPoint":{"x":1,"y":1}}`,
+			`{"startPoint":{"x":1,"y":1},"endPoint":{"x":1,"y":1}}`,
 		},
-		{v: &ts.User{Name: ""}, j: `{"name":""}`},
-		{v: &ts.User{Name: "foo"}, j: `{"name":"foo"}`},
+		{&ts.User{Name: ""}, `{"name":""}`},
+		{&ts.User{Name: "foo"}, `{"name":"foo"}`},
 		{
-			v: &ts.User{
+			&ts.User{
 				Name:    "foo",
 				Contact: &ts.ContactInfo{EmailAddress: "bar@example.com"},
 			},
-			j: `{"name":"foo","contact":{"emailAddress":"bar@example.com"}}`,
+			`{"name":"foo","contact":{"emailAddress":"bar@example.com"}}`,
 		},
 		{
-			v: &ts.User{
+			&ts.User{
 				Name:    "foo",
 				Contact: &ts.ContactInfo{EmailAddress: ""},
 			},
-			j: `{"name":"foo","contact":{"emailAddress":""}}`,
+			`{"name":"foo","contact":{"emailAddress":""}}`,
 		},
-		{v: &tu.EmptyUnion{}, j: "{}"},
-		{v: &tu.Document{Pdf: td.PDF("hello")}, j: `{"pdf":"aGVsbG8="}`},
-		{v: &tu.Document{Pdf: td.PDF{}}, w: &tu.Document{Pdf: nil}, j: `{}`},
-		{v: &tu.Document{Pdf: nil}, j: `{}`},
+		{&tu.EmptyUnion{}, "{}"},
+		{&tu.Document{Pdf: td.PDF("hello")}, `{"pdf":"aGVsbG8="}`},
 		{
-			v: &tu.Document{PlainText: stringp("hello")},
-			j: `{"plainText":"hello"}`,
+			&tu.Document{PlainText: stringp("hello")},
+			`{"plainText":"hello"}`,
 		},
-		{v: &tu.Document{PlainText: stringp("")}, j: `{"plainText":""}`},
+		{&tu.Document{PlainText: stringp("")}, `{"plainText":""}`},
 		{
-			v: &tu.ArbitraryValue{BoolValue: boolp(true)},
-			j: `{"boolValue":true}`,
+			&tu.ArbitraryValue{BoolValue: boolp(true)},
+			`{"boolValue":true}`,
 		},
 		{
-			v: &tu.ArbitraryValue{BoolValue: boolp(false)},
-			j: `{"boolValue":false}`,
+			&tu.ArbitraryValue{BoolValue: boolp(false)},
+			`{"boolValue":false}`,
 		},
 		{
-			v: &tu.ArbitraryValue{Int64Value: int64p(42)},
-			j: `{"int64Value":42}`,
+			&tu.ArbitraryValue{Int64Value: int64p(42)},
+			`{"int64Value":42}`,
 		},
 		{
-			v: &tu.ArbitraryValue{Int64Value: int64p(0)},
-			j: `{"int64Value":0}`,
+			&tu.ArbitraryValue{Int64Value: int64p(0)},
+			`{"int64Value":0}`,
 		},
 		{
-			v: &tu.ArbitraryValue{StringValue: stringp("foo")},
-			j: `{"stringValue":"foo"}`,
+			&tu.ArbitraryValue{StringValue: stringp("foo")},
+			`{"stringValue":"foo"}`,
 		},
 		{
-			v: &tu.ArbitraryValue{StringValue: stringp("")},
-			j: `{"stringValue":""}`,
+			&tu.ArbitraryValue{StringValue: stringp("")},
+			`{"stringValue":""}`,
 		},
 		{
-			v: &tu.ArbitraryValue{ListValue: nil},
-			j: `{}`,
-		},
-		{
-			v: &tu.ArbitraryValue{ListValue: []*tu.ArbitraryValue{}},
-			w: &tu.ArbitraryValue{ListValue: nil},
-			j: `{}`,
-		},
-		{
-			v: &tu.ArbitraryValue{ListValue: []*tu.ArbitraryValue{
+			&tu.ArbitraryValue{ListValue: []*tu.ArbitraryValue{
 				{BoolValue: boolp(true)},
 				{Int64Value: int64p(42)},
 				{StringValue: stringp("foo")},
 			}},
-			j: `{"listValue":[` +
+			`{"listValue":[` +
 				`{"boolValue":true},` +
 				`{"int64Value":42},` +
 				`{"stringValue":"foo"}` +
 				`]}`,
 		},
 		{
-			v: &tu.ArbitraryValue{MapValue: nil},
-			j: `{}`,
-		},
-		{
-			v: &tu.ArbitraryValue{MapValue: map[string]*tu.ArbitraryValue{}},
-			w: &tu.ArbitraryValue{MapValue: nil},
-			j: `{}`,
-		},
-		{
-			v: &tu.ArbitraryValue{MapValue: map[string]*tu.ArbitraryValue{
+			&tu.ArbitraryValue{MapValue: map[string]*tu.ArbitraryValue{
 				"bool":   {BoolValue: boolp(true)},
 				"int64":  {Int64Value: int64p(42)},
 				"string": {StringValue: stringp("foo")},
 			}},
-			j: `{"mapValue":{` +
+			`{"mapValue":{` +
 				`"bool":{"boolValue":true},` +
 				`"int64":{"int64Value":42},` +
 				`"string":{"stringValue":"foo"}` +
 				`}}`,
 		},
 		{
-			v: &ts.List{Value: 0, Tail: &ts.List{Value: 1}},
-			j: `{"value":0,"tail":{"value":1}}`,
+			&ts.List{Value: 0, Tail: &ts.List{Value: 1}},
+			`{"value":0,"tail":{"value":1}}`,
 		},
 		{
-			v: &ts.Rename{Default: "foo", CamelCase: "bar"},
-			j: `{"default":"foo","snake_case":"bar"}`,
+			&ts.Rename{Default: "foo", CamelCase: "bar"},
+			`{"default":"foo","snake_case":"bar"}`,
 		},
 		{
-			v: &ts.Omit{Serialized: "foo", Hidden: ""},
-			j: `{"serialized":"foo"}`,
+			&ts.Omit{Serialized: "foo", Hidden: ""},
+			`{"serialized":"foo"}`,
 		},
 	}
 
@@ -1012,15 +992,39 @@ func TestStructJSON(t *testing.T) {
 			assert.Equal(t, tt.j, string(encoded))
 		}
 
-		u := tt.v
-		if tt.w != nil {
-			u = tt.w
-		}
-		v := reflect.New(reflect.TypeOf(u).Elem()).Interface()
+		v := reflect.New(reflect.TypeOf(tt.v).Elem()).Interface()
 		if assert.NoError(t, json.Unmarshal([]byte(tt.j), v), "failed to decode %q", tt.j) {
-			assert.Equal(t, u, v)
+			assert.Equal(t, tt.v, v)
 		}
 	}
+}
+
+func TestOptionalEmptyListJSON(t *testing.T) {
+	give := tu.ArbitraryValue{ListValue: []*tu.ArbitraryValue{}}
+	want := tu.ArbitraryValue{ListValue: nil}
+	j := `{}`
+
+	encoded, err := json.Marshal(give)
+	require.NoError(t, err, "failed to encode to JSON")
+	assert.Equal(t, j, string(encoded))
+
+	var get tu.ArbitraryValue
+	require.NoError(t, json.Unmarshal(encoded, &get), "failed to decode JSON")
+	assert.Equal(t, want, get)
+}
+
+func TestOptionalEmptyMapJSON(t *testing.T) {
+	give := tu.ArbitraryValue{MapValue: map[string]*tu.ArbitraryValue{}}
+	want := tu.ArbitraryValue{MapValue: nil}
+	j := `{}`
+
+	encoded, err := json.Marshal(give)
+	require.NoError(t, err, "failed to encode to JSON")
+	assert.Equal(t, j, string(encoded))
+
+	var get tu.ArbitraryValue
+	require.NoError(t, json.Unmarshal(encoded, &get), "failed to decode JSON")
+	assert.Equal(t, want, get)
 }
 
 func TestJSONOmitBehaviour(t *testing.T) {

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -517,9 +517,9 @@ func (v *MyEnum) UnmarshalJSON(text []byte) error {
 }
 
 type PrimitiveContainers struct {
-	A []string            `json:"ListOrSetOrMap"`
-	B map[string]struct{} `json:"List_Or_SetOrMap"`
-	C map[string]string   `json:"ListOrSet_Or_Map"`
+	A []string            `json:"ListOrSetOrMap,omitempty"`
+	B map[string]struct{} `json:"List_Or_SetOrMap,omitempty"`
+	C map[string]string   `json:"ListOrSet_Or_Map,omitempty"`
 }
 
 type _List_String_ValueList []string

--- a/gen/testdata/containers/types.go
+++ b/gen/testdata/containers/types.go
@@ -16,24 +16,24 @@ import (
 )
 
 type ContainersOfContainers struct {
-	ListOfLists   [][]int32             `json:"listOfLists"`
-	ListOfSets    []map[int32]struct{}  `json:"listOfSets"`
-	ListOfMaps    []map[int32]int32     `json:"listOfMaps"`
-	SetOfSets     []map[string]struct{} `json:"setOfSets"`
-	SetOfLists    [][]string            `json:"setOfLists"`
-	SetOfMaps     []map[string]string   `json:"setOfMaps"`
+	ListOfLists   [][]int32             `json:"listOfLists,omitempty"`
+	ListOfSets    []map[int32]struct{}  `json:"listOfSets,omitempty"`
+	ListOfMaps    []map[int32]int32     `json:"listOfMaps,omitempty"`
+	SetOfSets     []map[string]struct{} `json:"setOfSets,omitempty"`
+	SetOfLists    [][]string            `json:"setOfLists,omitempty"`
+	SetOfMaps     []map[string]string   `json:"setOfMaps,omitempty"`
 	MapOfMapToInt []struct {
 		Key   map[string]int32
 		Value int64
-	} `json:"mapOfMapToInt"`
+	} `json:"mapOfMapToInt,omitempty"`
 	MapOfListToSet []struct {
 		Key   []int32
 		Value map[int64]struct{}
-	} `json:"mapOfListToSet"`
+	} `json:"mapOfListToSet,omitempty"`
 	MapOfSetToListOfDouble []struct {
 		Key   map[int32]struct{}
 		Value []float64
-	} `json:"mapOfSetToListOfDouble"`
+	} `json:"mapOfSetToListOfDouble,omitempty"`
 }
 
 type _List_I32_ValueList []int32
@@ -1653,9 +1653,9 @@ func (v *ContainersOfContainers) Equals(rhs *ContainersOfContainers) bool {
 }
 
 type EnumContainers struct {
-	ListOfEnums []enums.EnumDefault                     `json:"listOfEnums"`
-	SetOfEnums  map[enums.EnumWithValues]struct{}       `json:"setOfEnums"`
-	MapOfEnums  map[enums.EnumWithDuplicateValues]int32 `json:"mapOfEnums"`
+	ListOfEnums []enums.EnumDefault                     `json:"listOfEnums,omitempty"`
+	SetOfEnums  map[enums.EnumWithValues]struct{}       `json:"setOfEnums,omitempty"`
+	MapOfEnums  map[enums.EnumWithDuplicateValues]int32 `json:"mapOfEnums,omitempty"`
 }
 
 type _List_EnumDefault_ValueList []enums.EnumDefault
@@ -2561,8 +2561,8 @@ type MapOfBinaryAndString struct {
 	BinaryToString []struct {
 		Key   []byte
 		Value string
-	} `json:"binaryToString"`
-	StringToBinary map[string][]byte `json:"stringToBinary"`
+	} `json:"binaryToString,omitempty"`
+	StringToBinary map[string][]byte `json:"stringToBinary,omitempty"`
 }
 
 type _Map_Binary_String_MapItemList []struct {
@@ -2885,12 +2885,12 @@ func (v *MapOfBinaryAndString) Equals(rhs *MapOfBinaryAndString) bool {
 }
 
 type PrimitiveContainers struct {
-	ListOfBinary      [][]byte            `json:"listOfBinary"`
-	ListOfInts        []int64             `json:"listOfInts"`
-	SetOfStrings      map[string]struct{} `json:"setOfStrings"`
-	SetOfBytes        map[int8]struct{}   `json:"setOfBytes"`
-	MapOfIntToString  map[int32]string    `json:"mapOfIntToString"`
-	MapOfStringToBool map[string]bool     `json:"mapOfStringToBool"`
+	ListOfBinary      [][]byte            `json:"listOfBinary,omitempty"`
+	ListOfInts        []int64             `json:"listOfInts,omitempty"`
+	SetOfStrings      map[string]struct{} `json:"setOfStrings,omitempty"`
+	SetOfBytes        map[int8]struct{}   `json:"setOfBytes,omitempty"`
+	MapOfIntToString  map[int32]string    `json:"mapOfIntToString,omitempty"`
+	MapOfStringToBool map[string]bool     `json:"mapOfStringToBool,omitempty"`
 }
 
 type _List_Binary_ValueList [][]byte

--- a/gen/testdata/services/keyvalue_getmanyvalues.go
+++ b/gen/testdata/services/keyvalue_getmanyvalues.go
@@ -16,7 +16,7 @@ import (
 //
 // The arguments for getManyValues are sent and received over the wire as this struct.
 type KeyValue_GetManyValues_Args struct {
-	Range []Key `json:"range"`
+	Range []Key `json:"range,omitempty"`
 }
 
 type _List_Key_ValueList []Key
@@ -295,7 +295,7 @@ func init() {
 // Success is set only if the function did not throw an exception.
 type KeyValue_GetManyValues_Result struct {
 	// Value returned by getManyValues after a successful execution.
-	Success      []*unions.ArbitraryValue          `json:"success"`
+	Success      []*unions.ArbitraryValue          `json:"success,omitempty"`
 	DoesNotExist *exceptions.DoesNotExistException `json:"doesNotExist,omitempty"`
 }
 

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -124,8 +124,8 @@ type DefaultsStruct struct {
 	OptionalPrimitive *int32             `json:"optionalPrimitive,omitempty"`
 	RequiredEnum      *enums.EnumDefault `json:"requiredEnum,omitempty"`
 	OptionalEnum      *enums.EnumDefault `json:"optionalEnum,omitempty"`
-	RequiredList      []string           `json:"requiredList"`
-	OptionalList      []float64          `json:"optionalList"`
+	RequiredList      []string           `json:"requiredList,omitempty"`
+	OptionalList      []float64          `json:"optionalList,omitempty"`
 	RequiredStruct    *Frame             `json:"requiredStruct,omitempty"`
 	OptionalStruct    *Edge              `json:"optionalStruct,omitempty"`
 }
@@ -1953,7 +1953,7 @@ type PrimitiveOptionalStruct struct {
 	Int64Field  *int64   `json:"int64Field,omitempty"`
 	DoubleField *float64 `json:"doubleField,omitempty"`
 	StringField *string  `json:"stringField,omitempty"`
-	BinaryField []byte   `json:"binaryField"`
+	BinaryField []byte   `json:"binaryField,omitempty"`
 }
 
 // ToWire translates a PrimitiveOptionalStruct struct into a Thrift-level intermediate

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -1088,7 +1088,7 @@ func (lhs Timestamp) Equals(rhs Timestamp) bool {
 type Transition struct {
 	FromState State      `json:"fromState,required"`
 	ToState   State      `json:"toState,required"`
-	Events    EventGroup `json:"events"`
+	Events    EventGroup `json:"events,omitempty"`
 }
 
 // ToWire translates a Transition struct into a Thrift-level intermediate

--- a/gen/testdata/unions/types.go
+++ b/gen/testdata/unions/types.go
@@ -23,8 +23,8 @@ type ArbitraryValue struct {
 	BoolValue   *bool                      `json:"boolValue,omitempty"`
 	Int64Value  *int64                     `json:"int64Value,omitempty"`
 	StringValue *string                    `json:"stringValue,omitempty"`
-	ListValue   []*ArbitraryValue          `json:"listValue"`
-	MapValue    map[string]*ArbitraryValue `json:"mapValue"`
+	ListValue   []*ArbitraryValue          `json:"listValue,omitempty"`
+	MapValue    map[string]*ArbitraryValue `json:"mapValue,omitempty"`
 }
 
 type _List_ArbitraryValue_ValueList []*ArbitraryValue
@@ -461,7 +461,7 @@ func (v *ArbitraryValue) GetStringValue() (o string) {
 }
 
 type Document struct {
-	Pdf       typedefs.PDF `json:"pdf"`
+	Pdf       typedefs.PDF `json:"pdf,omitempty"`
 	PlainText *string      `json:"plainText,omitempty"`
 }
 

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -330,7 +330,7 @@ type Function struct {
 	// List of exceptions raised by the function.
 	//
 	// This list is in the order specified by the user in the Thrift file.
-	Exceptions []*Argument `json:"exceptions"`
+	Exceptions []*Argument `json:"exceptions,omitempty"`
 	// Whether this function is oneway or not. This should be assumed to be
 	// false unless explicitly stated otherwise. If this is true, the
 	// returnType and exceptions will be null or empty.
@@ -1089,7 +1089,7 @@ type GenerateServiceResponse struct {
 	// absolute location of the directory.
 	//
 	// The paths MUST NOT contain the string ".." or the request will fail.
-	Files map[string][]byte `json:"files"`
+	Files map[string][]byte `json:"files,omitempty"`
 }
 
 type _Map_String_Binary_MapItemList map[string][]byte

--- a/wire/evaluate.go
+++ b/wire/evaluate.go
@@ -24,13 +24,13 @@ import "fmt"
 
 // EvaluateValue ensures that the given Value is fully evaluated. Lazy lists
 // are spinned and any errors raised by them are returned.
-func EvaluateValue(v Value) error {
+func EvaluateValue(v Value) (err error) {
 	switch v.Type() {
 	case TBool, TI8, TDouble, TI16, TI32, TI64, TBinary:
 		return nil
 	case TStruct:
 		for _, f := range v.GetStruct().Fields {
-			if err := EvaluateValue(f.Value); err != nil {
+			if err = EvaluateValue(f.Value); err != nil {
 				return err
 			}
 		}
@@ -39,13 +39,13 @@ func EvaluateValue(v Value) error {
 		m := v.GetMap()
 		defer m.Close()
 		return m.ForEach(func(item MapItem) error {
-			if err := EvaluateValue(item.Key); err != nil {
+			if err = EvaluateValue(item.Key); err != nil {
 				return err
 			}
-			if err := EvaluateValue(item.Value); err != nil {
+			if err = EvaluateValue(item.Value); err != nil {
 				return err
 			}
-			return nil
+			return err
 		})
 	case TSet:
 		s := v.GetSet()

--- a/wire/evaluate.go
+++ b/wire/evaluate.go
@@ -24,13 +24,13 @@ import "fmt"
 
 // EvaluateValue ensures that the given Value is fully evaluated. Lazy lists
 // are spinned and any errors raised by them are returned.
-func EvaluateValue(v Value) (err error) {
+func EvaluateValue(v Value) error {
 	switch v.Type() {
 	case TBool, TI8, TDouble, TI16, TI32, TI64, TBinary:
 		return nil
 	case TStruct:
 		for _, f := range v.GetStruct().Fields {
-			if err = EvaluateValue(f.Value); err != nil {
+			if err := EvaluateValue(f.Value); err != nil {
 				return err
 			}
 		}
@@ -39,13 +39,10 @@ func EvaluateValue(v Value) (err error) {
 		m := v.GetMap()
 		defer m.Close()
 		return m.ForEach(func(item MapItem) error {
-			if err = EvaluateValue(item.Key); err != nil {
+			if err := EvaluateValue(item.Key); err != nil {
 				return err
 			}
-			if err = EvaluateValue(item.Value); err != nil {
-				return err
-			}
-			return err
+			return EvaluateValue(item.Value)
 		})
 	case TSet:
 		s := v.GetSet()


### PR DESCRIPTION
This changes code generation to enable the `omitempty` JSON option for
optional collections to reduce `null` noise in the JSON output.

So,

    struct OptionalListField {
        1: optional list<Item> items
        2: optional map<Key, Value> dictionary
    }

Becomes,

    type OptionalListField struct {
      Items       []Item         `json:"items,omitempty"`
      Dictionary  map[Key]Value  `json:"dictionary,omitempty"`
    }

Encoding `OptionalListField{}` will now produce, `{}` instead of,

    {"items": null, "dictionary": null}

Resolves #330 