### PR TITLE
gen/plugin: Add pointer to typedefs of structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - gen/plugin: Fixed a bug where typedefs of structs were mishandled; while they
-  should have been pointers, they were generated without '*' and failed to
+  should have been pointers, they were generated without `*` and failed to
   compile.
 
 ## [1.13.0] - 2018-09-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- gen/plugin: Fixed a bug where typedefs of structs were mishandled; while they
+  should have been pointers, they were generated without '*' and failed to
+  compile.
 
 ## [1.13.0] - 2018-09-10
 ### Added

--- a/gen/plugin.go
+++ b/gen/plugin.go
@@ -343,11 +343,8 @@ func (g *generateServiceBuilder) buildType(spec compile.TypeSpec, required bool)
 			},
 		}
 
-		if isStructType(spec) {
-			return &api.Type{PointerType: t}, nil
-		}
-
-		if !required && !isReferenceType(spec) {
+		if (!required && !isReferenceType(spec)) ||
+			isStructType(spec) {
 			t = &api.Type{PointerType: t}
 		}
 

--- a/gen/plugin.go
+++ b/gen/plugin.go
@@ -343,6 +343,10 @@ func (g *generateServiceBuilder) buildType(spec compile.TypeSpec, required bool)
 			},
 		}
 
+		if isStructType(spec) {
+			return &api.Type{PointerType: t}, nil
+		}
+
 		if !required && !isReferenceType(spec) {
 			t = &api.Type{PointerType: t}
 		}

--- a/gen/plugin_test.go
+++ b/gen/plugin_test.go
@@ -710,6 +710,23 @@ func TestBuildType(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "typedef of struct",
+			spec: &compile.TypedefSpec{
+				Name:   "Foo",
+				File:   "idl/foo/bar.thrift",
+				Target: &compile.StructSpec{},
+			},
+			required: true,
+			want: &api.Type{
+				PointerType: &api.Type{
+					ReferenceType: &api.TypeReference{
+						Name:       "Foo",
+						ImportPath: "go.uber.org/thriftrw/gen/internal/tests/foo/bar",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Typedefs of structs were mishandled with plugins; while they should have
been pointers, they were generated without `*`. This commit addresses
this issue.