### PR TITLE
make: Fix golint import path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ install:
 .PHONY: install_ci
 install_ci: install
 ifdef SHOULD_LINT
-	go get -u -f github.com/golang/lint/golint
+	go get -u -f golang.org/x/lint/golint
 	go get -u -f github.com/kisielk/errcheck
 endif
 	go get -u github.com/wadey/gocovmerge


### PR DESCRIPTION
golint changed the import path of imported modules from
`github.com/golang/lint/...` to `golang.org/x/lint/...`.