### PR TITLE
Add accessors for all struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add accessors for all struct fields.
+- Structs now include getter functions for all fields.
 
 ## [1.11.0] - 2018-03-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Structs now include getter functions for all fields.
+- Structs now include getter functions for all fields. This
+  improves Apache Thrift compatibility.
 
 ## [1.11.0] - 2018-03-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- Add accessors for all struct fields.
 
 ## [1.11.0] - 2018-03-27
 ### Added

--- a/gen/field.go
+++ b/gen/field.go
@@ -474,7 +474,7 @@ func (f fieldGroupGenerator) Accessors(g Generator) error {
 			<reserveFieldOrMethod $fname>
 			<reserveFieldOrMethod (printf "Get%v" $fname)>
 			// Get<$fname> returns the value of <$fname> if it is set or its
-			// zero value if it is unset.
+			// <if .Default>default<else>zero<end> value if it is unset.
 			func (<$v> *<$name>) Get<$fname>() (<$o> <typeReference .Type>) {
 				<- if .Required ->
 				  return <$v>.<$fname>

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1674,6 +1674,70 @@ func TestStructAccessors(t *testing.T) {
 				assert.Equal(t, te.EnumDefaultBaz, s.GetOptionalEnum())
 			})
 		})
+
+		t.Run("RequiredList", func(t *testing.T) {
+			t.Run("set", func(t *testing.T) {
+				lst := []string{"foo", "bar", "baz"}
+				s := ts.DefaultsStruct{RequiredList: lst}
+				assert.Equal(t, lst, s.GetRequiredList())
+			})
+			t.Run("unset", func(t *testing.T) {
+				var s ts.DefaultsStruct
+				assert.Equal(t, []string{"hello", "world"}, s.GetRequiredList())
+			})
+		})
+		t.Run("OptionalList", func(t *testing.T) {
+			t.Run("set", func(t *testing.T) {
+				lst := []float64{0, 1, 2}
+				s := ts.DefaultsStruct{OptionalList: lst}
+				assert.Equal(t, lst, s.GetOptionalList())
+			})
+			t.Run("unset", func(t *testing.T) {
+				var s ts.DefaultsStruct
+				assert.Equal(t, []float64{1, 2, 3}, s.GetOptionalList())
+			})
+		})
+		t.Run("RequiredStruct", func(t *testing.T) {
+			t.Run("set", func(t *testing.T) {
+				f := &ts.Frame{
+					TopLeft: &ts.Point{X: 1, Y: 1},
+					Size:    &ts.Size{Width: 1, Height: 1},
+				}
+				s := ts.DefaultsStruct{RequiredStruct: f}
+				assert.Equal(t, f, s.GetRequiredStruct())
+			})
+			t.Run("unset", func(t *testing.T) {
+				var s ts.DefaultsStruct
+				assert.Equal(t,
+					&ts.Frame{
+						TopLeft: &ts.Point{X: 1, Y: 2},
+						Size:    &ts.Size{Width: 100, Height: 200},
+					},
+					s.GetRequiredStruct(),
+				)
+
+			})
+		})
+		t.Run("OptionalStruct", func(t *testing.T) {
+			t.Run("set", func(t *testing.T) {
+				e := &ts.Edge{
+					StartPoint: &ts.Point{X: 1.0, Y: 1.0},
+					EndPoint:   &ts.Point{X: 1.0, Y: 1.0},
+				}
+				s := ts.DefaultsStruct{OptionalStruct: e}
+				assert.Equal(t, e, s.GetOptionalStruct())
+			})
+			t.Run("unset", func(t *testing.T) {
+				var s ts.DefaultsStruct
+				assert.Equal(t,
+					&ts.Edge{
+						StartPoint: &ts.Point{X: 1.0, Y: 2.0},
+						EndPoint:   &ts.Point{X: 3.0, Y: 4.0},
+					},
+					s.GetOptionalStruct(),
+				)
+			})
+		})
 	})
 }
 

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -871,6 +871,36 @@ func (v *PrimitiveContainers) Equals(rhs *PrimitiveContainers) bool {
 	return true
 }
 
