### PR TITLE
make: Fix linting

### DIFF
--- a/gen/enum_test.go
+++ b/gen/enum_test.go
@@ -541,11 +541,11 @@ func TestEnumLabelConflict(t *testing.T) {
 			compile.EnumSpec{
 				Name: "duplicate item name",
 				Items: []compile.EnumItem{
-					compile.EnumItem{
+					{
 						Name:  "A",
 						Value: 0,
 					},
-					compile.EnumItem{
+					{
 						Name:  "B",
 						Value: 1,
 						Annotations: map[string]string{
@@ -561,14 +561,14 @@ func TestEnumLabelConflict(t *testing.T) {
 			compile.EnumSpec{
 				Name: "duplicate item name",
 				Items: []compile.EnumItem{
-					compile.EnumItem{
+					{
 						Name:  "A",
 						Value: 0,
 						Annotations: map[string]string{
 							"go.label": "C",
 						},
 					},
-					compile.EnumItem{
+					{
 						Name:  "B",
 						Value: 1,
 						Annotations: map[string]string{

--- a/gen/zap_test.go
+++ b/gen/zap_test.go
@@ -501,7 +501,7 @@ func TestTypedefsZapLogging(t *testing.T) {
 	testUUID := td.UUID(td.I128{High: 123, Low: 456})
 	testTimestamp := td.Timestamp(123)
 	test3 := td.EventGroup([]*td.Event{
-		&td.Event{
+		{
 			UUID: &testUUID,
 			Time: &testTimestamp,
 		},

--- a/internal/plugin/multi_test.go
+++ b/internal/plugin/multi_test.go
@@ -147,7 +147,7 @@ func TestMultiServiceGeneratorGenerate(t *testing.T) {
 					"foo/d.go": {1, 2, 3},
 				}}},
 				{success: &api.GenerateServiceResponse{Files: map[string][]byte{
-				// no files
+					// no files
 				}}},
 				{success: &api.GenerateServiceResponse{Files: map[string][]byte{
 					"foo/keyvalue/e.go": {4, 5, 6},

--- a/protocol/binary.go
+++ b/protocol/binary.go
@@ -230,6 +230,8 @@ type EnvelopeV0Responder struct {
 	SeqID int32
 }
 
+// EncodeResponse writes the response to the writer using a non-strict
+// envelope.
 func (r EnvelopeV0Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
 	writer := binary.BorrowWriter(w)
 	err := writer.WriteLegacyEnveloped(wire.Envelope{
@@ -248,6 +250,8 @@ type EnvelopeV1Responder struct {
 	SeqID int32
 }
 
+// EncodeResponse writes the response to the writer using a strict, version 1
+// envelope.
 func (r EnvelopeV1Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
 	writer := binary.BorrowWriter(w)
 	err := writer.WriteEnveloped(wire.Envelope{


### PR DESCRIPTION
Turns out we accidentally disabled linting because the specification of
which versions of Go we want to lint against was specified in two
places: the Makefile and the .travis.yml. The Makefile case was set to
1.8 and stopped being matched when we dropped Go 1.8 support.

This changes the opt-out in the Makefile, instead relying on the
.travis.yml to decide when to lint, and fixes any lint issues found
thereafter.