### PR TITLE
Add tool for listing imported thrift files

### DIFF
--- a/cmd/thriftrw-list-deps/README.md
+++ b/cmd/thriftrw-list-deps/README.md
@@ -1,0 +1,17 @@
+# list-deps
+
+This tool can be used on a given Thrift file to output the list of Thrift files that the given file depends on.
+
+## Installation
+
+```bash
+$ go get go.uber.org/thriftrw/cmd/thriftrw-list-deps
+```
+
+## Usage
+
+```bash
+$ thriftrw-list-deps -relative=$(pwd) gen/testdata/thrift/structs.thrift
+gen/testdata/thrift/enums.thrift
+$
+```

--- a/cmd/thriftrw-list-deps/README.md
+++ b/cmd/thriftrw-list-deps/README.md
@@ -1,4 +1,4 @@
-# list-deps
+# thriftrw-list-deps
 
 This tool can be used on a given Thrift file to output the list of Thrift files that the given file depends on.
 
@@ -11,7 +11,7 @@ $ go get go.uber.org/thriftrw/cmd/thriftrw-list-deps
 ## Usage
 
 ```bash
-$ thriftrw-list-deps --relative=$(pwd) gen/testdata/thrift/structs.thrift
+$ thriftrw-list-deps --relative-to=$(pwd) gen/testdata/thrift/structs.thrift
 gen/testdata/thrift/enums.thrift
 $
 ```

--- a/cmd/thriftrw-list-deps/README.md
+++ b/cmd/thriftrw-list-deps/README.md
@@ -11,7 +11,7 @@ $ go get go.uber.org/thriftrw/cmd/thriftrw-list-deps
 ## Usage
 
 ```bash
-$ thriftrw-list-deps -relative=$(pwd) gen/testdata/thrift/structs.thrift
+$ thriftrw-list-deps --relative=$(pwd) gen/testdata/thrift/structs.thrift
 gen/testdata/thrift/enums.thrift
 $
 ```

--- a/cmd/thriftrw-list-deps/main.go
+++ b/cmd/thriftrw-list-deps/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"log"
-	"os"
 	"path/filepath"
 
 	"github.com/jessevdk/go-flags"
@@ -13,44 +11,65 @@ import (
 )
 
 type args struct {
-	ThriftFile string `positional-arg-name:"thrift-file"`
+	ThriftFile string `positional-arg-name:"file" description:"Path to the Thrift file"`
 }
 
 var opts struct {
-	Relative string `long:"relative" description:"Output paths will be relative to this directory"`
-	Args     args   `positional-args:"yes" required:"yes"`
+	RelativeTo string `long:"relative-to" description:"If specified, output paths will be relative to this directory"`
+	Args       args   `positional-args:"yes" required:"yes"`
 }
 