+// GetA returns the value of A if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainers) GetA() (o []string) {
+	if v.A != nil {
+		return v.A
+	}
+
+	return
+}
+
+// GetB returns the value of B if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainers) GetB() (o map[string]struct{}) {
+	if v.B != nil {
+		return v.B
+	}
+
+	return
+}
+
+// GetC returns the value of C if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainers) GetC() (o map[string]string) {
+	if v.C != nil {
+		return v.C
+	}
+
+	return
+}
+
 type StructCollision struct {
 	CollisionField  bool   `json:"collisionField,required"`
 	CollisionField2 string `json:"collision_field,required"`
@@ -1002,6 +1032,14 @@ func (v *StructCollision) Equals(rhs *StructCollision) bool {
 
 	return true
 }
+
+// GetCollisionField returns the value of CollisionField if it is set or its
+// zero value if it is unset.
+func (v *StructCollision) GetCollisionField() (o bool) { return v.CollisionField }
+
+// GetCollisionField2 returns the value of CollisionField2 if it is set or its
+// zero value if it is unset.
+func (v *StructCollision) GetCollisionField2() (o string) { return v.CollisionField2 }
 
 type UnionCollision struct {
 	CollisionField  *bool   `json:"collisionField,omitempty"`
@@ -1301,6 +1339,19 @@ func (v *WithDefault) Equals(rhs *WithDefault) bool {
 	}
 
 	return true
+}
+
+// GetPouet returns the value of Pouet if it is set or its
+// zero value if it is unset.
+func (v *WithDefault) GetPouet() (o *StructCollision2) {
+	if v.Pouet != nil {
+		return v.Pouet
+	}
+	o = &StructCollision2{
+		CollisionField:  false,
+		CollisionField2: "false indeed",
+	}
+	return
 }
 
 type LittlePotatoe2 float64
@@ -1609,6 +1660,14 @@ func (v *StructCollision2) Equals(rhs *StructCollision2) bool {
 
 	return true
 }
+
+// GetCollisionField returns the value of CollisionField if it is set or its
+// zero value if it is unset.
+func (v *StructCollision2) GetCollisionField() (o bool) { return v.CollisionField }
+
+// GetCollisionField2 returns the value of CollisionField2 if it is set or its
+// zero value if it is unset.
+func (v *StructCollision2) GetCollisionField2() (o string) { return v.CollisionField2 }
 
 type UnionCollision2 struct {
 	CollisionField  *bool   `json:"collisionField,omitempty"`

--- a/gen/testdata/collision/types.go
+++ b/gen/testdata/collision/types.go
@@ -1342,7 +1342,7 @@ func (v *WithDefault) Equals(rhs *WithDefault) bool {
 }
 
 // GetPouet returns the value of Pouet if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *WithDefault) GetPouet() (o *StructCollision2) {
 	if v.Pouet != nil {
 		return v.Pouet

--- a/gen/testdata/containers/types.go
+++ b/gen/testdata/containers/types.go
@@ -1652,6 +1652,105 @@ func (v *ContainersOfContainers) Equals(rhs *ContainersOfContainers) bool {
 	return true
 }
 
+// GetListOfLists returns the value of ListOfLists if it is set or its
+// zero value if it is unset.
+func (v *ContainersOfContainers) GetListOfLists() (o [][]int32) {
+	if v.ListOfLists != nil {
+		return v.ListOfLists
+	}
+
+	return
+}
+
+// GetListOfSets returns the value of ListOfSets if it is set or its
+// zero value if it is unset.
+func (v *ContainersOfContainers) GetListOfSets() (o []map[int32]struct{}) {
+	if v.ListOfSets != nil {
+		return v.ListOfSets
+	}
+
+	return
+}
+
+// GetListOfMaps returns the value of ListOfMaps if it is set or its
+// zero value if it is unset.
+func (v *ContainersOfContainers) GetListOfMaps() (o []map[int32]int32) {
+	if v.ListOfMaps != nil {
+		return v.ListOfMaps
+	}
+
+	return
+}
+
+// GetSetOfSets returns the value of SetOfSets if it is set or its
+// zero value if it is unset.
+func (v *ContainersOfContainers) GetSetOfSets() (o []map[string]struct{}) {
+	if v.SetOfSets != nil {
+		return v.SetOfSets
+	}
+
+	return
+}
+
+// GetSetOfLists returns the value of SetOfLists if it is set or its
+// zero value if it is unset.
+func (v *ContainersOfContainers) GetSetOfLists() (o [][]string) {
+	if v.SetOfLists != nil {
+		return v.SetOfLists
+	}
+
+	return
+}
+
+// GetSetOfMaps returns the value of SetOfMaps if it is set or its
+// zero value if it is unset.
+func (v *ContainersOfContainers) GetSetOfMaps() (o []map[string]string) {
+	if v.SetOfMaps != nil {
+		return v.SetOfMaps
+	}
+
+	return
+}
+
+// GetMapOfMapToInt returns the value of MapOfMapToInt if it is set or its
+// zero value if it is unset.
+func (v *ContainersOfContainers) GetMapOfMapToInt() (o []struct {
+	Key   map[string]int32
+	Value int64
+}) {
+	if v.MapOfMapToInt != nil {
+		return v.MapOfMapToInt
+	}
+
+	return
+}
+
+// GetMapOfListToSet returns the value of MapOfListToSet if it is set or its
+// zero value if it is unset.
+func (v *ContainersOfContainers) GetMapOfListToSet() (o []struct {
+	Key   []int32
+	Value map[int64]struct{}
+}) {
+	if v.MapOfListToSet != nil {
+		return v.MapOfListToSet
+	}
+
+	return
+}
+
+// GetMapOfSetToListOfDouble returns the value of MapOfSetToListOfDouble if it is set or its
+// zero value if it is unset.
+func (v *ContainersOfContainers) GetMapOfSetToListOfDouble() (o []struct {
+	Key   map[int32]struct{}
+	Value []float64
+}) {
+	if v.MapOfSetToListOfDouble != nil {
+		return v.MapOfSetToListOfDouble
+	}
+
+	return
+}
+
 type EnumContainers struct {
 	ListOfEnums []enums.EnumDefault                     `json:"listOfEnums,omitempty"`
 	SetOfEnums  map[enums.EnumWithValues]struct{}       `json:"setOfEnums,omitempty"`
@@ -2020,6 +2119,36 @@ func (v *EnumContainers) Equals(rhs *EnumContainers) bool {
 	return true
 }
 
+// GetListOfEnums returns the value of ListOfEnums if it is set or its
+// zero value if it is unset.
+func (v *EnumContainers) GetListOfEnums() (o []enums.EnumDefault) {
+	if v.ListOfEnums != nil {
+		return v.ListOfEnums
+	}
+
+	return
+}
+
+// GetSetOfEnums returns the value of SetOfEnums if it is set or its
+// zero value if it is unset.
+func (v *EnumContainers) GetSetOfEnums() (o map[enums.EnumWithValues]struct{}) {
+	if v.SetOfEnums != nil {
+		return v.SetOfEnums
+	}
+
+	return
+}
+
+// GetMapOfEnums returns the value of MapOfEnums if it is set or its
+// zero value if it is unset.
+func (v *EnumContainers) GetMapOfEnums() (o map[enums.EnumWithDuplicateValues]int32) {
+	if v.MapOfEnums != nil {
+		return v.MapOfEnums
+	}
+
+	return
+}
+
 type ListOfConflictingEnums struct {
 	Records      []enum_conflict.RecordType `json:"records,required"`
 	OtherRecords []enums.RecordType         `json:"otherRecords,required"`
@@ -2286,6 +2415,14 @@ func (v *ListOfConflictingEnums) Equals(rhs *ListOfConflictingEnums) bool {
 
 	return true
 }
+
+// GetRecords returns the value of Records if it is set or its
+// zero value if it is unset.
+func (v *ListOfConflictingEnums) GetRecords() (o []enum_conflict.RecordType) { return v.Records }
+
+// GetOtherRecords returns the value of OtherRecords if it is set or its
+// zero value if it is unset.
+func (v *ListOfConflictingEnums) GetOtherRecords() (o []enums.RecordType) { return v.OtherRecords }
 
 type ListOfConflictingUUIDs struct {
 	Uuids      []*typedefs.UUID     `json:"uuids,required"`
@@ -2556,6 +2693,14 @@ func (v *ListOfConflictingUUIDs) Equals(rhs *ListOfConflictingUUIDs) bool {
 
 	return true
 }
+
+// GetUuids returns the value of Uuids if it is set or its
+// zero value if it is unset.
+func (v *ListOfConflictingUUIDs) GetUuids() (o []*typedefs.UUID) { return v.Uuids }
+
+// GetOtherUUIDs returns the value of OtherUUIDs if it is set or its
+// zero value if it is unset.
+func (v *ListOfConflictingUUIDs) GetOtherUUIDs() (o []uuid_conflict.UUID) { return v.OtherUUIDs }
 
 type MapOfBinaryAndString struct {
 	BinaryToString []struct {
@@ -2882,6 +3027,29 @@ func (v *MapOfBinaryAndString) Equals(rhs *MapOfBinaryAndString) bool {
 	}
 
 	return true
+}
+
+// GetBinaryToString returns the value of BinaryToString if it is set or its
+// zero value if it is unset.
+func (v *MapOfBinaryAndString) GetBinaryToString() (o []struct {
+	Key   []byte
+	Value string
+}) {
+	if v.BinaryToString != nil {
+		return v.BinaryToString
+	}
+
+	return
+}
+
+// GetStringToBinary returns the value of StringToBinary if it is set or its
+// zero value if it is unset.
+func (v *MapOfBinaryAndString) GetStringToBinary() (o map[string][]byte) {
+	if v.StringToBinary != nil {
+		return v.StringToBinary
+	}
+
+	return
 }
 
 type PrimitiveContainers struct {
@@ -3448,6 +3616,66 @@ func (v *PrimitiveContainers) Equals(rhs *PrimitiveContainers) bool {
 	return true
 }
 
+// GetListOfBinary returns the value of ListOfBinary if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainers) GetListOfBinary() (o [][]byte) {
+	if v.ListOfBinary != nil {
+		return v.ListOfBinary
+	}
+
+	return
+}
+
+// GetListOfInts returns the value of ListOfInts if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainers) GetListOfInts() (o []int64) {
+	if v.ListOfInts != nil {
+		return v.ListOfInts
+	}
+
+	return
+}
+
+// GetSetOfStrings returns the value of SetOfStrings if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainers) GetSetOfStrings() (o map[string]struct{}) {
+	if v.SetOfStrings != nil {
+		return v.SetOfStrings
+	}
+
+	return
+}
+
+// GetSetOfBytes returns the value of SetOfBytes if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainers) GetSetOfBytes() (o map[int8]struct{}) {
+	if v.SetOfBytes != nil {
+		return v.SetOfBytes
+	}
+
+	return
+}
+
+// GetMapOfIntToString returns the value of MapOfIntToString if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainers) GetMapOfIntToString() (o map[int32]string) {
+	if v.MapOfIntToString != nil {
+		return v.MapOfIntToString
+	}
+
+	return
+}
+
+// GetMapOfStringToBool returns the value of MapOfStringToBool if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainers) GetMapOfStringToBool() (o map[string]bool) {
+	if v.MapOfStringToBool != nil {
+		return v.MapOfStringToBool
+	}
+
+	return
+}
+
 type PrimitiveContainersRequired struct {
 	ListOfStrings      []string           `json:"listOfStrings,required"`
 	SetOfInts          map[int32]struct{} `json:"setOfInts,required"`
@@ -3691,4 +3919,18 @@ func (v *PrimitiveContainersRequired) Equals(rhs *PrimitiveContainersRequired) b
 	}
 
 	return true
+}
+
+// GetListOfStrings returns the value of ListOfStrings if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainersRequired) GetListOfStrings() (o []string) { return v.ListOfStrings }
+
+// GetSetOfInts returns the value of SetOfInts if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainersRequired) GetSetOfInts() (o map[int32]struct{}) { return v.SetOfInts }
+
+// GetMapOfIntsToDoubles returns the value of MapOfIntsToDoubles if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveContainersRequired) GetMapOfIntsToDoubles() (o map[int64]float64) {
+	return v.MapOfIntsToDoubles
 }

