### PR TITLE
gen/struct: Make Equals nil-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - gen/enum: `MarshalText` and `UnmarshalText` now round-trips, even if
   the enum value is unrecognized.
 
+### Fixed
+- gen: Equals methods on generated structs no longer panic if either value is
+  nil.
+
 ## [1.12.0] - 2018-06-25
 ### Added
 - gen: Added `ThriftPackageImporter` to control import path

--- a/gen/field.go
+++ b/gen/field.go
@@ -454,6 +454,11 @@ func (f fieldGroupGenerator) Equals(g Generator) error {
 		//
 		// This function performs a deep comparison.
 		func (<$v> *<.Name>) Equals(<$rhs> *<.Name>) bool {
+			if <$v> == nil {
+				return <$rhs> == nil
+			} else if <$rhs> == nil {
+				return false
+			}
 			<range .Fields>
 				<- $fname := goName . ->
 				<- $lhsField := printf "%s.%s" $v $fname ->

--- a/gen/internal/tests/collision/types.go
+++ b/gen/internal/tests/collision/types.go
@@ -147,6 +147,11 @@ func _String_EqualsPtr(lhs, rhs *string) bool {
 //
 // This function performs a deep comparison.
 func (v *AccessorConflict) Equals(rhs *AccessorConflict) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_String_EqualsPtr(v.Name, rhs.Name) {
 		return false
 	}
@@ -311,6 +316,11 @@ func (v *AccessorNoConflict) String() string {
 //
 // This function performs a deep comparison.
 func (v *AccessorNoConflict) Equals(rhs *AccessorNoConflict) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_String_EqualsPtr(v.Getname, rhs.Getname) {
 		return false
 	}
@@ -931,6 +941,11 @@ func _Map_String_String_Equals(lhs, rhs map[string]string) bool {
 //
 // This function performs a deep comparison.
 func (v *PrimitiveContainers) Equals(rhs *PrimitiveContainers) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.A == nil && rhs.A == nil) || (v.A != nil && rhs.A != nil && _List_String_Equals(v.A, rhs.A))) {
 		return false
 	}
@@ -1150,6 +1165,11 @@ func (v *StructCollision) String() string {
 //
 // This function performs a deep comparison.
 func (v *StructCollision) Equals(rhs *StructCollision) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.CollisionField == rhs.CollisionField) {
 		return false
 	}
@@ -1323,6 +1343,11 @@ func _Bool_EqualsPtr(lhs, rhs *bool) bool {
 //
 // This function performs a deep comparison.
 func (v *UnionCollision) Equals(rhs *UnionCollision) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_Bool_EqualsPtr(v.CollisionField, rhs.CollisionField) {
 		return false
 	}
@@ -1481,6 +1506,11 @@ func (v *WithDefault) String() string {
 //
 // This function performs a deep comparison.
 func (v *WithDefault) Equals(rhs *WithDefault) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.Pouet == nil && rhs.Pouet == nil) || (v.Pouet != nil && rhs.Pouet != nil && v.Pouet.Equals(rhs.Pouet))) {
 		return false
 	}
@@ -1849,6 +1879,11 @@ func (v *StructCollision2) String() string {
 //
 // This function performs a deep comparison.
 func (v *StructCollision2) Equals(rhs *StructCollision2) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.CollisionField == rhs.CollisionField) {
 		return false
 	}
@@ -2012,6 +2047,11 @@ func (v *UnionCollision2) String() string {
 //
 // This function performs a deep comparison.
 func (v *UnionCollision2) Equals(rhs *UnionCollision2) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_Bool_EqualsPtr(v.CollisionField, rhs.CollisionField) {
 		return false
 	}

--- a/gen/internal/tests/containers/types.go
+++ b/gen/internal/tests/containers/types.go
@@ -1623,6 +1623,11 @@ func _Map_Set_I32_List_Double_Equals(lhs, rhs []struct {
 //
 // This function performs a deep comparison.
 func (v *ContainersOfContainers) Equals(rhs *ContainersOfContainers) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.ListOfLists == nil && rhs.ListOfLists == nil) || (v.ListOfLists != nil && rhs.ListOfLists != nil && _List_List_I32_Equals(v.ListOfLists, rhs.ListOfLists))) {
 		return false
 	}
@@ -2454,6 +2459,11 @@ func _Map_EnumWithDuplicateValues_I32_Equals(lhs, rhs map[enums.EnumWithDuplicat
 //
 // This function performs a deep comparison.
 func (v *EnumContainers) Equals(rhs *EnumContainers) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.ListOfEnums == nil && rhs.ListOfEnums == nil) || (v.ListOfEnums != nil && rhs.ListOfEnums != nil && _List_EnumDefault_Equals(v.ListOfEnums, rhs.ListOfEnums))) {
 		return false
 	}
@@ -2829,6 +2839,11 @@ func _List_RecordType_1_Equals(lhs, rhs []enums.RecordType) bool {
 //
 // This function performs a deep comparison.
 func (v *ListOfConflictingEnums) Equals(rhs *ListOfConflictingEnums) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_List_RecordType_Equals(v.Records, rhs.Records) {
 		return false
 	}
@@ -3145,6 +3160,11 @@ func _List_UUID_1_Equals(lhs, rhs []uuid_conflict.UUID) bool {
 //
 // This function performs a deep comparison.
 func (v *ListOfConflictingUUIDs) Equals(rhs *ListOfConflictingUUIDs) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_List_UUID_Equals(v.Uuids, rhs.Uuids) {
 		return false
 	}
@@ -3516,6 +3536,11 @@ func _Map_String_Binary_Equals(lhs, rhs map[string][]byte) bool {
 //
 // This function performs a deep comparison.
 func (v *MapOfBinaryAndString) Equals(rhs *MapOfBinaryAndString) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.BinaryToString == nil && rhs.BinaryToString == nil) || (v.BinaryToString != nil && rhs.BinaryToString != nil && _Map_Binary_String_Equals(v.BinaryToString, rhs.BinaryToString))) {
 		return false
 	}
@@ -4149,6 +4174,11 @@ func _Map_String_Bool_Equals(lhs, rhs map[string]bool) bool {
 //
 // This function performs a deep comparison.
 func (v *PrimitiveContainers) Equals(rhs *PrimitiveContainers) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.ListOfBinary == nil && rhs.ListOfBinary == nil) || (v.ListOfBinary != nil && rhs.ListOfBinary != nil && _List_Binary_Equals(v.ListOfBinary, rhs.ListOfBinary))) {
 		return false
 	}
@@ -4569,6 +4599,11 @@ func _Map_I64_Double_Equals(lhs, rhs map[int64]float64) bool {
 //
 // This function performs a deep comparison.
 func (v *PrimitiveContainersRequired) Equals(rhs *PrimitiveContainersRequired) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_List_String_Equals(v.ListOfStrings, rhs.ListOfStrings) {
 		return false
 	}

--- a/gen/internal/tests/enum_conflict/types.go
+++ b/gen/internal/tests/enum_conflict/types.go
@@ -362,6 +362,11 @@ func _RecordType_1_EqualsPtr(lhs, rhs *enums.RecordType) bool {
 //
 // This function performs a deep comparison.
 func (v *Records) Equals(rhs *Records) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_RecordType_EqualsPtr(v.RecordType, rhs.RecordType) {
 		return false
 	}

--- a/gen/internal/tests/enums/types.go
+++ b/gen/internal/tests/enums/types.go
@@ -1646,6 +1646,11 @@ func _EnumDefault_EqualsPtr(lhs, rhs *EnumDefault) bool {
 //
 // This function performs a deep comparison.
 func (v *StructWithOptionalEnum) Equals(rhs *StructWithOptionalEnum) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_EnumDefault_EqualsPtr(v.E, rhs.E) {
 		return false
 	}

--- a/gen/internal/tests/exceptions/types.go
+++ b/gen/internal/tests/exceptions/types.go
@@ -145,6 +145,11 @@ func _String_EqualsPtr(lhs, rhs *string) bool {
 //
 // This function performs a deep comparison.
 func (v *DoesNotExistException) Equals(rhs *DoesNotExistException) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Key == rhs.Key) {
 		return false
 	}
@@ -255,6 +260,11 @@ func (v *EmptyException) String() string {
 //
 // This function performs a deep comparison.
 func (v *EmptyException) Equals(rhs *EmptyException) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }

--- a/gen/internal/tests/nozap/types.go
+++ b/gen/internal/tests/nozap/types.go
@@ -716,6 +716,11 @@ func _Map_I64_Double_Equals(lhs, rhs map[int64]float64) bool {
 //
 // This function performs a deep comparison.
 func (v *PrimitiveRequiredStruct) Equals(rhs *PrimitiveRequiredStruct) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.BoolField == rhs.BoolField) {
 		return false
 	}

--- a/gen/internal/tests/services/cache_clear.go
+++ b/gen/internal/tests/services/cache_clear.go
@@ -85,6 +85,11 @@ func (v *Cache_Clear_Args) String() string {
 //
 // This function performs a deep comparison.
 func (v *Cache_Clear_Args) Equals(rhs *Cache_Clear_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }

--- a/gen/internal/tests/services/cache_clearafter.go
+++ b/gen/internal/tests/services/cache_clearafter.go
@@ -122,6 +122,11 @@ func _I64_EqualsPtr(lhs, rhs *int64) bool {
 //
 // This function performs a deep comparison.
 func (v *Cache_ClearAfter_Args) Equals(rhs *Cache_ClearAfter_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_I64_EqualsPtr(v.DurationMS, rhs.DurationMS) {
 		return false
 	}

--- a/gen/internal/tests/services/conflictingnames_setvalue.go
+++ b/gen/internal/tests/services/conflictingnames_setvalue.go
@@ -116,6 +116,11 @@ func (v *ConflictingNames_SetValue_Args) String() string {
 //
 // This function performs a deep comparison.
 func (v *ConflictingNames_SetValue_Args) Equals(rhs *ConflictingNames_SetValue_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.Request == nil && rhs.Request == nil) || (v.Request != nil && rhs.Request != nil && v.Request.Equals(rhs.Request))) {
 		return false
 	}
@@ -309,6 +314,11 @@ func (v *ConflictingNames_SetValue_Result) String() string {
 //
 // This function performs a deep comparison.
 func (v *ConflictingNames_SetValue_Result) Equals(rhs *ConflictingNames_SetValue_Result) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }

--- a/gen/internal/tests/services/keyvalue_deletevalue.go
+++ b/gen/internal/tests/services/keyvalue_deletevalue.go
@@ -130,6 +130,11 @@ func _Key_EqualsPtr(lhs, rhs *Key) bool {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_DeleteValue_Args) Equals(rhs *KeyValue_DeleteValue_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_Key_EqualsPtr(v.Key, rhs.Key) {
 		return false
 	}
@@ -420,6 +425,11 @@ func (v *KeyValue_DeleteValue_Result) String() string {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_DeleteValue_Result) Equals(rhs *KeyValue_DeleteValue_Result) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.DoesNotExist == nil && rhs.DoesNotExist == nil) || (v.DoesNotExist != nil && rhs.DoesNotExist != nil && v.DoesNotExist.Equals(rhs.DoesNotExist))) {
 		return false
 	}

--- a/gen/internal/tests/services/keyvalue_getmanyvalues.go
+++ b/gen/internal/tests/services/keyvalue_getmanyvalues.go
@@ -172,6 +172,11 @@ func _List_Key_Equals(lhs, rhs []Key) bool {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_GetManyValues_Args) Equals(rhs *KeyValue_GetManyValues_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.Range == nil && rhs.Range == nil) || (v.Range != nil && rhs.Range != nil && _List_Key_Equals(v.Range, rhs.Range))) {
 		return false
 	}
@@ -528,6 +533,11 @@ func _List_ArbitraryValue_Equals(lhs, rhs []*unions.ArbitraryValue) bool {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_GetManyValues_Result) Equals(rhs *KeyValue_GetManyValues_Result) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.Success == nil && rhs.Success == nil) || (v.Success != nil && rhs.Success != nil && _List_ArbitraryValue_Equals(v.Success, rhs.Success))) {
 		return false
 	}

--- a/gen/internal/tests/services/keyvalue_getvalue.go
+++ b/gen/internal/tests/services/keyvalue_getvalue.go
@@ -115,6 +115,11 @@ func (v *KeyValue_GetValue_Args) String() string {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_GetValue_Args) Equals(rhs *KeyValue_GetValue_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_Key_EqualsPtr(v.Key, rhs.Key) {
 		return false
 	}
@@ -390,6 +395,11 @@ func (v *KeyValue_GetValue_Result) String() string {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_GetValue_Result) Equals(rhs *KeyValue_GetValue_Result) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.Success == nil && rhs.Success == nil) || (v.Success != nil && rhs.Success != nil && v.Success.Equals(rhs.Success))) {
 		return false
 	}

--- a/gen/internal/tests/services/keyvalue_setvalue.go
+++ b/gen/internal/tests/services/keyvalue_setvalue.go
@@ -134,6 +134,11 @@ func (v *KeyValue_SetValue_Args) String() string {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_SetValue_Args) Equals(rhs *KeyValue_SetValue_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_Key_EqualsPtr(v.Key, rhs.Key) {
 		return false
 	}
@@ -346,6 +351,11 @@ func (v *KeyValue_SetValue_Result) String() string {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_SetValue_Result) Equals(rhs *KeyValue_SetValue_Result) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }

--- a/gen/internal/tests/services/keyvalue_setvaluev2.go
+++ b/gen/internal/tests/services/keyvalue_setvaluev2.go
@@ -143,6 +143,11 @@ func (v *KeyValue_SetValueV2_Args) String() string {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_SetValueV2_Args) Equals(rhs *KeyValue_SetValueV2_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Key == rhs.Key) {
 		return false
 	}
@@ -339,6 +344,11 @@ func (v *KeyValue_SetValueV2_Result) String() string {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_SetValueV2_Result) Equals(rhs *KeyValue_SetValueV2_Result) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }

--- a/gen/internal/tests/services/keyvalue_size.go
+++ b/gen/internal/tests/services/keyvalue_size.go
@@ -86,6 +86,11 @@ func (v *KeyValue_Size_Args) String() string {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_Size_Args) Equals(rhs *KeyValue_Size_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }
@@ -303,6 +308,11 @@ func (v *KeyValue_Size_Result) String() string {
 //
 // This function performs a deep comparison.
 func (v *KeyValue_Size_Result) Equals(rhs *KeyValue_Size_Result) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_I64_EqualsPtr(v.Success, rhs.Success) {
 		return false
 	}

--- a/gen/internal/tests/services/non_standard_service_name_non_standard_function_name.go
+++ b/gen/internal/tests/services/non_standard_service_name_non_standard_function_name.go
@@ -85,6 +85,11 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) String() string {
 //
 // This function performs a deep comparison.
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) Equals(rhs *NonStandardServiceName_NonStandardFunctionName_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }
@@ -254,6 +259,11 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) String() string 
 //
 // This function performs a deep comparison.
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) Equals(rhs *NonStandardServiceName_NonStandardFunctionName_Result) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }

--- a/gen/internal/tests/services/types.go
+++ b/gen/internal/tests/services/types.go
@@ -137,6 +137,11 @@ func (v *ConflictingNamesSetValueArgs) String() string {
 //
 // This function performs a deep comparison.
 func (v *ConflictingNamesSetValueArgs) Equals(rhs *ConflictingNamesSetValueArgs) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Key == rhs.Key) {
 		return false
 	}
@@ -272,6 +277,11 @@ func _String_EqualsPtr(lhs, rhs *string) bool {
 //
 // This function performs a deep comparison.
 func (v *InternalError) Equals(rhs *InternalError) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_String_EqualsPtr(v.Message, rhs.Message) {
 		return false
 	}

--- a/gen/internal/tests/structs/types.go
+++ b/gen/internal/tests/structs/types.go
@@ -114,6 +114,11 @@ func (v *ContactInfo) String() string {
 //
 // This function performs a deep comparison.
 func (v *ContactInfo) Equals(rhs *ContactInfo) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.EmailAddress == rhs.EmailAddress) {
 		return false
 	}
@@ -650,6 +655,11 @@ func _List_Double_Equals(lhs, rhs []float64) bool {
 //
 // This function performs a deep comparison.
 func (v *DefaultsStruct) Equals(rhs *DefaultsStruct) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_I32_EqualsPtr(v.RequiredPrimitive, rhs.RequiredPrimitive) {
 		return false
 	}
@@ -980,6 +990,11 @@ func (v *Edge) String() string {
 //
 // This function performs a deep comparison.
 func (v *Edge) Equals(rhs *Edge) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !v.StartPoint.Equals(rhs.StartPoint) {
 		return false
 	}
@@ -1082,6 +1097,11 @@ func (v *EmptyStruct) String() string {
 //
 // This function performs a deep comparison.
 func (v *EmptyStruct) Equals(rhs *EmptyStruct) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }
@@ -1225,6 +1245,11 @@ func (v *Frame) String() string {
 //
 // This function performs a deep comparison.
 func (v *Frame) Equals(rhs *Frame) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !v.TopLeft.Equals(rhs.TopLeft) {
 		return false
 	}
@@ -1481,6 +1506,11 @@ func _String_EqualsPtr(lhs, rhs *string) bool {
 //
 // This function performs a deep comparison.
 func (v *GoTags) Equals(rhs *GoTags) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Foo == rhs.Foo) {
 		return false
 	}
@@ -1723,6 +1753,11 @@ func _List_Edge_Equals(lhs, rhs []*Edge) bool {
 //
 // This function performs a deep comparison.
 func (v *Graph) Equals(rhs *Graph) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_List_Edge_Equals(v.Edges, rhs.Edges) {
 		return false
 	}
@@ -1917,6 +1952,11 @@ func (v *Node) String() string {
 //
 // This function performs a deep comparison.
 func (v *Node) Equals(rhs *Node) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Value == rhs.Value) {
 		return false
 	}
@@ -2075,6 +2115,11 @@ func (v *Omit) String() string {
 //
 // This function performs a deep comparison.
 func (v *Omit) Equals(rhs *Omit) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Serialized == rhs.Serialized) {
 		return false
 	}
@@ -2224,6 +2269,11 @@ func (v *Point) String() string {
 //
 // This function performs a deep comparison.
 func (v *Point) Equals(rhs *Point) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.X == rhs.X) {
 		return false
 	}
@@ -2561,6 +2611,11 @@ func _Double_EqualsPtr(lhs, rhs *float64) bool {
 //
 // This function performs a deep comparison.
 func (v *PrimitiveOptionalStruct) Equals(rhs *PrimitiveOptionalStruct) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_Bool_EqualsPtr(v.BoolField, rhs.BoolField) {
 		return false
 	}
@@ -2964,6 +3019,11 @@ func (v *PrimitiveRequiredStruct) String() string {
 //
 // This function performs a deep comparison.
 func (v *PrimitiveRequiredStruct) Equals(rhs *PrimitiveRequiredStruct) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.BoolField == rhs.BoolField) {
 		return false
 	}
@@ -3160,6 +3220,11 @@ func (v *Rename) String() string {
 //
 // This function performs a deep comparison.
 func (v *Rename) Equals(rhs *Rename) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Default == rhs.Default) {
 		return false
 	}
@@ -3311,6 +3376,11 @@ func (v *Size) String() string {
 //
 // This function performs a deep comparison.
 func (v *Size) Equals(rhs *Size) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Width == rhs.Width) {
 		return false
 	}
@@ -3505,6 +3575,11 @@ func (v *StructLabels) String() string {
 //
 // This function performs a deep comparison.
 func (v *StructLabels) Equals(rhs *StructLabels) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_Bool_EqualsPtr(v.IsRequired, rhs.IsRequired) {
 		return false
 	}
@@ -3705,6 +3780,11 @@ func (v *User) String() string {
 //
 // This function performs a deep comparison.
 func (v *User) Equals(rhs *User) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Name == rhs.Name) {
 		return false
 	}
@@ -3863,6 +3943,11 @@ func (v *ZapOptOutStruct) String() string {
 //
 // This function performs a deep comparison.
 func (v *ZapOptOutStruct) Equals(rhs *ZapOptOutStruct) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.Name == rhs.Name) {
 		return false
 	}

--- a/gen/internal/tests/typedefs/types.go
+++ b/gen/internal/tests/typedefs/types.go
@@ -256,6 +256,11 @@ func _State_EqualsPtr(lhs, rhs *State) bool {
 //
 // This function performs a deep comparison.
 func (v *DefaultPrimitiveTypedef) Equals(rhs *DefaultPrimitiveTypedef) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_State_EqualsPtr(v.State, rhs.State) {
 		return false
 	}
@@ -633,6 +638,11 @@ func _Timestamp_EqualsPtr(lhs, rhs *Timestamp) bool {
 //
 // This function performs a deep comparison.
 func (v *Event) Equals(rhs *Event) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !v.UUID.Equals(rhs.UUID) {
 		return false
 	}
@@ -1524,6 +1534,11 @@ func (v *Transition) String() string {
 //
 // This function performs a deep comparison.
 func (v *Transition) Equals(rhs *Transition) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.FromState == rhs.FromState) {
 		return false
 	}
@@ -1723,6 +1738,11 @@ func (v *I128) String() string {
 //
 // This function performs a deep comparison.
 func (v *I128) Equals(rhs *I128) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.High == rhs.High) {
 		return false
 	}

--- a/gen/internal/tests/unions/types.go
+++ b/gen/internal/tests/unions/types.go
@@ -413,6 +413,11 @@ func _Map_String_ArbitraryValue_Equals(lhs, rhs map[string]*ArbitraryValue) bool
 //
 // This function performs a deep comparison.
 func (v *ArbitraryValue) Equals(rhs *ArbitraryValue) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !_Bool_EqualsPtr(v.BoolValue, rhs.BoolValue) {
 		return false
 	}
@@ -674,6 +679,11 @@ func (v *Document) String() string {
 //
 // This function performs a deep comparison.
 func (v *Document) Equals(rhs *Document) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !((v.Pdf == nil && rhs.Pdf == nil) || (v.Pdf != nil && rhs.Pdf != nil && v.Pdf.Equals(rhs.Pdf))) {
 		return false
 	}
@@ -788,6 +798,11 @@ func (v *EmptyUnion) String() string {
 //
 // This function performs a deep comparison.
 func (v *EmptyUnion) Equals(rhs *EmptyUnion) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 
 	return true
 }

--- a/gen/internal/tests/uuid_conflict/types.go
+++ b/gen/internal/tests/uuid_conflict/types.go
@@ -179,6 +179,11 @@ func (v *UUIDConflict) String() string {
 //
 // This function performs a deep comparison.
 func (v *UUIDConflict) Equals(rhs *UUIDConflict) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
 	if !(v.LocalUUID == rhs.LocalUUID) {
 		return false
 	}

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -29,6 +29,7 @@ import (
 	tc "go.uber.org/thriftrw/gen/internal/tests/containers"
 	te "go.uber.org/thriftrw/gen/internal/tests/enums"
 	tx "go.uber.org/thriftrw/gen/internal/tests/exceptions"
+	tf "go.uber.org/thriftrw/gen/internal/tests/services"
 	ts "go.uber.org/thriftrw/gen/internal/tests/structs"
 	td "go.uber.org/thriftrw/gen/internal/tests/typedefs"
 	tu "go.uber.org/thriftrw/gen/internal/tests/unions"
@@ -1858,20 +1859,109 @@ func TestStructLabel(t *testing.T) {
 }
 
 func TestNilStructEquals(t *testing.T) {
-	t.Run("both nil", func(t *testing.T) {
-		var x, y *ts.Graph
-		assert.True(t, x.Equals(y))
-	})
+	structTypes := []interface{}{
+		te.StructWithOptionalEnum{},
+		tx.DoesNotExistException{},
+		tx.EmptyException{},
+		tu.ArbitraryValue{},
+		tu.Document{},
+		tu.EmptyUnion{},
+		td.DefaultPrimitiveTypedef{},
+		td.Event{},
+		td.Transition{},
+		td.I128{},
+		tf.Cache_Clear_Args{},
+		ts.ContactInfo{},
+		ts.DefaultsStruct{},
+		ts.Edge{},
+		ts.EmptyStruct{},
+		ts.Frame{},
+		ts.GoTags{},
+		ts.Graph{},
+		ts.Node{},
+		ts.Omit{},
+		ts.Point{},
+		ts.PrimitiveOptionalStruct{},
+		ts.PrimitiveRequiredStruct{},
+		ts.Rename{},
+		ts.Size{},
+		ts.StructLabels{},
+		ts.User{},
+		ts.ZapOptOutStruct{},
+		tc.ContainersOfContainers{},
+		tc.EnumContainers{},
+		tc.ListOfConflictingEnums{},
+		tc.ListOfConflictingUUIDs{},
+		tc.MapOfBinaryAndString{},
+		tc.PrimitiveContainers{},
+		tc.PrimitiveContainersRequired{},
+		tf.ConflictingNames_SetValue_Args{},
+		tf.ConflictingNames_SetValue_Result{},
+		tf.KeyValue_GetManyValues_Args{},
+		tf.KeyValue_GetManyValues_Result{},
+		tf.ConflictingNamesSetValueArgs{},
+		tf.InternalError{},
+		tf.KeyValue_SetValueV2_Args{},
+		tf.KeyValue_SetValueV2_Result{},
+		tf.KeyValue_SetValue_Args{},
+		tf.KeyValue_SetValue_Result{},
+		tf.KeyValue_DeleteValue_Args{},
+		tf.KeyValue_DeleteValue_Result{},
+		tf.KeyValue_GetValue_Args{},
+		tf.KeyValue_GetValue_Result{},
+		tf.NonStandardServiceName_NonStandardFunctionName_Args{},
+		tf.NonStandardServiceName_NonStandardFunctionName_Result{},
+		tf.Cache_ClearAfter_Args{},
+		tf.KeyValue_Size_Args{},
+		tf.KeyValue_Size_Result{},
+	}
 
-	t.Run("lhs not nil", func(t *testing.T) {
-		x := &ts.Graph{}
-		var y *ts.Graph
-		assert.False(t, x.Equals(y))
-	})
+	for _, st := range structTypes {
+		structType := reflect.TypeOf(st)
+		ptrType := reflect.PtrTo(structType)
 
-	t.Run("rhs not nil", func(t *testing.T) {
-		var x *ts.Graph
-		y := &ts.Graph{}
-		assert.False(t, x.Equals(y))
-	})
+		t.Run(structType.Name(), func(t *testing.T) {
+			t.Run("both nil", func(t *testing.T) {
+				// var x, y *Type
+				x := reflect.New(ptrType).Elem()
+				y := reflect.New(ptrType).Elem()
+
+				// x.Equals(y)
+				result := x.MethodByName("Equals").
+					Call([]reflect.Value{y})[0].
+					Interface().(bool)
+
+				assert.True(t, result)
+			})
+
+			t.Run("lhs not nil", func(t *testing.T) {
+				// var x Type
+				// var y *Type
+				x := reflect.New(structType)
+				y := reflect.New(ptrType).Elem()
+
+				// x.Equals(y)
+				result := x.MethodByName("Equals").
+					Call([]reflect.Value{y})[0].
+					Interface().(bool)
+
+				assert.False(t, result)
+			})
+
+			t.Run("rhs not nil", func(t *testing.T) {
+				// var x *Type
+				// var y Type
+				x := reflect.New(ptrType).Elem()
+				y := reflect.New(structType)
+
+				// x.Equals(y)
+				result := x.MethodByName("Equals").
+					Call([]reflect.Value{y})[0].
+					Interface().(bool)
+
+				assert.False(t, result)
+			})
+		})
+	}
+
 }

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1859,7 +1859,8 @@ func TestStructLabel(t *testing.T) {
 }
 
 func TestNilStructEquals(t *testing.T) {
-	structTypes := []interface{}{
+	// Samples of values being tested.
+	samples := []interface{}{
 		te.StructWithOptionalEnum{},
 		tx.DoesNotExistException{},
 		tx.EmptyException{},
@@ -1916,8 +1917,8 @@ func TestNilStructEquals(t *testing.T) {
 		tf.KeyValue_Size_Result{},
 	}
 
-	for _, st := range structTypes {
-		structType := reflect.TypeOf(st)
+	for _, sample := range samples {
+		structType := reflect.TypeOf(sample)
 		ptrType := reflect.PtrTo(structType)
 
 		t.Run(structType.Name(), func(t *testing.T) {

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1856,3 +1856,22 @@ func TestStructLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestNilStructEquals(t *testing.T) {
+	t.Run("both nil", func(t *testing.T) {
+		var x, y *ts.Graph
+		assert.True(t, x.Equals(y))
+	})
+
+	t.Run("lhs not nil", func(t *testing.T) {
+		x := &ts.Graph{}
+		var y *ts.Graph
+		assert.False(t, x.Equals(y))
+	})
+
+	t.Run("rhs not nil", func(t *testing.T) {
+		var x *ts.Graph
+		y := &ts.Graph{}
+		assert.False(t, x.Equals(y))
+	})
+}


### PR DESCRIPTION
The generated Equals methods on structs weren't nil safe and would panic
if either value was nil. This change adds a nil check on the generated
Equals methods. Two structs are considered equal if they're both nil.

Resolves #345