### PR TITLE
travis: Lint on Go 1.9 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ language: go
 
 go_import_path: go.uber.org/thriftrw
 
-go:
-    - 1.7
-    - 1.8
-    - 1.9
-    - tip
+matrix:
+  include:
+    - go: 1.7
+    - go: 1.8
+    - go: 1.9
+      env: LINT=1
 
 env:
     global:
@@ -18,7 +19,7 @@ install:
     - make install_ci
 
 script:
-    - make lint_ci
+    - test "$LINT" -eq 1 && make lint_ci || echo "Skipping lint"
     - make test_ci
     - travis_retry goveralls -coverprofile=cover.out -service=travis-ci
     - rm -rf vendor/*


### PR DESCRIPTION
Parts of the code fail to lint with Go 1.8 but are fine with 1.9.
Instead of trying to make the code friendly with the linters from all
versions, we will comply with only the latest version.