--- a/gen/testdata/enum_conflict/types.go
+++ b/gen/testdata/enum_conflict/types.go
@@ -336,7 +336,7 @@ func (v *Records) Equals(rhs *Records) bool {
 }
 
 // GetRecordType returns the value of RecordType if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *Records) GetRecordType() (o RecordType) {
 	if v.RecordType != nil {
 		return *v.RecordType
@@ -346,7 +346,7 @@ func (v *Records) GetRecordType() (o RecordType) {
 }
 
 // GetOtherRecordType returns the value of OtherRecordType if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *Records) GetOtherRecordType() (o enums.RecordType) {
 	if v.OtherRecordType != nil {
 		return *v.OtherRecordType

--- a/gen/testdata/exceptions/types.go
+++ b/gen/testdata/exceptions/types.go
@@ -154,6 +154,10 @@ func (v *DoesNotExistException) Equals(rhs *DoesNotExistException) bool {
 	return true
 }
 
+// GetKey returns the value of Key if it is set or its
+// zero value if it is unset.
+func (v *DoesNotExistException) GetKey() (o string) { return v.Key }
+
 // GetError2 returns the value of Error2 if it is set or its
 // zero value if it is unset.
 func (v *DoesNotExistException) GetError2() (o string) {

--- a/gen/testdata/services/conflictingnames_setvalue.go
+++ b/gen/testdata/services/conflictingnames_setvalue.go
@@ -122,6 +122,16 @@ func (v *ConflictingNames_SetValue_Args) Equals(rhs *ConflictingNames_SetValue_A
 	return true
 }
 
+// GetRequest returns the value of Request if it is set or its
+// zero value if it is unset.
+func (v *ConflictingNames_SetValue_Args) GetRequest() (o *ConflictingNamesSetValueArgs) {
+	if v.Request != nil {
+		return v.Request
+	}
+
+	return
+}
+
 // MethodName returns the name of the Thrift function as specified in
 // the IDL, for which this struct represent the arguments.
 //

--- a/gen/testdata/services/keyvalue_deletevalue.go
+++ b/gen/testdata/services/keyvalue_deletevalue.go
@@ -420,6 +420,26 @@ func (v *KeyValue_DeleteValue_Result) Equals(rhs *KeyValue_DeleteValue_Result) b
 	return true
 }
 
+// GetDoesNotExist returns the value of DoesNotExist if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_DeleteValue_Result) GetDoesNotExist() (o *exceptions.DoesNotExistException) {
+	if v.DoesNotExist != nil {
+		return v.DoesNotExist
+	}
+
+	return
+}
+
+// GetInternalError returns the value of InternalError if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_DeleteValue_Result) GetInternalError() (o *InternalError) {
+	if v.InternalError != nil {
+		return v.InternalError
+	}
+
+	return
+}
+
 // MethodName returns the name of the Thrift function as specified in
 // the IDL, for which this struct represent the result.
 //

