### PR TITLE
updateLicenses: Don't mess with gen/internal/tests

### DIFF
--- a/scripts/updateLicenses.sh
+++ b/scripts/updateLicenses.sh
@@ -3,4 +3,8 @@
 set -e
 set -x
 
-python "$(dirname $0)"/updateLicense.py $(go list -json $(glide nv) | jq -r '.Dir + "/" + (.GoFiles | .[])')
+python "$(dirname $0)"/updateLicense.py \
+	$(go list -json $(glide nv) \
+	| jq -r '.Dir + "/" + (.GoFiles | .[])' \
+	| grep -v /gen/internal/tests/ \
+	)


### PR DESCRIPTION
The golden test in gen/ relies on the exact contents of
gen/internal/tests so updateLicenses shouldn't mess with them.