### PR TITLE
gen: testing/quick based tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - gen: Equals methods on generated structs no longer panic if either value is
   nil.
+- gen: Fixed a bug where `*_Values` functions for empty enums would not be
+  generated.
 
 ## [1.12.0] - 2018-06-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - gen: Added support for a `go.label` annotation that allows overriding the
   user-readable string names of enum items and struct fields. This has no
   effect on the names of the generated Go entities.
-- Generated types now implement zapcore.ObjectMarshaler or
-  zapcore.ArrayMarshaler where appropriate. This should lead to much faster
+- Generated types now implement `zapcore.ObjectMarshaler` or
+  `zapcore.ArrayMarshaler` where appropriate. This should lead to much faster
   logging of these objects.
 - Added `go.nolog` annotation for struct fields: Those with
   this annotation will not be included in Zap logging.
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   nil.
 - gen: Fixed a bug where `*_Values` functions for empty enums would not be
   generated.
+- gen: Fixed infinite loop in generated `Equals` methods of specific typedefs.
 
 ## [1.12.0] - 2018-06-25
 ### Added

--- a/gen/collision_test.go
+++ b/gen/collision_test.go
@@ -557,17 +557,13 @@ func roundTrip(t *testing.T, x thriftType, msg string) thriftType {
 		xType = xType.Elem()
 	}
 
-	gotX := reflect.New(xType)
-	errval := gotX.MethodByName("FromWire").
-		Call([]reflect.Value{reflect.ValueOf(newV)})[0].
-		Interface()
-
-	if !assert.Nil(t, errval, "FromWire: %v", msg) {
+	gotX := reflect.New(xType).Interface().(thriftType)
+	if err := gotX.FromWire(newV); !assert.NoError(t, err, "FromWire: %v", msg) {
 		return nil
 	}
 
-	assert.Equal(t, x, gotX.Interface(), "FromWire: %v", msg)
-	return gotX.Interface().(thriftType)
+	assert.Equal(t, x, gotX, "FromWire: %v", msg)
+	return gotX
 }
 
 func TestCollisionAccessors(t *testing.T) {

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -79,6 +79,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 				<- formatDoc .Doc><enumItemName $enumName .> <$enumName> = <.Value>
 			<end>
 			)
+		<end>
 
 		// <$enumName>_Values returns all recognized values of <$enumName>.
 		func <$enumName>_Values() []<$enumName> {
@@ -88,7 +89,6 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 				<end>
 			}
 		}
-		<end>
 
 		<$v := newVar "v">
 		<$value := newVar "value">