--- a/gen/testdata/services/keyvalue_getmanyvalues.go
+++ b/gen/testdata/services/keyvalue_getmanyvalues.go
@@ -178,6 +178,16 @@ func (v *KeyValue_GetManyValues_Args) Equals(rhs *KeyValue_GetManyValues_Args) b
 	return true
 }
 
+// GetRange returns the value of Range if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_GetManyValues_Args) GetRange() (o []Key) {
+	if v.Range != nil {
+		return v.Range
+	}
+
+	return
+}
+
 // MethodName returns the name of the Thrift function as specified in
 // the IDL, for which this struct represent the arguments.
 //
@@ -503,6 +513,26 @@ func (v *KeyValue_GetManyValues_Result) Equals(rhs *KeyValue_GetManyValues_Resul
 	}
 
 	return true
+}
+
+// GetSuccess returns the value of Success if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_GetManyValues_Result) GetSuccess() (o []*unions.ArbitraryValue) {
+	if v.Success != nil {
+		return v.Success
+	}
+
+	return
+}
+
+// GetDoesNotExist returns the value of DoesNotExist if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_GetManyValues_Result) GetDoesNotExist() (o *exceptions.DoesNotExistException) {
+	if v.DoesNotExist != nil {
+		return v.DoesNotExist
+	}
+
+	return
 }
 
 // MethodName returns the name of the Thrift function as specified in