-func do(relative string, inputThriftFile string, output io.Writer) error {
+// listDependentThrifts lists the Thrift files that the given Thrift file depends on or includes, both directly (through imports) and
+// indirectly (through transitive imports).
+//
+// The returned file paths are absolute, unless relativeDir parameter is given, in which case the paths are relative to
+// the relativeDir.
+func listDependentThrifts(inputThriftFile string, relativeDir string) ([]string, error) {
+	dependentThriftFiles := make([]string, 0)
+
 	module, err := compile.Compile(inputThriftFile)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("could not compile %q: %v", inputThriftFile, err)
 	}
 
 	for _, included := range module.Includes {
 		outputFilePath := included.Module.ThriftPath
-		if relative != "" {
-			outputFilePath, err = filepath.Rel(relative, outputFilePath)
+
+		if relativeDir != "" {
+			outputFilePath, err = filepath.Rel(relativeDir, outputFilePath)
 			if err != nil {
-				return err
+				return nil, fmt.Errorf("cannot make %q relativeDir to %q: %v", outputFilePath, relativeDir, err)
 			}
 		}
-		fmt.Fprintf(output, "%s\n", outputFilePath)
+
+		dependentThriftFiles = append(dependentThriftFiles, outputFilePath)
+	}
+
+	return dependentThriftFiles, nil
+}
+
+func run() error {
+	if _, err := flags.Parse(&opts); err != nil {
+		return fmt.Errorf("error parsing arguments: %v", err)
+	}
+
+	inputThriftFile := opts.Args.ThriftFile
+
+	paths, err := listDependentThrifts(inputThriftFile, opts.RelativeTo)
+	if err != nil {
+		return fmt.Errorf("error listing deps of %q: %v", inputThriftFile, err)
+	}
+
+	for _, path := range paths {
+		fmt.Println(path)
 	}
 
 	return nil
 }
 
 func main() {
-	if _, err := flags.Parse(&opts); err != nil {
-		log.Fatalf("error parsing arguments: %s", err.Error())
-		os.Exit(1)
-	}
-
-	inputThriftFile := opts.Args.ThriftFile
-
-	if err := do(opts.Relative, inputThriftFile, os.Stdout); err != nil {
-		log.Fatalf("error listing deps of %s: %s", inputThriftFile, err.Error())
-		os.Exit(1)
+	log.SetFlags(0) // so that the error message isn't noisy
+	if err := run(); err != nil {
+		log.Fatalf("%v", err)
 	}
 }

--- a/cmd/thriftrw-list-deps/main.go
+++ b/cmd/thriftrw-list-deps/main.go
@@ -30,7 +30,7 @@ func listDependentThrifts(input string, relativeTo string) ([]string, error) {
 		return nil, fmt.Errorf("could not compile %q: %v", input, err)
 	}
 
-	module.Walk(func(mod *compile.Module) error {
+	err = module.Walk(func(mod *compile.Module) error {
 		output := mod.ThriftPath
 
 		// Do not return a self-referencing dependency
@@ -49,6 +49,10 @@ func listDependentThrifts(input string, relativeTo string) ([]string, error) {
 		deps = append(deps, output)
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
 
 	return deps, nil
 }

--- a/cmd/thriftrw-list-deps/main.go
+++ b/cmd/thriftrw-list-deps/main.go
@@ -10,42 +10,47 @@ import (
 	"go.uber.org/thriftrw/compile"
 )
 
-type args struct {
-	ThriftFile string `positional-arg-name:"file" description:"Path to the Thrift file"`
-}
-
 var opts struct {
 	RelativeTo string `long:"relative-to" description:"If specified, output paths will be relative to this directory"`
-	Args       args   `positional-args:"yes" required:"yes"`
+	Args       struct {
+		ThriftFile string `positional-arg-name:"file" description:"Path to the Thrift file"`
+	} `positional-args:"yes" required:"yes"`
 }
 
 // listDependentThrifts lists the Thrift files that the given Thrift file depends on or includes, both directly (through imports) and
 // indirectly (through transitive imports).
 //
-// The returned file paths are absolute, unless relativeDir parameter is given, in which case the paths are relative to
-// the relativeDir.
-func listDependentThrifts(inputThriftFile string, relativeDir string) ([]string, error) {
-	dependentThriftFiles := make([]string, 0)
+// The returned file paths are absolute, unless relativeTo parameter is given, in which case the paths are relative to
+// the relativeTo directory.
+func listDependentThrifts(input string, relativeTo string) ([]string, error) {
+	var deps []string
 
-	module, err := compile.Compile(inputThriftFile)
+	module, err := compile.Compile(input)
 	if err != nil {
-		return nil, fmt.Errorf("could not compile %q: %v", inputThriftFile, err)
+		return nil, fmt.Errorf("could not compile %q: %v", input, err)
 	}
 
-	for _, included := range module.Includes {
-		outputFilePath := included.Module.ThriftPath
+	module.Walk(func(mod *compile.Module) error {
+		output := mod.ThriftPath
 
-		if relativeDir != "" {
-			outputFilePath, err = filepath.Rel(relativeDir, outputFilePath)
+		// Do not return a self-referencing dependency
+		if output == input {
+			return nil
+		}
+
+		if relativeTo != "" {
+			output, err = filepath.Rel(relativeTo, output)
 			if err != nil {
-				return nil, fmt.Errorf("cannot make %q relativeDir to %q: %v", outputFilePath, relativeDir, err)
+				return fmt.Errorf("%q depends on %q, which is not relative to %q; ensure that --relative-to"+
+					" is an an ancestor of %q: %v", input, output, relativeTo, output, err)
 			}
 		}
 
-		dependentThriftFiles = append(dependentThriftFiles, outputFilePath)
-	}
+		deps = append(deps, output)
+		return nil
+	})
 
-	return dependentThriftFiles, nil
+	return deps, nil
 }
 
 func run() error {
@@ -53,11 +58,11 @@ func run() error {
 		return fmt.Errorf("error parsing arguments: %v", err)
 	}
 
-	inputThriftFile := opts.Args.ThriftFile
+	file := opts.Args.ThriftFile
 
-	paths, err := listDependentThrifts(inputThriftFile, opts.RelativeTo)
+	paths, err := listDependentThrifts(file, opts.RelativeTo)
 	if err != nil {
-		return fmt.Errorf("error listing deps of %q: %v", inputThriftFile, err)
+		return fmt.Errorf("error listing deps of %q: %v", file, err)
 	}
 
 	for _, path := range paths {
@@ -70,6 +75,6 @@ func run() error {
 func main() {
 	log.SetFlags(0) // so that the error message isn't noisy
 	if err := run(); err != nil {
-		log.Fatalf("%v", err)
+		log.Fatal(err)
 	}
 }

--- a/cmd/thriftrw-list-deps/main.go
+++ b/cmd/thriftrw-list-deps/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/jessevdk/go-flags"
+
+	"go.uber.org/thriftrw/compile"
+)
+
+type args struct {
+	ThriftFile string `positional-arg-name:"thrift-file"`
+}
+
+var opts struct {
+	Relative string `long:"relative" description:"Output paths will be relative to this directory"`
+	Args     args   `positional-args:"yes" required:"yes"`
+}
+
+func do(relative string, inputThriftFile string, output io.Writer) error {
+	module, err := compile.Compile(inputThriftFile)
+	if err != nil {
+		return err
+	}
+
+	for _, included := range module.Includes {
+		outputFilePath := included.Module.ThriftPath
+		if relative != "" {
+			outputFilePath, err = filepath.Rel(relative, outputFilePath)
+			if err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(output, "%s\n", outputFilePath)
+	}
+
+	return nil
+}
+
+func main() {
+	if _, err := flags.Parse(&opts); err != nil {
+		log.Fatalf("error parsing arguments: %s", err.Error())
+		os.Exit(1)
+	}
+
+	inputThriftFile := opts.Args.ThriftFile
+
+	if err := do(opts.Relative, inputThriftFile, os.Stdout); err != nil {
+		log.Fatalf("error listing deps of %s: %s", inputThriftFile, err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/thriftrw-list-deps/main_test.go
+++ b/cmd/thriftrw-list-deps/main_test.go
@@ -16,9 +16,7 @@ import (
 
 func TestThriftrwListDeps(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Skipf("error creating temporary directory: %v", err)
-	}
+	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
 
@@ -33,13 +31,9 @@ include "./c.thrift"`,
 	for name, content := range exampleThrifts {
 		path := filepath.Join(tmpDir, name)
 		err = os.MkdirAll(filepath.Dir(path), 0755)
-		if err != nil {
-			t.Skipf("error mkdir %s: %v", path, err)
-		}
+		require.NoError(t, err)
 		err = ioutil.WriteFile(path, []byte(content), 0644)
-		if err != nil {
-			t.Skipf("error writing %s: %v", path, err)
-		}
+		require.NoError(t, err)
 	}
 
 	t.Run("no dependencies", func(t *testing.T) {
@@ -47,33 +41,28 @@ include "./c.thrift"`,
 		require.NoError(t, err)
 		sort.Strings(outputLines)
 		t.Logf("output lines: %+v", outputLines)
-		assert.Equal(t, 0, len(outputLines))
+		assert.Empty(t, outputLines)
 	})
 	t.Run("one dependency", func(t *testing.T) {
 		outputLines, err := listDependentThrifts(filepath.Join(tmpDir, "test/b.thrift"), tmpDir)
 		require.NoError(t, err)
 		sort.Strings(outputLines)
 		t.Logf("output lines: %+v", outputLines)
-		assert.Equal(t, 1, len(outputLines))
-		assert.Equal(t, "test/a.thrift", outputLines[0])
+		assert.Equal(t, []string{"test/a.thrift"}, outputLines)
 	})
 	t.Run("one dependency with relative path", func(t *testing.T) {
 		outputLines, err := listDependentThrifts(filepath.Join(tmpDir, "test/b.thrift"), filepath.Join(tmpDir, "test"))
 		require.NoError(t, err)
 		sort.Strings(outputLines)
 		t.Logf("output lines: %+v", outputLines)
-		assert.Equal(t, 1, len(outputLines))
-		assert.Equal(t, "a.thrift", outputLines[0])
+		assert.Equal(t, []string{"a.thrift"}, outputLines)
 	})
 	t.Run("transitive and multiple dependencies", func(t *testing.T) {
 		outputLines, err := listDependentThrifts(filepath.Join(tmpDir, "test/d.thrift"), tmpDir)
 		require.NoError(t, err)
 		sort.Strings(outputLines)
 		t.Logf("output lines: %+v", outputLines)
-		assert.Equal(t, 3, len(outputLines))
-		assert.Equal(t, "test/a.thrift", outputLines[0])
-		assert.Equal(t, "test/b.thrift", outputLines[1])
-		assert.Equal(t, "test/c.thrift", outputLines[2])
+		assert.Equal(t, []string{"test/a.thrift", "test/b.thrift", "test/c.thrift"}, outputLines)
 	})
 	t.Run("with open error", func(t *testing.T) {
 		_, err := listDependentThrifts("/does-not-exist", "")

--- a/cmd/thriftrw-list-deps/main_test.go
+++ b/cmd/thriftrw-list-deps/main_test.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,37 +11,23 @@ import (
 
 func TestRecursiveImports(t *testing.T) {
 	t.Run("default options", func(t *testing.T) {
-		outputBuf := new(bytes.Buffer)
 		cwd, err := os.Getwd()
 		require.NoError(t, err)
 		idlRoot := filepath.Join(cwd, "../../gen/testdata/thrift")
-		err = do(idlRoot, filepath.Join(idlRoot, "structs.thrift"), outputBuf)
+		outputLines, err := listDependentThrifts(filepath.Join(idlRoot, "structs.thrift"), idlRoot)
 		require.NoError(t, err)
-		outputLines := strings.Split(outputBuf.String(), "\n")
 		t.Logf("output lines: %+v", outputLines)
-		assert.Equal(t, 2, len(outputLines))
+		assert.Equal(t, 1, len(outputLines))
 		assert.Equal(t, "enums.thrift", outputLines[0])
-		assert.Equal(t, "", outputLines[1])
 	})
 	t.Run("with relative path", func(t *testing.T) {
-		outputBuf := new(bytes.Buffer)
 		cwd, err := os.Getwd()
 		require.NoError(t, err)
 		idlRoot := filepath.Join(cwd, "../../gen/testdata/thrift")
-		err = do(filepath.Join(cwd, "../../"), filepath.Join(idlRoot, "structs.thrift"), outputBuf)
+		outputLines, err := listDependentThrifts(filepath.Join(idlRoot, "structs.thrift"), filepath.Join(cwd, "../../"))
 		require.NoError(t, err)
-		outputLines := strings.Split(outputBuf.String(), "\n")
 		t.Logf("output lines: %+v", outputLines)
-		assert.Equal(t, 2, len(outputLines))
+		assert.Equal(t, 1, len(outputLines))
 		assert.Equal(t, "gen/testdata/thrift/enums.thrift", outputLines[0])
-		assert.Equal(t, "", outputLines[1])
 	})
-}
-
-func ExampleUsage() {
-	cwd, _ := os.Getwd()
-	thriftrwRoot := filepath.Join(cwd, "../..")
-	do(thriftrwRoot, filepath.Join(thriftrwRoot, "gen/testdata/thrift/structs.thrift"), os.Stdout)
-	// Output:
-	// gen/testdata/thrift/enums.thrift
 }

--- a/cmd/thriftrw-list-deps/main_test.go
+++ b/cmd/thriftrw-list-deps/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecursiveImports(t *testing.T) {
+	t.Run("default options", func(t *testing.T) {
+		outputBuf := new(bytes.Buffer)
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		idlRoot := filepath.Join(cwd, "../../gen/testdata/thrift")
+		err = do(idlRoot, filepath.Join(idlRoot, "structs.thrift"), outputBuf)
+		require.NoError(t, err)
+		outputLines := strings.Split(outputBuf.String(), "\n")
+		t.Logf("output lines: %+v", outputLines)
+		assert.Equal(t, 2, len(outputLines))
+		assert.Equal(t, "enums.thrift", outputLines[0])
+		assert.Equal(t, "", outputLines[1])
+	})
+	t.Run("with relative path", func(t *testing.T) {
+		outputBuf := new(bytes.Buffer)
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		idlRoot := filepath.Join(cwd, "../../gen/testdata/thrift")
+		err = do(filepath.Join(cwd, "../../"), filepath.Join(idlRoot, "structs.thrift"), outputBuf)
+		require.NoError(t, err)
+		outputLines := strings.Split(outputBuf.String(), "\n")
+		t.Logf("output lines: %+v", outputLines)
+		assert.Equal(t, 2, len(outputLines))
+		assert.Equal(t, "gen/testdata/thrift/enums.thrift", outputLines[0])
+		assert.Equal(t, "", outputLines[1])
+	})
+}
+
+func ExampleUsage() {
+	cwd, _ := os.Getwd()
+	thriftrwRoot := filepath.Join(cwd, "../..")
+	do(thriftrwRoot, filepath.Join(thriftrwRoot, "gen/testdata/thrift/structs.thrift"), os.Stdout)
+	// Output:
+	// gen/testdata/thrift/enums.thrift
+}

--- a/cmd/thriftrw-list-deps/main_test.go
+++ b/cmd/thriftrw-list-deps/main_test.go
@@ -42,4 +42,12 @@ func TestRecursiveImports(t *testing.T) {
 		assert.Equal(t, "structs.thrift", outputLines[1])
 		assert.Equal(t, "typedefs.thrift", outputLines[2])
 	})
+	t.Run("with open error", func(t *testing.T) {
+		_, err := listDependentThrifts("/does-not-exist", "")
+		require.Error(t, err)
+	})
+	t.Run("with relative error", func(t *testing.T) {
+		_, err := listDependentThrifts(filepath.Join(idlRoot, "unions.thrift"), "./")
+		require.Error(t, err)
+	})
 }

--- a/cmd/thriftrw-list-deps/main_test.go
+++ b/cmd/thriftrw-list-deps/main_test.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"path/filepath"
-	"testing"
-
-	"sort"
-
 	"io/ioutil"
-
 	"os"
+	"path/filepath"
+	"sort"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/cmd/thriftrw-list-deps/main_test.go
+++ b/cmd/thriftrw-list-deps/main_test.go
@@ -1,53 +1,86 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"sort"
 
+	"io/ioutil"
+
+	"os"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRecursiveImports(t *testing.T) {
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	idlRoot := filepath.Join(cwd, "../../gen/testdata/thrift")
+func TestThriftrwListDeps(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Skipf("error creating temporary directory: %v", err)
+	}
 
-	t.Run("default options", func(t *testing.T) {
-		outputLines, err := listDependentThrifts(filepath.Join(idlRoot, "structs.thrift"), idlRoot)
+	defer os.RemoveAll(tmpDir)
+
+	exampleThrifts := map[string]string{
+		"test/a.thrift": "",
+		"test/b.thrift": `include "./a.thrift"`,
+		"test/c.thrift": `include "./a.thrift"`,
+		"test/d.thrift": `include "./b.thrift"
+include "./c.thrift"`,
+	}
+
+	for name, content := range exampleThrifts {
+		path := filepath.Join(tmpDir, name)
+		err = os.MkdirAll(filepath.Dir(path), 0755)
+		if err != nil {
+			t.Skipf("error mkdir %s: %v", path, err)
+		}
+		err = ioutil.WriteFile(path, []byte(content), 0644)
+		if err != nil {
+			t.Skipf("error writing %s: %v", path, err)
+		}
+	}
+
+	t.Run("no dependencies", func(t *testing.T) {
+		outputLines, err := listDependentThrifts(filepath.Join(tmpDir, "test/a.thrift"), tmpDir)
+		require.NoError(t, err)
+		sort.Strings(outputLines)
+		t.Logf("output lines: %+v", outputLines)
+		assert.Equal(t, 0, len(outputLines))
+	})
+	t.Run("one dependency", func(t *testing.T) {
+		outputLines, err := listDependentThrifts(filepath.Join(tmpDir, "test/b.thrift"), tmpDir)
 		require.NoError(t, err)
 		sort.Strings(outputLines)
 		t.Logf("output lines: %+v", outputLines)
 		assert.Equal(t, 1, len(outputLines))
-		assert.Equal(t, "enums.thrift", outputLines[0])
+		assert.Equal(t, "test/a.thrift", outputLines[0])
 	})
-	t.Run("with relative path", func(t *testing.T) {
-		outputLines, err := listDependentThrifts(filepath.Join(idlRoot, "structs.thrift"), filepath.Join(cwd, "../../"))
+	t.Run("one dependency with relative path", func(t *testing.T) {
+		outputLines, err := listDependentThrifts(filepath.Join(tmpDir, "test/b.thrift"), filepath.Join(tmpDir, "test"))
 		require.NoError(t, err)
 		sort.Strings(outputLines)
 		t.Logf("output lines: %+v", outputLines)
 		assert.Equal(t, 1, len(outputLines))
-		assert.Equal(t, "gen/testdata/thrift/enums.thrift", outputLines[0])
+		assert.Equal(t, "a.thrift", outputLines[0])
 	})
-	t.Run("with transitive dependency", func(t *testing.T) {
-		outputLines, err := listDependentThrifts(filepath.Join(idlRoot, "unions.thrift"), idlRoot)
+	t.Run("transitive and multiple dependencies", func(t *testing.T) {
+		outputLines, err := listDependentThrifts(filepath.Join(tmpDir, "test/d.thrift"), tmpDir)
 		require.NoError(t, err)
 		sort.Strings(outputLines)
 		t.Logf("output lines: %+v", outputLines)
 		assert.Equal(t, 3, len(outputLines))
-		assert.Equal(t, "enums.thrift", outputLines[0])
-		assert.Equal(t, "structs.thrift", outputLines[1])
-		assert.Equal(t, "typedefs.thrift", outputLines[2])
+		assert.Equal(t, "test/a.thrift", outputLines[0])
+		assert.Equal(t, "test/b.thrift", outputLines[1])
+		assert.Equal(t, "test/c.thrift", outputLines[2])
 	})
 	t.Run("with open error", func(t *testing.T) {
 		_, err := listDependentThrifts("/does-not-exist", "")
 		require.Error(t, err)
 	})
 	t.Run("with relative error", func(t *testing.T) {
-		_, err := listDependentThrifts(filepath.Join(idlRoot, "unions.thrift"), "./")
+		_, err := listDependentThrifts(filepath.Join(tmpDir, "test/b.thrift"), "./")
 		require.Error(t, err)
 	})
 }

--- a/cmd/thriftrw-list-deps/main_test.go
+++ b/cmd/thriftrw-list-deps/main_test.go
@@ -5,29 +5,41 @@ import (
 	"path/filepath"
 	"testing"
 
+	"sort"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRecursiveImports(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	idlRoot := filepath.Join(cwd, "../../gen/testdata/thrift")
+
 	t.Run("default options", func(t *testing.T) {
-		cwd, err := os.Getwd()
-		require.NoError(t, err)
-		idlRoot := filepath.Join(cwd, "../../gen/testdata/thrift")
 		outputLines, err := listDependentThrifts(filepath.Join(idlRoot, "structs.thrift"), idlRoot)
 		require.NoError(t, err)
+		sort.Strings(outputLines)
 		t.Logf("output lines: %+v", outputLines)
 		assert.Equal(t, 1, len(outputLines))
 		assert.Equal(t, "enums.thrift", outputLines[0])
 	})
 	t.Run("with relative path", func(t *testing.T) {
-		cwd, err := os.Getwd()
-		require.NoError(t, err)
-		idlRoot := filepath.Join(cwd, "../../gen/testdata/thrift")
 		outputLines, err := listDependentThrifts(filepath.Join(idlRoot, "structs.thrift"), filepath.Join(cwd, "../../"))
 		require.NoError(t, err)
+		sort.Strings(outputLines)
 		t.Logf("output lines: %+v", outputLines)
 		assert.Equal(t, 1, len(outputLines))
 		assert.Equal(t, "gen/testdata/thrift/enums.thrift", outputLines[0])
+	})
+	t.Run("with transitive dependency", func(t *testing.T) {
+		outputLines, err := listDependentThrifts(filepath.Join(idlRoot, "unions.thrift"), idlRoot)
+		require.NoError(t, err)
+		sort.Strings(outputLines)
+		t.Logf("output lines: %+v", outputLines)
+		assert.Equal(t, 3, len(outputLines))
+		assert.Equal(t, "enums.thrift", outputLines[0])
+		assert.Equal(t, "structs.thrift", outputLines[1])
+		assert.Equal(t, "typedefs.thrift", outputLines[2])
 	})
 }


### PR DESCRIPTION
Adds a tool that given a thrift file outputs the list of thrift files that the given file depends. This can be used for build tools that use file-based dependency rules. 