### PR TITLE
gen: Expose Ptr() method on enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.9.0 (unreleased)
 -------------------
 
--   No changes yet.
+-   Generates enum types now include a `Ptr()` method.
 
 
 v1.8.0 (2017-09-29)

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -107,8 +107,8 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 			}
 		}
 
-		// ToPtr translates <$enumName> into its pointer representation.
-		func (<$v> <$enumName>) ToPtr() *<$enumName> {
+		// Ptr returns a pointer to this enum value.
+		func (<$v> <$enumName>) Ptr() *<$enumName> {
 			return &<$v>
 		}
 

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -107,6 +107,11 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 			}
 		}
 
+		// ToPtr translates <$enumName> into its pointer representation.
+		func (<$v> <$enumName>) ToPtr() *<$enumName> {
+			return &<$v>
+		}
+
 		// ToWire translates <$enumName> into a Thrift-level intermediate
 		// representation. This intermediate representation may be serialized
 		// into bytes using a ThriftRW protocol implementation.

--- a/gen/enum_test.go
+++ b/gen/enum_test.go
@@ -324,6 +324,11 @@ func TestUnmarshalTextReturnsValue(t *testing.T) {
 	assert.Equal(t, te.EnumDefaultFoo, v)
 }
 
+func TestEnumValueCanBecomePointer(t *testing.T) {
+	v := te.EnumDefaultFoo
+	assert.Equal(t, &v, te.EnumDefaultFoo.ToPtr())
+}
+
 func TestUnmarshalTextReturnsErrorOnInvalidValue(t *testing.T) {
 	var v te.EnumDefault
 	err := v.UnmarshalText([]byte("blah"))

--- a/gen/enum_test.go
+++ b/gen/enum_test.go
@@ -326,7 +326,7 @@ func TestUnmarshalTextReturnsValue(t *testing.T) {
 
 func TestEnumValueCanBecomePointer(t *testing.T) {
 	v := te.EnumDefaultFoo
-	assert.Equal(t, &v, te.EnumDefaultFoo.ToPtr())
+	assert.Equal(t, &v, te.EnumDefaultFoo.Ptr())
 }
 
 func TestUnmarshalTextReturnsErrorOnInvalidValue(t *testing.T) {

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -407,8 +407,8 @@ func (v *MyEnum) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates MyEnum into its pointer representation.
-func (v MyEnum) ToPtr() *MyEnum {
+// Ptr returns a pointer to this enum value.
+func (v MyEnum) Ptr() *MyEnum {
 	return &v
 }
 
@@ -1372,8 +1372,8 @@ func (v *MyEnum2) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates MyEnum2 into its pointer representation.
-func (v MyEnum2) ToPtr() *MyEnum2 {
+// Ptr returns a pointer to this enum value.
+func (v MyEnum2) Ptr() *MyEnum2 {
 	return &v
 }
 

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -407,6 +407,11 @@ func (v *MyEnum) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToPtr translates MyEnum into its pointer representation.
+func (v MyEnum) ToPtr() *MyEnum {
+	return &v
+}
+
 // ToWire translates MyEnum into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1365,6 +1370,11 @@ func (v *MyEnum2) UnmarshalText(value []byte) error {
 	default:
 		return fmt.Errorf("unknown enum value %q for %q", value, "MyEnum2")
 	}
+}
+
+// ToPtr translates MyEnum2 into its pointer representation.
+func (v MyEnum2) ToPtr() *MyEnum2 {
+	return &v
 }
 
 // ToWire translates MyEnum2 into a Thrift-level intermediate

--- a/gen/testdata/enum_conflict/types.go
+++ b/gen/testdata/enum_conflict/types.go
@@ -47,8 +47,8 @@ func (v *RecordType) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates RecordType into its pointer representation.
-func (v RecordType) ToPtr() *RecordType {
+// Ptr returns a pointer to this enum value.
+func (v RecordType) Ptr() *RecordType {
 	return &v
 }
 

--- a/gen/testdata/enum_conflict/types.go
+++ b/gen/testdata/enum_conflict/types.go
@@ -47,6 +47,11 @@ func (v *RecordType) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToPtr translates RecordType into its pointer representation.
+func (v RecordType) ToPtr() *RecordType {
+	return &v
+}
+
 // ToWire translates RecordType into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -24,8 +24,8 @@ func (v *EmptyEnum) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates EmptyEnum into its pointer representation.
-func (v EmptyEnum) ToPtr() *EmptyEnum {
+// Ptr returns a pointer to this enum value.
+func (v EmptyEnum) Ptr() *EmptyEnum {
 	return &v
 }
 
@@ -152,8 +152,8 @@ func (v *EnumDefault) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates EnumDefault into its pointer representation.
-func (v EnumDefault) ToPtr() *EnumDefault {
+// Ptr returns a pointer to this enum value.
+func (v EnumDefault) Ptr() *EnumDefault {
 	return &v
 }
 
@@ -326,8 +326,8 @@ func (v *EnumWithDuplicateName) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates EnumWithDuplicateName into its pointer representation.
-func (v EnumWithDuplicateName) ToPtr() *EnumWithDuplicateName {
+// Ptr returns a pointer to this enum value.
+func (v EnumWithDuplicateName) Ptr() *EnumWithDuplicateName {
 	return &v
 }
 
@@ -494,8 +494,8 @@ func (v *EnumWithDuplicateValues) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates EnumWithDuplicateValues into its pointer representation.
-func (v EnumWithDuplicateValues) ToPtr() *EnumWithDuplicateValues {
+// Ptr returns a pointer to this enum value.
+func (v EnumWithDuplicateValues) Ptr() *EnumWithDuplicateValues {
 	return &v
 }
 
@@ -634,8 +634,8 @@ func (v *EnumWithValues) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates EnumWithValues into its pointer representation.
-func (v EnumWithValues) ToPtr() *EnumWithValues {
+// Ptr returns a pointer to this enum value.
+func (v EnumWithValues) Ptr() *EnumWithValues {
 	return &v
 }
 
@@ -786,8 +786,8 @@ func (v *RecordType) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates RecordType into its pointer representation.
-func (v RecordType) ToPtr() *RecordType {
+// Ptr returns a pointer to this enum value.
+func (v RecordType) Ptr() *RecordType {
 	return &v
 }
 
@@ -925,8 +925,8 @@ func (v *RecordTypeValues) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates RecordTypeValues into its pointer representation.
-func (v RecordTypeValues) ToPtr() *RecordTypeValues {
+// Ptr returns a pointer to this enum value.
+func (v RecordTypeValues) Ptr() *RecordTypeValues {
 	return &v
 }
 
@@ -1197,8 +1197,8 @@ func (v *LowerCaseEnum) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates LowerCaseEnum into its pointer representation.
-func (v LowerCaseEnum) ToPtr() *LowerCaseEnum {
+// Ptr returns a pointer to this enum value.
+func (v LowerCaseEnum) Ptr() *LowerCaseEnum {
 	return &v
 }
 

--- a/gen/testdata/enums/types.go
+++ b/gen/testdata/enums/types.go
@@ -24,6 +24,11 @@ func (v *EmptyEnum) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToPtr translates EmptyEnum into its pointer representation.
+func (v EmptyEnum) ToPtr() *EmptyEnum {
+	return &v
+}
+
 // ToWire translates EmptyEnum into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -145,6 +150,11 @@ func (v *EnumDefault) UnmarshalText(value []byte) error {
 	default:
 		return fmt.Errorf("unknown enum value %q for %q", value, "EnumDefault")
 	}
+}
+
+// ToPtr translates EnumDefault into its pointer representation.
+func (v EnumDefault) ToPtr() *EnumDefault {
+	return &v
 }
 
 // ToWire translates EnumDefault into a Thrift-level intermediate
@@ -316,6 +326,11 @@ func (v *EnumWithDuplicateName) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToPtr translates EnumWithDuplicateName into its pointer representation.
+func (v EnumWithDuplicateName) ToPtr() *EnumWithDuplicateName {
+	return &v
+}
+
 // ToWire translates EnumWithDuplicateName into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -479,6 +494,11 @@ func (v *EnumWithDuplicateValues) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToPtr translates EnumWithDuplicateValues into its pointer representation.
+func (v EnumWithDuplicateValues) ToPtr() *EnumWithDuplicateValues {
+	return &v
+}
+
 // ToWire translates EnumWithDuplicateValues into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -612,6 +632,11 @@ func (v *EnumWithValues) UnmarshalText(value []byte) error {
 	default:
 		return fmt.Errorf("unknown enum value %q for %q", value, "EnumWithValues")
 	}
+}
+
+// ToPtr translates EnumWithValues into its pointer representation.
+func (v EnumWithValues) ToPtr() *EnumWithValues {
+	return &v
 }
 
 // ToWire translates EnumWithValues into a Thrift-level intermediate
@@ -761,6 +786,11 @@ func (v *RecordType) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToPtr translates RecordType into its pointer representation.
+func (v RecordType) ToPtr() *RecordType {
+	return &v
+}
+
 // ToWire translates RecordType into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -893,6 +923,11 @@ func (v *RecordTypeValues) UnmarshalText(value []byte) error {
 	default:
 		return fmt.Errorf("unknown enum value %q for %q", value, "RecordTypeValues")
 	}
+}
+
+// ToPtr translates RecordTypeValues into its pointer representation.
+func (v RecordTypeValues) ToPtr() *RecordTypeValues {
+	return &v
 }
 
 // ToWire translates RecordTypeValues into a Thrift-level intermediate
@@ -1160,6 +1195,11 @@ func (v *LowerCaseEnum) UnmarshalText(value []byte) error {
 	default:
 		return fmt.Errorf("unknown enum value %q for %q", value, "LowerCaseEnum")
 	}
+}
+
+// ToPtr translates LowerCaseEnum into its pointer representation.
+func (v LowerCaseEnum) ToPtr() *LowerCaseEnum {
+	return &v
 }
 
 // ToWire translates LowerCaseEnum into a Thrift-level intermediate

--- a/internal/envelope/exception/types.go
+++ b/internal/envelope/exception/types.go
@@ -111,8 +111,8 @@ func (v *ExceptionType) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates ExceptionType into its pointer representation.
-func (v ExceptionType) ToPtr() *ExceptionType {
+// Ptr returns a pointer to this enum value.
+func (v ExceptionType) Ptr() *ExceptionType {
 	return &v
 }
 

--- a/internal/envelope/exception/types.go
+++ b/internal/envelope/exception/types.go
@@ -111,6 +111,11 @@ func (v *ExceptionType) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToPtr translates ExceptionType into its pointer representation.
+func (v ExceptionType) ToPtr() *ExceptionType {
+	return &v
+}
+
 // ToWire translates ExceptionType into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -221,6 +221,11 @@ func (v *Feature) UnmarshalText(value []byte) error {
 	}
 }
 
+// ToPtr translates Feature into its pointer representation.
+func (v Feature) ToPtr() *Feature {
+	return &v
+}
+
 // ToWire translates Feature into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -2216,6 +2221,11 @@ func (v *SimpleType) UnmarshalText(value []byte) error {
 	default:
 		return fmt.Errorf("unknown enum value %q for %q", value, "SimpleType")
 	}
+}
+
+// ToPtr translates SimpleType into its pointer representation.
+func (v SimpleType) ToPtr() *SimpleType {
+	return &v
 }
 
 // ToWire translates SimpleType into a Thrift-level intermediate

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -221,8 +221,8 @@ func (v *Feature) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates Feature into its pointer representation.
-func (v Feature) ToPtr() *Feature {
+// Ptr returns a pointer to this enum value.
+func (v Feature) Ptr() *Feature {
 	return &v
 }
 
@@ -2223,8 +2223,8 @@ func (v *SimpleType) UnmarshalText(value []byte) error {
 	}
 }
 
-// ToPtr translates SimpleType into its pointer representation.
-func (v SimpleType) ToPtr() *SimpleType {
+// Ptr returns a pointer to this enum value.
+func (v SimpleType) Ptr() *SimpleType {
 	return &v
 }
 


### PR DESCRIPTION
This adds a `Ptr()` method to generated enum types which returns a pointer to
the enum value.

For example, given,

```
// action_type.thrift
enum ActionType {
    ENUM_ONE  = 1
    ENUM_TWO = 2 
    ENUM_THREE = 3
}
```

```
// main.go
import pkg "path.to.generated.types"

func DoSomething(aPtr *ActionType) {
    ...
}

func main() {
    DoSomething(&pkg.ActionTypeEnumOne)
}
```

The above will fail because `pkg.ActionTypeEnumOne` is a `const`. Go does not
allow taking pointers to `const` values.

With this PR, we can do,

```
// main.go
import pkg "path.to.generated.code"

func DoSomething(aPtr *ActionType) {
    ...
}

func main() {
    DoSomething(pkg.ActionTypeEnumOne.Ptr())
}
```

Resolves #335