--- a/gen/testdata/services/keyvalue_getvalue.go
+++ b/gen/testdata/services/keyvalue_getvalue.go
@@ -390,6 +390,26 @@ func (v *KeyValue_GetValue_Result) Equals(rhs *KeyValue_GetValue_Result) bool {
 	return true
 }
 
+// GetSuccess returns the value of Success if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_GetValue_Result) GetSuccess() (o *unions.ArbitraryValue) {
+	if v.Success != nil {
+		return v.Success
+	}
+
+	return
+}
+
+// GetDoesNotExist returns the value of DoesNotExist if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_GetValue_Result) GetDoesNotExist() (o *exceptions.DoesNotExistException) {
+	if v.DoesNotExist != nil {
+		return v.DoesNotExist
+	}
+
+	return
+}
+
 // MethodName returns the name of the Thrift function as specified in
 // the IDL, for which this struct represent the result.
 //

--- a/gen/testdata/services/keyvalue_setvalue.go
+++ b/gen/testdata/services/keyvalue_setvalue.go
@@ -153,6 +153,16 @@ func (v *KeyValue_SetValue_Args) GetKey() (o Key) {
 	return
 }
 
+// GetValue returns the value of Value if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_SetValue_Args) GetValue() (o *unions.ArbitraryValue) {
+	if v.Value != nil {
+		return v.Value
+	}
+
+	return
+}
+
 // MethodName returns the name of the Thrift function as specified in
 // the IDL, for which this struct represent the arguments.
 //

--- a/gen/testdata/services/keyvalue_setvaluev2.go
+++ b/gen/testdata/services/keyvalue_setvaluev2.go
@@ -152,6 +152,14 @@ func (v *KeyValue_SetValueV2_Args) Equals(rhs *KeyValue_SetValueV2_Args) bool {
 	return true
 }
 
+// GetKey returns the value of Key if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_SetValueV2_Args) GetKey() (o Key) { return v.Key }
+
+// GetValue returns the value of Value if it is set or its
+// zero value if it is unset.
+func (v *KeyValue_SetValueV2_Args) GetValue() (o *unions.ArbitraryValue) { return v.Value }
+
 // MethodName returns the name of the Thrift function as specified in
 // the IDL, for which this struct represent the arguments.
 //

--- a/gen/testdata/services/types.go
+++ b/gen/testdata/services/types.go
@@ -145,6 +145,14 @@ func (v *ConflictingNamesSetValueArgs) Equals(rhs *ConflictingNamesSetValueArgs)
 	return true
 }
 
+// GetKey returns the value of Key if it is set or its
+// zero value if it is unset.
+func (v *ConflictingNamesSetValueArgs) GetKey() (o string) { return v.Key }
+
+// GetValue returns the value of Value if it is set or its
+// zero value if it is unset.
+func (v *ConflictingNamesSetValueArgs) GetValue() (o []byte) { return v.Value }
+
 type InternalError struct {
 	Message *string `json:"message,omitempty"`
 }

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -119,6 +119,10 @@ func (v *ContactInfo) Equals(rhs *ContactInfo) bool {
 	return true
 }
 
