### PR TITLE
glide: Pin to multierr ^1

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d0f43f812a18bfa1f7490f400166b9116e3021f8f77e723dd0a5901a6745e0b9
-updated: 2017-08-03T15:10:56.086707616-07:00
+hash: 26c2c55ca402d6605deed8219389876b6207f46109135620b0f6ec7f84ca1a84
+updated: 2018-04-24T13:31:10.646395712-07:00
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -16,24 +16,24 @@ imports:
 - name: github.com/kr/text
   version: 7cafcd837844e784b526369c9bce262804aebc60
 - name: go.uber.org/atomic
-  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
 - name: go.uber.org/multierr
-  version: a3d1fc1f1316d4132fc61f4ea1159ae0613fb474
+  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: golang.org/x/tools
   version: 4e70a1b26a7875f00ca1916637a876b5ffaeec59
   subpackages:
   - go/ast/astutil
 testImports:
 - name: github.com/davecgh/go-spew
-  version: adab96458c51a58dc1783b3335dcce5461522e75
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 05e8a0eda380579888eb53c394909df027f06991
+  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
 - package: github.com/jessevdk/go-flags
 - package: github.com/anmitsu/go-shlex
 - package: go.uber.org/multierr
-  version: ~0.2.0
+  version: ^1
 - package: github.com/fatih/structtag
   version: ^0.1.0
 testImport:


### PR DESCRIPTION
We were pinned to a pre-1.0 release of multierr. This switches to the
1.0 release.

There have been no breaking changes so we don't need to change any
code.