--- a/gen/internal/tests/collision/types.go
+++ b/gen/internal/tests/collision/types.go
@@ -392,7 +392,7 @@ func (v *LittlePotatoe) FromWire(w wire.Value) error {
 // Equals returns true if this LittlePotatoe is equal to the provided
 // LittlePotatoe.
 func (lhs LittlePotatoe) Equals(rhs LittlePotatoe) bool {
-	return (lhs == rhs)
+	return ((int64)(lhs) == (int64)(rhs))
 }
 
 type MyEnum int32
@@ -1563,7 +1563,7 @@ func (v *LittlePotatoe2) FromWire(w wire.Value) error {
 // Equals returns true if this LittlePotatoe2 is equal to the provided
 // LittlePotatoe2.
 func (lhs LittlePotatoe2) Equals(rhs LittlePotatoe2) bool {
-	return (lhs == rhs)
+	return ((float64)(lhs) == (float64)(rhs))
 }
 
 type MyEnum2 int32

--- a/gen/internal/tests/enums/types.go
+++ b/gen/internal/tests/enums/types.go
@@ -17,6 +17,11 @@ import (
 
 type EmptyEnum int32
 
+// EmptyEnum_Values returns all recognized values of EmptyEnum.
+func EmptyEnum_Values() []EmptyEnum {
+	return []EmptyEnum{}
+}
+
 // UnmarshalText tries to decode EmptyEnum from a byte slice
 // containing its name.
 func (v *EmptyEnum) UnmarshalText(value []byte) error {

--- a/gen/internal/tests/nozap/types.go
+++ b/gen/internal/tests/nozap/types.go
@@ -861,7 +861,7 @@ func (v *StringList) FromWire(w wire.Value) error {
 // Equals returns true if this StringList is equal to the provided
 // StringList.
 func (lhs StringList) Equals(rhs StringList) bool {
-	return _List_String_Equals(lhs, rhs)
+	return _List_String_Equals(([]string)(lhs), ([]string)(rhs))
 }
 
 type _Map_String_String_MapItemList map[string]string
@@ -972,5 +972,5 @@ func (v *StringMap) FromWire(w wire.Value) error {
 // Equals returns true if this StringMap is equal to the provided
 // StringMap.
 func (lhs StringMap) Equals(rhs StringMap) bool {
-	return _Map_String_String_Equals(lhs, rhs)
+	return _Map_String_String_Equals((map[string]string)(lhs), (map[string]string)(rhs))
 }

--- a/gen/internal/tests/services/types.go
+++ b/gen/internal/tests/services/types.go
@@ -340,5 +340,5 @@ func (v *Key) FromWire(w wire.Value) error {
 // Equals returns true if this Key is equal to the provided
 // Key.
 func (lhs Key) Equals(rhs Key) bool {
-	return (lhs == rhs)
+	return ((string)(lhs) == (string)(rhs))
 }

--- a/gen/internal/tests/structs/types.go
+++ b/gen/internal/tests/structs/types.go
@@ -3922,7 +3922,7 @@ func (v *UserMap) FromWire(w wire.Value) error {
 // Equals returns true if this UserMap is equal to the provided
 // UserMap.
 func (lhs UserMap) Equals(rhs UserMap) bool {
-	return _Map_String_User_Equals(lhs, rhs)
+	return _Map_String_User_Equals((map[string]*User)(lhs), (map[string]*User)(rhs))
 }
 
 func (v UserMap) MarshalLogObject(enc zapcore.ObjectEncoder) error {

--- a/gen/internal/tests/typedefs/types.go
+++ b/gen/internal/tests/typedefs/types.go
@@ -124,7 +124,7 @@ func (v *BinarySet) FromWire(w wire.Value) error {
 // Equals returns true if this BinarySet is equal to the provided
 // BinarySet.
 func (lhs BinarySet) Equals(rhs BinarySet) bool {
-	return _Set_Binary_Equals(lhs, rhs)
+	return _Set_Binary_Equals(([][]byte)(lhs), ([][]byte)(rhs))
 }
 
 func (v BinarySet) MarshalLogArray(enc zapcore.ArrayEncoder) error {
@@ -476,7 +476,13 @@ func (v *EdgeMap) FromWire(w wire.Value) error {
 // Equals returns true if this EdgeMap is equal to the provided
 // EdgeMap.
 func (lhs EdgeMap) Equals(rhs EdgeMap) bool {
-	return _Map_Edge_Edge_Equals(lhs, rhs)
+	return _Map_Edge_Edge_Equals(([]struct {
+		Key   *structs.Edge
+		Value *structs.Edge
+	})(lhs), ([]struct {
+		Key   *structs.Edge
+		Value *structs.Edge
+	})(rhs))
 }
 
 func (v EdgeMap) MarshalLogArray(enc zapcore.ArrayEncoder) error {
@@ -779,7 +785,7 @@ func (v *EventGroup) FromWire(w wire.Value) error {
 // Equals returns true if this EventGroup is equal to the provided
 // EventGroup.
 func (lhs EventGroup) Equals(rhs EventGroup) bool {
-	return _List_Event_Equals(lhs, rhs)
+	return _List_Event_Equals(([]*Event)(lhs), ([]*Event)(rhs))
 }
 
 func (v EventGroup) MarshalLogArray(enc zapcore.ArrayEncoder) error {
@@ -900,7 +906,7 @@ func (v *FrameGroup) FromWire(w wire.Value) error {
 // Equals returns true if this FrameGroup is equal to the provided
 // FrameGroup.
 func (lhs FrameGroup) Equals(rhs FrameGroup) bool {
-	return _Set_Frame_Equals(lhs, rhs)
+	return _Set_Frame_Equals(([]*structs.Frame)(lhs), ([]*structs.Frame)(rhs))
 }
 
 func (v FrameGroup) MarshalLogArray(enc zapcore.ArrayEncoder) error {
@@ -941,7 +947,7 @@ func (v *MyEnum) FromWire(w wire.Value) error {
 // Equals returns true if this MyEnum is equal to the provided
 // MyEnum.
 func (lhs MyEnum) Equals(rhs MyEnum) bool {
-	return lhs.Equals(rhs)
+	return (enums.EnumWithValues)(lhs).Equals((enums.EnumWithValues)(rhs))
 }
 
 func (v MyEnum) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -976,7 +982,7 @@ func (v *PDF) FromWire(w wire.Value) error {
 // Equals returns true if this PDF is equal to the provided
 // PDF.
 func (lhs PDF) Equals(rhs PDF) bool {
-	return bytes.Equal(lhs, rhs)
+	return bytes.Equal(([]byte)(lhs), ([]byte)(rhs))
 }
 
 type _Map_Point_Point_MapItemList []struct {
@@ -1167,7 +1173,13 @@ func (v *PointMap) FromWire(w wire.Value) error {
 // Equals returns true if this PointMap is equal to the provided
 // PointMap.
 func (lhs PointMap) Equals(rhs PointMap) bool {
-	return _Map_Point_Point_Equals(lhs, rhs)
+	return _Map_Point_Point_Equals(([]struct {
+		Key   *structs.Point
+		Value *structs.Point
+	})(lhs), ([]struct {
+		Key   *structs.Point
+		Value *structs.Point
+	})(rhs))
 }
 
 func (v PointMap) MarshalLogArray(enc zapcore.ArrayEncoder) error {
@@ -1205,7 +1217,7 @@ func (v *State) FromWire(w wire.Value) error {
 // Equals returns true if this State is equal to the provided
 // State.
 func (lhs State) Equals(rhs State) bool {
-	return (lhs == rhs)
+	return ((string)(lhs) == (string)(rhs))
 }
 
 type _Map_State_I64_MapItemList map[State]int64
@@ -1327,7 +1339,7 @@ func (v *StateMap) FromWire(w wire.Value) error {
 // Equals returns true if this StateMap is equal to the provided
 // StateMap.
 func (lhs StateMap) Equals(rhs StateMap) bool {
-	return _Map_State_I64_Equals(lhs, rhs)
+	return _Map_State_I64_Equals((map[State]int64)(lhs), (map[State]int64)(rhs))
 }
 
 func (v StateMap) MarshalLogObject(enc zapcore.ObjectEncoder) error {
@@ -1365,7 +1377,7 @@ func (v *Timestamp) FromWire(w wire.Value) error {
 // Equals returns true if this Timestamp is equal to the provided
 // Timestamp.
 func (lhs Timestamp) Equals(rhs Timestamp) bool {
-	return (lhs == rhs)
+	return ((int64)(lhs) == (int64)(rhs))
 }
 
 type Transition struct {

--- a/gen/internal/tests/uuid_conflict/types.go
+++ b/gen/internal/tests/uuid_conflict/types.go
@@ -41,7 +41,7 @@ func (v *UUID) FromWire(w wire.Value) error {
 // Equals returns true if this UUID is equal to the provided
 // UUID.
 func (lhs UUID) Equals(rhs UUID) bool {
-	return (lhs == rhs)
+	return ((string)(lhs) == (string)(rhs))
 }
 
 type UUIDConflict struct {

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -28,55 +28,151 @@ import (
 	"time"
 
 	tc "go.uber.org/thriftrw/gen/internal/tests/containers"
+	te "go.uber.org/thriftrw/gen/internal/tests/enums"
+	tx "go.uber.org/thriftrw/gen/internal/tests/exceptions"
+	tf "go.uber.org/thriftrw/gen/internal/tests/services"
 	ts "go.uber.org/thriftrw/gen/internal/tests/structs"
+	td "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	tu "go.uber.org/thriftrw/gen/internal/tests/unions"
+	"go.uber.org/thriftrw/wire"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func generateValue(t *testing.T, typ reflect.Type, rand *rand.Rand) thriftType {
+	for {
+		// We will keep trying to generate a value until a valid one
+		// is found.
+
+		v, ok := quick.Value(typ, rand)
+		require.True(t, ok, "failed to generate a value")
+
+		tval := v.Addr().Interface().(thriftType)
+
+		// TODO(abg): ToWire + EvaluateValue to validate here means we end
+		// up serializing this value twice. We may want to include a
+		// Validate method on generated types.
+
+		w, err := tval.ToWire()
+		if err != nil {
+			// Value fails validity check. Try again.
+			continue
+		}
+
+		// Because we evaluate collections lazily, validation issues
+		// with items in them won't be known until we try to serialize
+		// it or explicitly evaluate the lazy lists with
+		// wire.EvaluateValue.
+		if err := wire.EvaluateValue(w); err != nil {
+			// Value fails validity check. Try again.
+			continue
+		}
+
+		return tval
+	}
+}
+
 func TestQuickRoundTrip(t *testing.T) {
-	tests := []reflect.Type{
-		reflect.TypeOf(tc.PrimitiveContainers{}),
-		reflect.TypeOf(tc.PrimitiveContainersRequired{}),
-		reflect.TypeOf(tc.EnumContainers{}),
-		reflect.TypeOf(ts.PrimitiveRequiredStruct{}),
-		reflect.TypeOf(ts.PrimitiveOptionalStruct{}),
-		reflect.TypeOf(ts.Point{}),
-		reflect.TypeOf(ts.Size{}),
-		// TODO Uncomment once we validate required fields
-		// reflect.TypeOf(testdata.Frame{}),
-		// reflect.TypeOf(testdata.Edge{}),
-		// reflect.TypeOf(testdata.Graph{}),
-		reflect.TypeOf(ts.ContactInfo{}),
-		reflect.TypeOf(ts.User{}),
-		reflect.TypeOf(tc.ContainersOfContainers{}),
+	type testCase struct {
+		// Sample value of the type to be tested.
+		Sample interface{}
 	}
 
-	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	attempts := 1000
+	// The following types from our tests have been skipped.
+	// - unions.ArbitraryValue: Self-reference causes testing/quick to loop
+	//   for too long
+	// - services.KeyValue_SetValue_Args{}: Accepts an ArbitraryValue
+	// - services.KeyValue_SetValueV2_Args: Accepts an ArbitraryValue
+	// - services.KeyValue_GetManyValues_Result{}: Produces an ArbitraryValue
+	// - services.KeyValue_GetValue_Result{}: Produces an ArbitraryValue
+
+	// TODO(abg): ^Use custom generators to make this not-a-problem.
+
+	tests := []testCase{
+		// structs, unions, and exceptions
+		{Sample: tc.ContainersOfContainers{}},
+		{Sample: tc.EnumContainers{}},
+		{Sample: tc.ListOfConflictingEnums{}},
+		{Sample: tc.ListOfConflictingUUIDs{}},
+		{Sample: tc.MapOfBinaryAndString{}},
+		{Sample: tc.PrimitiveContainersRequired{}},
+		{Sample: tc.PrimitiveContainers{}},
+		{Sample: td.DefaultPrimitiveTypedef{}},
+		{Sample: td.Event{}},
+		{Sample: td.I128{}},
+		{Sample: td.Transition{}},
+		{Sample: te.StructWithOptionalEnum{}},
+		{Sample: tf.Cache_Clear_Args{}},
+		{Sample: tf.Cache_ClearAfter_Args{}},
+		{Sample: tf.ConflictingNames_SetValue_Args{}},
+		{Sample: tf.ConflictingNames_SetValue_Result{}},
+		{Sample: tf.ConflictingNamesSetValueArgs{}},
+		{Sample: tf.InternalError{}},
+		{Sample: tf.KeyValue_DeleteValue_Args{}},
+		{Sample: tf.KeyValue_DeleteValue_Result{}},
+		{Sample: tf.KeyValue_GetManyValues_Args{}},
+		{Sample: tf.KeyValue_GetValue_Args{}},
+		{Sample: tf.KeyValue_SetValue_Result{}},
+		{Sample: tf.KeyValue_SetValueV2_Result{}},
+		{Sample: tf.KeyValue_Size_Args{}},
+		{Sample: tf.KeyValue_Size_Result{}},
+		{Sample: tf.NonStandardServiceName_NonStandardFunctionName_Args{}},
+		{Sample: tf.NonStandardServiceName_NonStandardFunctionName_Result{}},
+		{Sample: ts.ContactInfo{}},
+		{Sample: ts.DefaultsStruct{}},
+		{Sample: ts.Edge{}},
+		{Sample: ts.EmptyStruct{}},
+		{Sample: ts.Frame{}},
+		{Sample: ts.GoTags{}},
+		{Sample: ts.Graph{}},
+		{Sample: ts.Node{}},
+		{Sample: ts.Omit{}},
+		{Sample: ts.Point{}},
+		{Sample: ts.PrimitiveOptionalStruct{}},
+		{Sample: ts.PrimitiveRequiredStruct{}},
+		{Sample: ts.Rename{}},
+		{Sample: ts.Size{}},
+		{Sample: ts.StructLabels{}},
+		{Sample: ts.User{}},
+		{Sample: ts.ZapOptOutStruct{}},
+		{Sample: tu.Document{}},
+		{Sample: tu.EmptyUnion{}},
+		{Sample: tx.DoesNotExistException{}},
+		{Sample: tx.EmptyException{}},
+
+		// typedefs
+		{Sample: td.BinarySet{}},
+		{Sample: td.EdgeMap{}},
+		{Sample: td.FrameGroup{}},
+		{Sample: td.MyEnum(0)},
+		{Sample: td.PDF{}},
+		{Sample: td.PointMap{}},
+		{Sample: td.State("")},
+		{Sample: td.StateMap{}},
+		{Sample: td.Timestamp(0)},
+		{Sample: td.UUID{}},
+	}
+
+	// Log the seed so that we can reproduce this if it ever fails.
+	seed := time.Now().UnixNano()
+	rand := rand.New(rand.NewSource(seed))
+	t.Logf("Using seed %v for testing/quick", seed)
+
+	const numValues = 1000 // number of values to test against
 	for _, tt := range tests {
-		i := 0
-		for i < attempts {
-			structValue, ok := quick.Value(tt, rand)
-			if !ok {
-				t.Fatalf("failed to generate a value for %v", tt)
+		typ := reflect.TypeOf(tt.Sample)
+		t.Run(typ.Name(), func(t *testing.T) {
+			for i := 0; i < numValues; i++ {
+				give := generateValue(t, typ, rand)
+				w, err := give.ToWire()
+				require.NoError(t, err, "failed to Thrift encode %v", give)
+
+				got := reflect.New(typ).Interface().(thriftType)
+				require.NoError(t, got.FromWire(w), "failed to Thrift decode from %v", w)
+
+				assert.Equal(t, got, give)
 			}
-
-			result := structValue.Addr().MethodByName("ToWire").Call(nil)
-			if result[1].Interface() != nil {
-				continue // invalid value generated
-			}
-
-			i++ // increment i only if we found a valid sample
-
-			wireValue := result[0]
-			parsedValue := reflect.New(tt)
-			result = parsedValue.MethodByName("FromWire").
-				Call([]reflect.Value{wireValue})
-			if result[0].Interface() != nil {
-				t.Fatal("failed to parse", tt, "from", wireValue.Interface())
-			}
-
-			assert.Equal(t, structValue.Addr().Interface(), parsedValue.Interface())
-		}
+		})
 	}
 }

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -21,6 +21,7 @@
 package gen
 
 import (
+	"encoding"
 	"encoding/json"
 	"math/rand"
 	"reflect"
@@ -120,6 +121,10 @@ func TestQuickRoundTrip(t *testing.T) {
 		// round-trip with JSON successfully due to nil versus empty
 		// collection differences.
 		JSON bool
+
+		// Whether we should evaluate encoding.TextMarshaler round-tripping.
+		// This is only suported on enums.
+		Text bool
 	}
 
 	// The following types from our tests have been skipped.
@@ -201,46 +206,55 @@ func TestQuickRoundTrip(t *testing.T) {
 			Sample:    te.EmptyEnum(0),
 			Generator: enumValueGenerator(te.EmptyEnum_Values),
 			JSON:      true,
+			Text:      true,
 		},
 		{
 			Sample:    te.EnumDefault(0),
 			Generator: enumValueGenerator(te.EnumDefault_Values),
 			JSON:      true,
+			Text:      true,
 		},
 		{
 			Sample:    te.EnumWithDuplicateName(0),
 			Generator: enumValueGenerator(te.EnumWithDuplicateName_Values),
 			JSON:      true,
+			Text:      true,
 		},
 		{
 			Sample:    te.EnumWithDuplicateValues(0),
 			Generator: enumValueGenerator(te.EnumWithDuplicateValues_Values),
 			JSON:      true,
+			Text:      true,
 		},
 		{
 			Sample:    te.EnumWithLabel(0),
 			Generator: enumValueGenerator(te.EnumWithLabel_Values),
 			JSON:      true,
+			Text:      true,
 		},
 		{
 			Sample:    te.EnumWithValues(0),
 			Generator: enumValueGenerator(te.EnumWithValues_Values),
 			JSON:      true,
+			Text:      true,
 		},
 		{
 			Sample:    te.LowerCaseEnum(0),
 			Generator: enumValueGenerator(te.LowerCaseEnum_Values),
 			JSON:      true,
+			Text:      true,
 		},
 		{
 			Sample:    te.RecordType(0),
 			Generator: enumValueGenerator(te.RecordType_Values),
 			JSON:      true,
+			Text:      true,
 		},
 		{
 			Sample:    te.RecordTypeValues(0),
 			Generator: enumValueGenerator(te.RecordTypeValues_Values),
 			JSON:      true,
+			Text:      true,
 		},
 	}
 
@@ -296,6 +310,24 @@ func TestQuickRoundTrip(t *testing.T) {
 						require.True(t, ok, "Type does not implement json.Unmarshaler")
 
 						require.NoError(t, got.UnmarshalJSON(bs), "failed to decode from %q", bs)
+						assert.Equal(t, got, give, "could not round-trip")
+					}
+				})
+			}
+
+			if tt.Text {
+				t.Run("Text", func(t *testing.T) {
+					for _, giveValue := range values {
+						give, ok := giveValue.(encoding.TextMarshaler)
+						require.True(t, ok, "Type does not implement encoding.TextMarshaler")
+
+						bs, err := give.MarshalText()
+						require.NoError(t, err, "failed to encode %v", give)
+
+						got, ok := reflect.New(typ).Interface().(encoding.TextUnmarshaler)
+						require.True(t, ok, "Type does not implement encoding.TextUnmarshaler")
+
+						require.NoError(t, got.UnmarshalText(bs), "failed to decode from %q", bs)
 						assert.Equal(t, got, give, "could not round-trip")
 					}
 				})

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -252,6 +252,14 @@ func TestQuickRoundTrip(t *testing.T) {
 					assert.Equal(t, got, give)
 				}
 			})
+
+			t.Run("String", func(t *testing.T) {
+				for _, give := range values {
+					assert.NotPanics(t, func() {
+						_ = give.String()
+					}, "failed to String %#v", give)
+				}
+			})
 		})
 	}
 }

--- a/gen/roundtrip_test.go
+++ b/gen/roundtrip_test.go
@@ -73,13 +73,9 @@ func assertRoundTrip(t *testing.T, x thriftType, v wire.Value, msg string, args 
 		xType = xType.Elem()
 	}
 
-	gotX := reflect.New(xType)
-	err := gotX.MethodByName("FromWire").
-		Call([]reflect.Value{reflect.ValueOf(v)})[0].
-		Interface()
-
-	if assert.Nil(t, err, "FromWire: %v", message) {
-		return assert.Equal(t, x, gotX.Interface(), "FromWire: %v", message)
+	gotX := reflect.New(xType).Interface().(thriftType)
+	if assert.NoError(t, gotX.FromWire(v), "FromWire: %v", message) {
+		return assert.Equal(t, x, gotX, "FromWire: %v", message)
 	}
 	return false
 }

--- a/gen/roundtrip_test.go
+++ b/gen/roundtrip_test.go
@@ -32,11 +32,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type thriftType interface {
-	ToWire() (wire.Value, error)
-	FromWire(wire.Value) error
-}
-
 // assertRoundTrip checks if x.ToWire() results in the given Value and whether
 // x.FromWire() with the given value results in the original x.
 func assertRoundTrip(t *testing.T, x thriftType, v wire.Value, msg string, args ...interface{}) bool {

--- a/gen/service_test.go
+++ b/gen/service_test.go
@@ -665,11 +665,9 @@ func TestArgsAndResultValidation(t *testing.T) {
 			t.Fatalf("invalid test %q: either typ or serialize must be set", tt.desc)
 		}
 
-		x := reflect.New(typ)
-		args := []reflect.Value{reflect.ValueOf(tt.deserialize)}
-		e := x.MethodByName("FromWire").Call(args)[0].Interface()
-		if assert.NotNil(t, e, "%v: expected failure but got %v", tt.desc, x) {
-			assert.Contains(t, e.(error).Error(), tt.wantError, tt.desc)
+		x := reflect.New(typ).Interface().(serviceType)
+		if err := x.FromWire(tt.deserialize); assert.Errorf(t, err, "%v: expected failure but got %v", tt.desc, x) {
+			assert.Contains(t, err.Error(), tt.wantError, tt.desc)
 		}
 	}
 }

--- a/gen/service_test.go
+++ b/gen/service_test.go
@@ -23,6 +23,7 @@ package gen
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -40,7 +41,9 @@ import (
 
 // serviceType is the args or result struct for a thrift function.
 type serviceType interface {
+	fmt.Stringer
 	envelope.Enveloper
+
 	FromWire(wire.Value) error
 }
 

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1610,11 +1610,9 @@ func TestStructValidation(t *testing.T) {
 			t.Fatalf("invalid test %q: either typ or serialize must be set", tt.desc)
 		}
 
-		x := reflect.New(typ)
-		args := []reflect.Value{reflect.ValueOf(tt.deserialize)}
-		e := x.MethodByName("FromWire").Call(args)[0].Interface()
-		if assert.NotNil(t, e, "%v: expected failure but got %v", tt.desc, x) {
-			assert.Contains(t, e.(error).Error(), tt.wantError, tt.desc)
+		x := reflect.New(typ).Interface().(thriftType)
+		if err := x.FromWire(tt.deserialize); assert.Error(t, err, "%v: expected failure but got %v", tt.desc, x) {
+			assert.Contains(t, err.Error(), tt.wantError, tt.desc)
 		}
 	}
 }

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -44,12 +44,9 @@ import (
 func TestStructRoundTripAndString(t *testing.T) {
 	tests := []struct {
 		desc string
-		x    interface {
-			thriftType
-			String() string
-		}
-		v wire.Value
-		s string
+		x    thriftType
+		v    wire.Value
+		s    string
 	}{
 		{
 			"PrimitiveRequiredStruct",

--- a/gen/typedef.go
+++ b/gen/typedef.go
@@ -97,11 +97,9 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 		// Equals returns true if this <typeName .> is equal to the provided
 		// <typeName .>.
 		func (<$lhs> <$typedefType>) Equals(<$rhs> <$typedefType>) bool {
-			<if isStructType . ->
-				return (<typeReference .Target>)(<$lhs>).Equals((<typeReference .Target>)(<$rhs>))
-			<- else ->
-				return <equals .Target $lhs $rhs>
-			<- end>
+			<- $lhsCast := printf "(%v)(%v)" (typeReference .Target) $lhs ->
+			<- $rhsCast := printf "(%v)(%v)" (typeReference .Target) $rhs ->
+			return <equals .Target $lhsCast $rhsCast>
 		}
 
 		<if not (checkNoZap) ->

--- a/gen/util_for_test.go
+++ b/gen/util_for_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gen
+
+import "go.uber.org/thriftrw/wire"
+
+// thriftType is implemented by all generated types that know how to encode
+// and decode themselves.
+//
+// Having this interface allows tests that use reflection to be more readable
+// by relying on the interface rather than reflection to call methods.
+type thriftType interface {
+	ToWire() (wire.Value, error)
+	FromWire(wire.Value) error
+}

--- a/gen/util_for_test.go
+++ b/gen/util_for_test.go
@@ -20,7 +20,11 @@
 
 package gen
 
-import "go.uber.org/thriftrw/wire"
+import (
+	"fmt"
+
+	"go.uber.org/thriftrw/wire"
+)
 
 // thriftType is implemented by all generated types that know how to encode
 // and decode themselves.
@@ -28,6 +32,8 @@ import "go.uber.org/thriftrw/wire"
 // Having this interface allows tests that use reflection to be more readable
 // by relying on the interface rather than reflection to call methods.
 type thriftType interface {
+	fmt.Stringer
+
 	ToWire() (wire.Value, error)
 	FromWire(wire.Value) error
 }


### PR DESCRIPTION
We had a stale `testing/quick` based test in the repository from way
back that did some basic round-tripping.

This PR adds a series of commits that expand that to test most of the
generated types in internal/tests.

The following functionalties are tested thus far:

- `wire.Value` round-tripping
- `String()`
- Zap logging
- For enums, JSON and encoding.TextMarhsaler round-tripping

I found a minor bug for empty enums where we weren't generating the
`*_Values` function. This fixes that bug too.

For reviewers: Every commit is individually reviewable. In fact, I would
recommend that route rather than the whole change.