+// GetEmailAddress returns the value of EmailAddress if it is set or its
+// zero value if it is unset.
+func (v *ContactInfo) GetEmailAddress() (o string) { return v.EmailAddress }
+
 type DefaultsStruct struct {
 	RequiredPrimitive *int32             `json:"requiredPrimitive,omitempty"`
 	OptionalPrimitive *int32             `json:"optionalPrimitive,omitempty"`
@@ -705,6 +709,71 @@ func (v *DefaultsStruct) GetOptionalEnum() (o enums.EnumDefault) {
 	return
 }
 
+// GetRequiredList returns the value of RequiredList if it is set or its
+// zero value if it is unset.
+func (v *DefaultsStruct) GetRequiredList() (o []string) {
+	if v.RequiredList != nil {
+		return v.RequiredList
+	}
+	o = []string{
+		"hello",
+		"world",
+	}
+	return
+}
+
+// GetOptionalList returns the value of OptionalList if it is set or its
+// zero value if it is unset.
+func (v *DefaultsStruct) GetOptionalList() (o []float64) {
+	if v.OptionalList != nil {
+		return v.OptionalList
+	}
+	o = []float64{
+		1,
+		2,
+		3,
+	}
+	return
+}
+
+// GetRequiredStruct returns the value of RequiredStruct if it is set or its
+// zero value if it is unset.
+func (v *DefaultsStruct) GetRequiredStruct() (o *Frame) {
+	if v.RequiredStruct != nil {
+		return v.RequiredStruct
+	}
+	o = &Frame{
+		Size: &Size{
+			Height: 200,
+			Width:  100,
+		},
+		TopLeft: &Point{
+			X: 1,
+			Y: 2,
+		},
+	}
+	return
+}
+
+// GetOptionalStruct returns the value of OptionalStruct if it is set or its
+// zero value if it is unset.
+func (v *DefaultsStruct) GetOptionalStruct() (o *Edge) {
+	if v.OptionalStruct != nil {
+		return v.OptionalStruct
+	}
+	o = &Edge{
+		EndPoint: &Point{
+			X: 3,
+			Y: 4,
+		},
+		StartPoint: &Point{
+			X: 1,
+			Y: 2,
+		},
+	}
+	return
+}
+
 type Edge struct {
 	StartPoint *Point `json:"startPoint,required"`
 	EndPoint   *Point `json:"endPoint,required"`
@@ -847,6 +916,14 @@ func (v *Edge) Equals(rhs *Edge) bool {
 
 	return true
 }
+
+// GetStartPoint returns the value of StartPoint if it is set or its
+// zero value if it is unset.
+func (v *Edge) GetStartPoint() (o *Point) { return v.StartPoint }
+
+// GetEndPoint returns the value of EndPoint if it is set or its
+// zero value if it is unset.
+func (v *Edge) GetEndPoint() (o *Point) { return v.EndPoint }
 
 type EmptyStruct struct {
 }
@@ -1066,6 +1143,14 @@ func (v *Frame) Equals(rhs *Frame) bool {
 
 	return true
 }
+
+// GetTopLeft returns the value of TopLeft if it is set or its
+// zero value if it is unset.
+func (v *Frame) GetTopLeft() (o *Point) { return v.TopLeft }
+
+// GetSize returns the value of Size if it is set or its
+// zero value if it is unset.
+func (v *Frame) GetSize() (o *Size) { return v.Size }
 
 type GoTags struct {
 	Foo                 string  `json:"-" foo:"bar"`
@@ -1315,6 +1400,10 @@ func (v *GoTags) Equals(rhs *GoTags) bool {
 	return true
 }
 
+// GetFoo returns the value of Foo if it is set or its
+// zero value if it is unset.
+func (v *GoTags) GetFoo() (o string) { return v.Foo }
+
 // GetBar returns the value of Bar if it is set or its
 // zero value if it is unset.
 func (v *GoTags) GetBar() (o string) {
@@ -1325,6 +1414,14 @@ func (v *GoTags) GetBar() (o string) {
 	return
 }
 
+// GetFooBar returns the value of FooBar if it is set or its
+// zero value if it is unset.
+func (v *GoTags) GetFooBar() (o string) { return v.FooBar }
+
+// GetFooBarWithSpace returns the value of FooBarWithSpace if it is set or its
+// zero value if it is unset.
+func (v *GoTags) GetFooBarWithSpace() (o string) { return v.FooBarWithSpace }
+
 // GetFooBarWithOmitEmpty returns the value of FooBarWithOmitEmpty if it is set or its
 // zero value if it is unset.
 func (v *GoTags) GetFooBarWithOmitEmpty() (o string) {
@@ -1334,6 +1431,10 @@ func (v *GoTags) GetFooBarWithOmitEmpty() (o string) {
 
 	return
 }
+
+// GetFooBarWithRequired returns the value of FooBarWithRequired if it is set or its
+// zero value if it is unset.
+func (v *GoTags) GetFooBarWithRequired() (o string) { return v.FooBarWithRequired }
 
 // A graph is comprised of zero or more edges.
 type Graph struct {
@@ -1510,6 +1611,10 @@ func (v *Graph) Equals(rhs *Graph) bool {
 	return true
 }
 
+// GetEdges returns the value of Edges if it is set or its
+// zero value if it is unset.
+func (v *Graph) GetEdges() (o []*Edge) { return v.Edges }
+
 type List Node
 
 // ToWire translates List into a Thrift-level intermediate
@@ -1677,6 +1782,20 @@ func (v *Node) Equals(rhs *Node) bool {
 	return true
 }
 
+// GetValue returns the value of Value if it is set or its
+// zero value if it is unset.
+func (v *Node) GetValue() (o int32) { return v.Value }
+
+// GetTail returns the value of Tail if it is set or its
+// zero value if it is unset.
+func (v *Node) GetTail() (o *List) {
+	if v.Tail != nil {
+		return v.Tail
+	}
+
+	return
+}
+
 type Omit struct {
 	Serialized string `json:"serialized,required"`
 	Hidden     string `json:"-"`
@@ -1808,6 +1927,14 @@ func (v *Omit) Equals(rhs *Omit) bool {
 
 	return true
 }
+
+// GetSerialized returns the value of Serialized if it is set or its
+// zero value if it is unset.
+func (v *Omit) GetSerialized() (o string) { return v.Serialized }
+
+// GetHidden returns the value of Hidden if it is set or its
+// zero value if it is unset.
+func (v *Omit) GetHidden() (o string) { return v.Hidden }
 
 // A point in 2D space.
 type Point struct {
@@ -1941,6 +2068,14 @@ func (v *Point) Equals(rhs *Point) bool {
 
 	return true
 }
+
+// GetX returns the value of X if it is set or its
+// zero value if it is unset.
+func (v *Point) GetX() (o float64) { return v.X }
+
+// GetY returns the value of Y if it is set or its
+// zero value if it is unset.
+func (v *Point) GetY() (o float64) { return v.Y }
 
 // A struct that contains primitive fields exclusively.
 //
@@ -2351,6 +2486,16 @@ func (v *PrimitiveOptionalStruct) GetStringField() (o string) {
 	return
 }
 
+// GetBinaryField returns the value of BinaryField if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveOptionalStruct) GetBinaryField() (o []byte) {
+	if v.BinaryField != nil {
+		return v.BinaryField
+	}
+
+	return
+}
+
 // A struct that contains primitive fields exclusively.
 //
 // All fields are required.
@@ -2644,6 +2789,38 @@ func (v *PrimitiveRequiredStruct) Equals(rhs *PrimitiveRequiredStruct) bool {
 	return true
 }
 
+// GetBoolField returns the value of BoolField if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveRequiredStruct) GetBoolField() (o bool) { return v.BoolField }
+
+// GetByteField returns the value of ByteField if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveRequiredStruct) GetByteField() (o int8) { return v.ByteField }
+
+// GetInt16Field returns the value of Int16Field if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveRequiredStruct) GetInt16Field() (o int16) { return v.Int16Field }
+
+// GetInt32Field returns the value of Int32Field if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveRequiredStruct) GetInt32Field() (o int32) { return v.Int32Field }
+
+// GetInt64Field returns the value of Int64Field if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveRequiredStruct) GetInt64Field() (o int64) { return v.Int64Field }
+
+// GetDoubleField returns the value of DoubleField if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveRequiredStruct) GetDoubleField() (o float64) { return v.DoubleField }
+
+// GetStringField returns the value of StringField if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveRequiredStruct) GetStringField() (o string) { return v.StringField }
+
+// GetBinaryField returns the value of BinaryField if it is set or its
+// zero value if it is unset.
+func (v *PrimitiveRequiredStruct) GetBinaryField() (o []byte) { return v.BinaryField }
+
 type Rename struct {
 	Default   string `json:"default,required"`
 	CamelCase string `json:"snake_case,required"`
@@ -2775,6 +2952,14 @@ func (v *Rename) Equals(rhs *Rename) bool {
 
 	return true
 }
+
+// GetDefault returns the value of Default if it is set or its
+// zero value if it is unset.
+func (v *Rename) GetDefault() (o string) { return v.Default }
+
+// GetCamelCase returns the value of CamelCase if it is set or its
+// zero value if it is unset.
+func (v *Rename) GetCamelCase() (o string) { return v.CamelCase }
 
 // Size of something.
 type Size struct {
@@ -2911,6 +3096,14 @@ func (v *Size) Equals(rhs *Size) bool {
 	return true
 }
 
+// GetWidth returns the value of Width if it is set or its
+// zero value if it is unset.
+func (v *Size) GetWidth() (o float64) { return v.Width }
+
+// GetHeight returns the value of Height if it is set or its
+// zero value if it is unset.
+func (v *Size) GetHeight() (o float64) { return v.Height }
+
 type User struct {
 	Name    string       `json:"name,required"`
 	Contact *ContactInfo `json:"contact,omitempty"`
@@ -3045,4 +3238,18 @@ func (v *User) Equals(rhs *User) bool {
 	}
 
 	return true
+}
+
+// GetName returns the value of Name if it is set or its
+// zero value if it is unset.
+func (v *User) GetName() (o string) { return v.Name }
+
+// GetContact returns the value of Contact if it is set or its
+// zero value if it is unset.
+func (v *User) GetContact() (o *ContactInfo) {
+	if v.Contact != nil {
+		return v.Contact
+	}
+
+	return
 }

--- a/gen/testdata/structs/types.go
+++ b/gen/testdata/structs/types.go
@@ -670,7 +670,7 @@ func (v *DefaultsStruct) Equals(rhs *DefaultsStruct) bool {
 }
 
 // GetRequiredPrimitive returns the value of RequiredPrimitive if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *DefaultsStruct) GetRequiredPrimitive() (o int32) {
 	if v.RequiredPrimitive != nil {
 		return *v.RequiredPrimitive
@@ -680,7 +680,7 @@ func (v *DefaultsStruct) GetRequiredPrimitive() (o int32) {
 }
 
 // GetOptionalPrimitive returns the value of OptionalPrimitive if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *DefaultsStruct) GetOptionalPrimitive() (o int32) {
 	if v.OptionalPrimitive != nil {
 		return *v.OptionalPrimitive
@@ -690,7 +690,7 @@ func (v *DefaultsStruct) GetOptionalPrimitive() (o int32) {
 }
 
 // GetRequiredEnum returns the value of RequiredEnum if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *DefaultsStruct) GetRequiredEnum() (o enums.EnumDefault) {
 	if v.RequiredEnum != nil {
 		return *v.RequiredEnum
@@ -700,7 +700,7 @@ func (v *DefaultsStruct) GetRequiredEnum() (o enums.EnumDefault) {
 }
 
 // GetOptionalEnum returns the value of OptionalEnum if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *DefaultsStruct) GetOptionalEnum() (o enums.EnumDefault) {
 	if v.OptionalEnum != nil {
 		return *v.OptionalEnum
@@ -710,7 +710,7 @@ func (v *DefaultsStruct) GetOptionalEnum() (o enums.EnumDefault) {
 }
 
 // GetRequiredList returns the value of RequiredList if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *DefaultsStruct) GetRequiredList() (o []string) {
 	if v.RequiredList != nil {
 		return v.RequiredList
@@ -723,7 +723,7 @@ func (v *DefaultsStruct) GetRequiredList() (o []string) {
 }
 
 // GetOptionalList returns the value of OptionalList if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *DefaultsStruct) GetOptionalList() (o []float64) {
 	if v.OptionalList != nil {
 		return v.OptionalList
@@ -737,7 +737,7 @@ func (v *DefaultsStruct) GetOptionalList() (o []float64) {
 }
 
 // GetRequiredStruct returns the value of RequiredStruct if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *DefaultsStruct) GetRequiredStruct() (o *Frame) {
 	if v.RequiredStruct != nil {
 		return v.RequiredStruct
@@ -756,7 +756,7 @@ func (v *DefaultsStruct) GetRequiredStruct() (o *Frame) {
 }
 
 // GetOptionalStruct returns the value of OptionalStruct if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *DefaultsStruct) GetOptionalStruct() (o *Edge) {
 	if v.OptionalStruct != nil {
 		return v.OptionalStruct

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -247,7 +247,7 @@ func (v *DefaultPrimitiveTypedef) Equals(rhs *DefaultPrimitiveTypedef) bool {
 }
 
 // GetState returns the value of State if it is set or its
-// zero value if it is unset.
+// default value if it is unset.
 func (v *DefaultPrimitiveTypedef) GetState() (o State) {
 	if v.State != nil {
 		return *v.State

--- a/gen/testdata/typedefs/types.go
+++ b/gen/testdata/typedefs/types.go
@@ -575,6 +575,10 @@ func (v *Event) Equals(rhs *Event) bool {
 	return true
 }
 
+// GetUUID returns the value of UUID if it is set or its
+// zero value if it is unset.
+func (v *Event) GetUUID() (o *UUID) { return v.UUID }
+
 // GetTime returns the value of Time if it is set or its
 // zero value if it is unset.
 func (v *Event) GetTime() (o Timestamp) {
@@ -1247,6 +1251,24 @@ func (v *Transition) Equals(rhs *Transition) bool {
 	return true
 }
 
+// GetFromState returns the value of FromState if it is set or its
+// zero value if it is unset.
+func (v *Transition) GetFromState() (o State) { return v.FromState }
+
+// GetToState returns the value of ToState if it is set or its
+// zero value if it is unset.
+func (v *Transition) GetToState() (o State) { return v.ToState }
+
+// GetEvents returns the value of Events if it is set or its
+// zero value if it is unset.
+func (v *Transition) GetEvents() (o EventGroup) {
+	if v.Events != nil {
+		return v.Events
+	}
+
+	return
+}
+
 type UUID I128
 
 // ToWire translates UUID into a Thrift-level intermediate
@@ -1407,3 +1429,11 @@ func (v *I128) Equals(rhs *I128) bool {
 
 	return true
 }
+
+// GetHigh returns the value of High if it is set or its
+// zero value if it is unset.
+func (v *I128) GetHigh() (o int64) { return v.High }
+
+// GetLow returns the value of Low if it is set or its
+// zero value if it is unset.
+func (v *I128) GetLow() (o int64) { return v.Low }

--- a/gen/testdata/unions/types.go
+++ b/gen/testdata/unions/types.go
@@ -460,6 +460,26 @@ func (v *ArbitraryValue) GetStringValue() (o string) {
 	return
 }
 
+// GetListValue returns the value of ListValue if it is set or its
+// zero value if it is unset.
+func (v *ArbitraryValue) GetListValue() (o []*ArbitraryValue) {
+	if v.ListValue != nil {
+		return v.ListValue
+	}
+
+	return
+}
+
+// GetMapValue returns the value of MapValue if it is set or its
+// zero value if it is unset.
+func (v *ArbitraryValue) GetMapValue() (o map[string]*ArbitraryValue) {
+	if v.MapValue != nil {
+		return v.MapValue
+	}
+
+	return
+}
+
 type Document struct {
 	Pdf       typedefs.PDF `json:"pdf,omitempty"`
 	PlainText *string      `json:"plainText,omitempty"`
@@ -609,6 +629,16 @@ func (v *Document) Equals(rhs *Document) bool {
 	}
 
 	return true
+}
+
+// GetPdf returns the value of Pdf if it is set or its
+// zero value if it is unset.
+func (v *Document) GetPdf() (o typedefs.PDF) {
+	if v.Pdf != nil {
+		return v.Pdf
+	}
+
+	return
 }
 
 // GetPlainText returns the value of PlainText if it is set or its

--- a/gen/testdata/uuid_conflict/types.go
+++ b/gen/testdata/uuid_conflict/types.go
@@ -187,3 +187,11 @@ func (v *UUIDConflict) Equals(rhs *UUIDConflict) bool {
 
 	return true
 }
+
+// GetLocalUUID returns the value of LocalUUID if it is set or its
+// zero value if it is unset.
+func (v *UUIDConflict) GetLocalUUID() (o UUID) { return v.LocalUUID }
+
+// GetImportedUUID returns the value of ImportedUUID if it is set or its
+// zero value if it is unset.
+func (v *UUIDConflict) GetImportedUUID() (o *typedefs.UUID) { return v.ImportedUUID }


### PR DESCRIPTION
This removes the constraint for generating struct field accessors for primitive types only.

Previously, the following struct:
```
type Foo struct {
    Bar *int32
    Baz []string
}
```

Would generate a struct with a `GetBar` method, but would omit a `GetBaz` method because it was not a primitive type. Now, we would expect to see both of these methods.