### PR TITLE
gen/enum: Fix int parsing for unmarshaling

### DIFF
--- a/envelope/internal/tests/enums/types.go
+++ b/envelope/internal/tests/enums/types.go
@@ -41,7 +41,7 @@ type EmptyEnum int32
 func (v *EmptyEnum) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EmptyEnum", err)
 		}
@@ -193,7 +193,7 @@ func (v *EnumDefault) UnmarshalText(value []byte) error {
 		*v = EnumDefaultBaz
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumDefault", err)
 		}
@@ -407,7 +407,7 @@ func (v *EnumWithDuplicateName) UnmarshalText(value []byte) error {
 		*v = EnumWithDuplicateNameZ
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumWithDuplicateName", err)
 		}
@@ -639,7 +639,7 @@ func (v *EnumWithDuplicateValues) UnmarshalText(value []byte) error {
 		*v = EnumWithDuplicateValuesR
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumWithDuplicateValues", err)
 		}
@@ -830,7 +830,7 @@ func (v *EnumWithLabel) UnmarshalText(value []byte) error {
 		*v = EnumWithLabelNaive4N1
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumWithLabel", err)
 		}
@@ -1038,7 +1038,7 @@ func (v *EnumWithValues) UnmarshalText(value []byte) error {
 		*v = EnumWithValuesZ
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumWithValues", err)
 		}
@@ -1230,7 +1230,7 @@ func (v *RecordType) UnmarshalText(value []byte) error {
 		*v = RecordTypeWorkAddress
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "RecordType", err)
 		}
@@ -1409,7 +1409,7 @@ func (v *RecordTypeValues) UnmarshalText(value []byte) error {
 		*v = RecordTypeValuesBar
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "RecordTypeValues", err)
 		}
@@ -1728,7 +1728,7 @@ func (v *LowerCaseEnum) UnmarshalText(value []byte) error {
 		*v = LowerCaseEnumItems
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "LowerCaseEnum", err)
 		}

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -115,7 +115,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 					return nil
 			<end ->
 				default:
-					<$val>, err := <$strconv>.ParseInt(<$s>, 10, 64)
+					<$val>, err := <$strconv>.ParseInt(<$s>, 10, 32)
 					if err != nil {
 						return <$fmt>.Errorf("unknown enum value %q for %q: %v", <$s>, "<$enumName>", err)
 					}

--- a/gen/internal/tests/collision/types.go
+++ b/gen/internal/tests/collision/types.go
@@ -428,7 +428,7 @@ func (v *MyEnum) UnmarshalText(value []byte) error {
 		*v = MyEnumFooBar2
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "MyEnum", err)
 		}
@@ -1577,7 +1577,7 @@ func (v *MyEnum2) UnmarshalText(value []byte) error {
 		*v = MyEnum2Z
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "MyEnum2", err)
 		}

--- a/gen/internal/tests/enum_conflict/types.go
+++ b/gen/internal/tests/enum_conflict/types.go
@@ -44,7 +44,7 @@ func (v *RecordType) UnmarshalText(value []byte) error {
 		*v = RecordTypeEmail
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "RecordType", err)
 		}

--- a/gen/internal/tests/enums/types.go
+++ b/gen/internal/tests/enums/types.go
@@ -21,7 +21,7 @@ type EmptyEnum int32
 func (v *EmptyEnum) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EmptyEnum", err)
 		}
@@ -173,7 +173,7 @@ func (v *EnumDefault) UnmarshalText(value []byte) error {
 		*v = EnumDefaultBaz
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumDefault", err)
 		}
@@ -387,7 +387,7 @@ func (v *EnumWithDuplicateName) UnmarshalText(value []byte) error {
 		*v = EnumWithDuplicateNameZ
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumWithDuplicateName", err)
 		}
@@ -619,7 +619,7 @@ func (v *EnumWithDuplicateValues) UnmarshalText(value []byte) error {
 		*v = EnumWithDuplicateValuesR
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumWithDuplicateValues", err)
 		}
@@ -810,7 +810,7 @@ func (v *EnumWithLabel) UnmarshalText(value []byte) error {
 		*v = EnumWithLabelNaive4N1
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumWithLabel", err)
 		}
@@ -1018,7 +1018,7 @@ func (v *EnumWithValues) UnmarshalText(value []byte) error {
 		*v = EnumWithValuesZ
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumWithValues", err)
 		}
@@ -1210,7 +1210,7 @@ func (v *RecordType) UnmarshalText(value []byte) error {
 		*v = RecordTypeWorkAddress
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "RecordType", err)
 		}
@@ -1389,7 +1389,7 @@ func (v *RecordTypeValues) UnmarshalText(value []byte) error {
 		*v = RecordTypeValuesBar
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "RecordTypeValues", err)
 		}
@@ -1708,7 +1708,7 @@ func (v *LowerCaseEnum) UnmarshalText(value []byte) error {
 		*v = LowerCaseEnumItems
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "LowerCaseEnum", err)
 		}

--- a/gen/internal/tests/nozap/types.go
+++ b/gen/internal/tests/nozap/types.go
@@ -48,7 +48,7 @@ func (v *EnumDefault) UnmarshalText(value []byte) error {
 		*v = EnumDefaultBaz
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EnumDefault", err)
 		}

--- a/internal/envelope/exception/types.go
+++ b/internal/envelope/exception/types.go
@@ -108,7 +108,7 @@ func (v *ExceptionType) UnmarshalText(value []byte) error {
 		*v = ExceptionTypeUnsupportedClientType
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "ExceptionType", err)
 		}

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -237,7 +237,7 @@ func (v *Feature) UnmarshalText(value []byte) error {
 		*v = FeatureServiceGenerator
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "Feature", err)
 		}
@@ -2763,7 +2763,7 @@ func (v *SimpleType) UnmarshalText(value []byte) error {
 		*v = SimpleTypeStructEmpty
 		return nil
 	default:
-		val, err := strconv.ParseInt(s, 10, 64)
+		val, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
 			return fmt.Errorf("unknown enum value %q for %q: %v", s, "SimpleType", err)
 		}


### PR DESCRIPTION
Enums are int32, so we should parse in 32-bit.