### PR TITLE
gen/zap: Don't panic on nil structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - gen/plugin: Fixed a bug where typedefs of structs were mishandled; while they
   should have been pointers, they were generated without `*` and failed to
   compile.
+- gen/zap: Fixed a bug where logging nil structs would panic.
 
 ## [1.13.0] - 2018-09-10
 ### Added

--- a/gen/field.go
+++ b/gen/field.go
@@ -489,6 +489,9 @@ func (f fieldGroupGenerator) Zap(g Generator) error {
 		// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 		// fast logging of <.Name>.
 		func (<$v> *<.Name>) MarshalLogObject(<$enc> <$zapcore>.ObjectEncoder) (err error) {
+			if <$v> == nil {
+				return nil
+			}
 			<range .Fields>
 				<- if not (zapOptOut .) ->
 					<- $fval := printf "%s.%s" $v (goName .) ->

--- a/gen/internal/tests/collision/types.go
+++ b/gen/internal/tests/collision/types.go
@@ -166,6 +166,9 @@ func (v *AccessorConflict) Equals(rhs *AccessorConflict) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of AccessorConflict.
 func (v *AccessorConflict) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Name != nil {
 		enc.AddString("name", *v.Name)
 	}
@@ -335,6 +338,9 @@ func (v *AccessorNoConflict) Equals(rhs *AccessorNoConflict) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of AccessorNoConflict.
 func (v *AccessorNoConflict) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Getname != nil {
 		enc.AddString("getname", *v.Getname)
 	}
@@ -996,6 +1002,9 @@ func (m _Map_String_String_Zapper) MarshalLogObject(enc zapcore.ObjectEncoder) (
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of PrimitiveContainers.
 func (v *PrimitiveContainers) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.A != nil {
 		err = multierr.Append(err, enc.AddArray("ListOrSetOrMap", (_List_String_Zapper)(v.A)))
 	}
@@ -1178,6 +1187,9 @@ func (v *StructCollision) Equals(rhs *StructCollision) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of StructCollision.
 func (v *StructCollision) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddBool("collisionField", v.CollisionField)
 	enc.AddString("collision_field", v.CollisionField2)
 	return err
@@ -1356,6 +1368,9 @@ func (v *UnionCollision) Equals(rhs *UnionCollision) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of UnionCollision.
 func (v *UnionCollision) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.CollisionField != nil {
 		enc.AddBool("collisionField", *v.CollisionField)
 	}
@@ -1516,6 +1531,9 @@ func (v *WithDefault) Equals(rhs *WithDefault) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of WithDefault.
 func (v *WithDefault) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Pouet != nil {
 		err = multierr.Append(err, enc.AddObject("pouet", v.Pouet))
 	}
@@ -1890,6 +1908,9 @@ func (v *StructCollision2) Equals(rhs *StructCollision2) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of StructCollision2.
 func (v *StructCollision2) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddBool("collisionField", v.CollisionField)
 	enc.AddString("collision_field", v.CollisionField2)
 	return err
@@ -2058,6 +2079,9 @@ func (v *UnionCollision2) Equals(rhs *UnionCollision2) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of UnionCollision2.
 func (v *UnionCollision2) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.CollisionField != nil {
 		enc.AddBool("collisionField", *v.CollisionField)
 	}

--- a/gen/internal/tests/containers/types.go
+++ b/gen/internal/tests/containers/types.go
@@ -1928,6 +1928,9 @@ func (m _Map_Set_I32_List_Double_Zapper) MarshalLogArray(enc zapcore.ArrayEncode
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ContainersOfContainers.
 func (v *ContainersOfContainers) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.ListOfLists != nil {
 		err = multierr.Append(err, enc.AddArray("listOfLists", (_List_List_I32_Zapper)(v.ListOfLists)))
 	}
@@ -2479,6 +2482,9 @@ func (m _Map_EnumWithDuplicateValues_I32_Zapper) MarshalLogArray(enc zapcore.Arr
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of EnumContainers.
 func (v *EnumContainers) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.ListOfEnums != nil {
 		err = multierr.Append(err, enc.AddArray("listOfEnums", (_List_EnumDefault_Zapper)(v.ListOfEnums)))
 	}
@@ -2818,6 +2824,9 @@ func (l _List_RecordType_1_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (er
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ListOfConflictingEnums.
 func (v *ListOfConflictingEnums) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	err = multierr.Append(err, enc.AddArray("records", (_List_RecordType_Zapper)(v.Records)))
 	err = multierr.Append(err, enc.AddArray("otherRecords", (_List_RecordType_1_Zapper)(v.OtherRecords)))
 	return err
@@ -3131,6 +3140,9 @@ func (l _List_UUID_1_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err erro
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ListOfConflictingUUIDs.
 func (v *ListOfConflictingUUIDs) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	err = multierr.Append(err, enc.AddArray("uuids", (_List_UUID_Zapper)(v.Uuids)))
 	err = multierr.Append(err, enc.AddArray("otherUUIDs", (_List_UUID_1_Zapper)(v.OtherUUIDs)))
 	return err
@@ -3519,6 +3531,9 @@ func (m _Map_String_Binary_Zapper) MarshalLogObject(enc zapcore.ObjectEncoder) (
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of MapOfBinaryAndString.
 func (v *MapOfBinaryAndString) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.BinaryToString != nil {
 		err = multierr.Append(err, enc.AddArray("binaryToString", (_Map_Binary_String_Zapper)(v.BinaryToString)))
 	}
@@ -4191,6 +4206,9 @@ func (m _Map_String_Bool_Zapper) MarshalLogObject(enc zapcore.ObjectEncoder) (er
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of PrimitiveContainers.
 func (v *PrimitiveContainers) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.ListOfBinary != nil {
 		err = multierr.Append(err, enc.AddArray("listOfBinary", (_List_Binary_Zapper)(v.ListOfBinary)))
 	}
@@ -4549,6 +4567,9 @@ func (m _Map_I64_Double_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err e
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of PrimitiveContainersRequired.
 func (v *PrimitiveContainersRequired) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	err = multierr.Append(err, enc.AddArray("listOfStrings", (_List_String_Zapper)(v.ListOfStrings)))
 	err = multierr.Append(err, enc.AddArray("setOfInts", (_Set_I32_Zapper)(v.SetOfInts)))
 	err = multierr.Append(err, enc.AddArray("mapOfIntsToDoubles", (_Map_I64_Double_Zapper)(v.MapOfIntsToDoubles)))

--- a/gen/internal/tests/enum_conflict/types.go
+++ b/gen/internal/tests/enum_conflict/types.go
@@ -381,6 +381,9 @@ func (v *Records) Equals(rhs *Records) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Records.
 func (v *Records) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.RecordType != nil {
 		err = multierr.Append(err, enc.AddObject("recordType", *v.RecordType))
 	}

--- a/gen/internal/tests/enums/types.go
+++ b/gen/internal/tests/enums/types.go
@@ -1667,6 +1667,9 @@ func (v *StructWithOptionalEnum) Equals(rhs *StructWithOptionalEnum) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of StructWithOptionalEnum.
 func (v *StructWithOptionalEnum) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.E != nil {
 		err = multierr.Append(err, enc.AddObject("e", *v.E))
 	}

--- a/gen/internal/tests/exceptions/types.go
+++ b/gen/internal/tests/exceptions/types.go
@@ -163,6 +163,9 @@ func (v *DoesNotExistException) Equals(rhs *DoesNotExistException) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of DoesNotExistException.
 func (v *DoesNotExistException) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("key", v.Key)
 	if v.Error2 != nil {
 		enc.AddString("Error", *v.Error2)
@@ -272,6 +275,9 @@ func (v *EmptyException) Equals(rhs *EmptyException) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of EmptyException.
 func (v *EmptyException) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 

--- a/gen/internal/tests/services/cache_clear.go
+++ b/gen/internal/tests/services/cache_clear.go
@@ -97,6 +97,9 @@ func (v *Cache_Clear_Args) Equals(rhs *Cache_Clear_Args) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Cache_Clear_Args.
 func (v *Cache_Clear_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 

--- a/gen/internal/tests/services/cache_clearafter.go
+++ b/gen/internal/tests/services/cache_clearafter.go
@@ -137,6 +137,9 @@ func (v *Cache_ClearAfter_Args) Equals(rhs *Cache_ClearAfter_Args) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Cache_ClearAfter_Args.
 func (v *Cache_ClearAfter_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.DurationMS != nil {
 		enc.AddInt64("durationMS", *v.DurationMS)
 	}

--- a/gen/internal/tests/services/conflictingnames_setvalue.go
+++ b/gen/internal/tests/services/conflictingnames_setvalue.go
@@ -132,6 +132,9 @@ func (v *ConflictingNames_SetValue_Args) Equals(rhs *ConflictingNames_SetValue_A
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ConflictingNames_SetValue_Args.
 func (v *ConflictingNames_SetValue_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Request != nil {
 		err = multierr.Append(err, enc.AddObject("request", v.Request))
 	}
@@ -325,6 +328,9 @@ func (v *ConflictingNames_SetValue_Result) Equals(rhs *ConflictingNames_SetValue
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ConflictingNames_SetValue_Result.
 func (v *ConflictingNames_SetValue_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 

--- a/gen/internal/tests/services/keyvalue_deletevalue.go
+++ b/gen/internal/tests/services/keyvalue_deletevalue.go
@@ -146,6 +146,9 @@ func (v *KeyValue_DeleteValue_Args) Equals(rhs *KeyValue_DeleteValue_Args) bool 
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_DeleteValue_Args.
 func (v *KeyValue_DeleteValue_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Key != nil {
 		enc.AddString("key", (string)(*v.Key))
 	}
@@ -444,6 +447,9 @@ func (v *KeyValue_DeleteValue_Result) Equals(rhs *KeyValue_DeleteValue_Result) b
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_DeleteValue_Result.
 func (v *KeyValue_DeleteValue_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.DoesNotExist != nil {
 		err = multierr.Append(err, enc.AddObject("doesNotExist", v.DoesNotExist))
 	}

--- a/gen/internal/tests/services/keyvalue_getmanyvalues.go
+++ b/gen/internal/tests/services/keyvalue_getmanyvalues.go
@@ -199,6 +199,9 @@ func (l _List_Key_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err error) 
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_GetManyValues_Args.
 func (v *KeyValue_GetManyValues_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Range != nil {
 		err = multierr.Append(err, enc.AddArray("range", (_List_Key_Zapper)(v.Range)))
 	}
@@ -561,6 +564,9 @@ func (l _List_ArbitraryValue_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_GetManyValues_Result.
 func (v *KeyValue_GetManyValues_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Success != nil {
 		err = multierr.Append(err, enc.AddArray("success", (_List_ArbitraryValue_Zapper)(v.Success)))
 	}

--- a/gen/internal/tests/services/keyvalue_getvalue.go
+++ b/gen/internal/tests/services/keyvalue_getvalue.go
@@ -131,6 +131,9 @@ func (v *KeyValue_GetValue_Args) Equals(rhs *KeyValue_GetValue_Args) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_GetValue_Args.
 func (v *KeyValue_GetValue_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Key != nil {
 		enc.AddString("key", (string)(*v.Key))
 	}
@@ -414,6 +417,9 @@ func (v *KeyValue_GetValue_Result) Equals(rhs *KeyValue_GetValue_Result) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_GetValue_Result.
 func (v *KeyValue_GetValue_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Success != nil {
 		err = multierr.Append(err, enc.AddObject("success", v.Success))
 	}

--- a/gen/internal/tests/services/keyvalue_setvalue.go
+++ b/gen/internal/tests/services/keyvalue_setvalue.go
@@ -153,6 +153,9 @@ func (v *KeyValue_SetValue_Args) Equals(rhs *KeyValue_SetValue_Args) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_SetValue_Args.
 func (v *KeyValue_SetValue_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Key != nil {
 		enc.AddString("key", (string)(*v.Key))
 	}
@@ -362,6 +365,9 @@ func (v *KeyValue_SetValue_Result) Equals(rhs *KeyValue_SetValue_Result) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_SetValue_Result.
 func (v *KeyValue_SetValue_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 

--- a/gen/internal/tests/services/keyvalue_setvaluev2.go
+++ b/gen/internal/tests/services/keyvalue_setvaluev2.go
@@ -162,6 +162,9 @@ func (v *KeyValue_SetValueV2_Args) Equals(rhs *KeyValue_SetValueV2_Args) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_SetValueV2_Args.
 func (v *KeyValue_SetValueV2_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("key", (string)(v.Key))
 	err = multierr.Append(err, enc.AddObject("value", v.Value))
 	return err
@@ -355,6 +358,9 @@ func (v *KeyValue_SetValueV2_Result) Equals(rhs *KeyValue_SetValueV2_Result) boo
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_SetValueV2_Result.
 func (v *KeyValue_SetValueV2_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 

--- a/gen/internal/tests/services/keyvalue_size.go
+++ b/gen/internal/tests/services/keyvalue_size.go
@@ -98,6 +98,9 @@ func (v *KeyValue_Size_Args) Equals(rhs *KeyValue_Size_Args) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_Size_Args.
 func (v *KeyValue_Size_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 
@@ -323,6 +326,9 @@ func (v *KeyValue_Size_Result) Equals(rhs *KeyValue_Size_Result) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of KeyValue_Size_Result.
 func (v *KeyValue_Size_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Success != nil {
 		enc.AddInt64("success", *v.Success)
 	}

--- a/gen/internal/tests/services/non_standard_service_name_non_standard_function_name.go
+++ b/gen/internal/tests/services/non_standard_service_name_non_standard_function_name.go
@@ -97,6 +97,9 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) Equals(rhs *NonSta
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of NonStandardServiceName_NonStandardFunctionName_Args.
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 
@@ -271,6 +274,9 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) Equals(rhs *NonS
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of NonStandardServiceName_NonStandardFunctionName_Result.
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 

--- a/gen/internal/tests/services/types.go
+++ b/gen/internal/tests/services/types.go
@@ -155,6 +155,9 @@ func (v *ConflictingNamesSetValueArgs) Equals(rhs *ConflictingNamesSetValueArgs)
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ConflictingNamesSetValueArgs.
 func (v *ConflictingNamesSetValueArgs) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("key", v.Key)
 	enc.AddString("value", base64.StdEncoding.EncodeToString(v.Value))
 	return err
@@ -292,6 +295,9 @@ func (v *InternalError) Equals(rhs *InternalError) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of InternalError.
 func (v *InternalError) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Message != nil {
 		enc.AddString("message", *v.Message)
 	}

--- a/gen/internal/tests/structs/types.go
+++ b/gen/internal/tests/structs/types.go
@@ -130,6 +130,9 @@ func (v *ContactInfo) Equals(rhs *ContactInfo) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ContactInfo.
 func (v *ContactInfo) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("emailAddress", v.EmailAddress)
 	return err
 }
@@ -714,6 +717,9 @@ func (l _List_Double_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err erro
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of DefaultsStruct.
 func (v *DefaultsStruct) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.RequiredPrimitive != nil {
 		enc.AddInt32("requiredPrimitive", *v.RequiredPrimitive)
 	}
@@ -997,6 +1003,9 @@ func (v *Edge) Equals(rhs *Edge) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Edge.
 func (v *Edge) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	err = multierr.Append(err, enc.AddObject("startPoint", v.StartPoint))
 	err = multierr.Append(err, enc.AddObject("endPoint", v.EndPoint))
 	return err
@@ -1094,6 +1103,9 @@ func (v *EmptyStruct) Equals(rhs *EmptyStruct) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of EmptyStruct.
 func (v *EmptyStruct) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 
@@ -1248,6 +1260,9 @@ func (v *Frame) Equals(rhs *Frame) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Frame.
 func (v *Frame) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	err = multierr.Append(err, enc.AddObject("topLeft", v.TopLeft))
 	err = multierr.Append(err, enc.AddObject("size", v.Size))
 	return err
@@ -1517,6 +1532,9 @@ func (v *GoTags) Equals(rhs *GoTags) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of GoTags.
 func (v *GoTags) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("Foo", v.Foo)
 	if v.Bar != nil {
 		enc.AddString("Bar", *v.Bar)
@@ -1760,6 +1778,9 @@ func (l _List_Edge_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err error)
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Graph.
 func (v *Graph) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	err = multierr.Append(err, enc.AddArray("edges", (_List_Edge_Zapper)(v.Edges)))
 	return err
 }
@@ -1947,6 +1968,9 @@ func (v *Node) Equals(rhs *Node) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Node.
 func (v *Node) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddInt32("value", v.Value)
 	if v.Tail != nil {
 		err = multierr.Append(err, enc.AddObject("tail", (*Node)(v.Tail)))
@@ -2108,6 +2132,9 @@ func (v *Omit) Equals(rhs *Omit) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Omit.
 func (v *Omit) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("serialized", v.Serialized)
 	enc.AddString("hidden", v.Hidden)
 	return err
@@ -2262,6 +2289,9 @@ func (v *Point) Equals(rhs *Point) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Point.
 func (v *Point) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddFloat64("x", v.X)
 	enc.AddFloat64("y", v.Y)
 	return err
@@ -2622,6 +2652,9 @@ func (v *PrimitiveOptionalStruct) Equals(rhs *PrimitiveOptionalStruct) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of PrimitiveOptionalStruct.
 func (v *PrimitiveOptionalStruct) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.BoolField != nil {
 		enc.AddBool("boolField", *v.BoolField)
 	}
@@ -3030,6 +3063,9 @@ func (v *PrimitiveRequiredStruct) Equals(rhs *PrimitiveRequiredStruct) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of PrimitiveRequiredStruct.
 func (v *PrimitiveRequiredStruct) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddBool("boolField", v.BoolField)
 	enc.AddInt8("byteField", v.ByteField)
 	enc.AddInt16("int16Field", v.Int16Field)
@@ -3213,6 +3249,9 @@ func (v *Rename) Equals(rhs *Rename) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Rename.
 func (v *Rename) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("Default", v.Default)
 	enc.AddString("camelCase", v.CamelCase)
 	return err
@@ -3369,6 +3408,9 @@ func (v *Size) Equals(rhs *Size) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Size.
 func (v *Size) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddFloat64("width", v.Width)
 	enc.AddFloat64("height", v.Height)
 	return err
@@ -3574,6 +3616,9 @@ func (v *StructLabels) Equals(rhs *StructLabels) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of StructLabels.
 func (v *StructLabels) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.IsRequired != nil {
 		enc.AddBool("required", *v.IsRequired)
 	}
@@ -3773,6 +3818,9 @@ func (v *User) Equals(rhs *User) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of User.
 func (v *User) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("name", v.Name)
 	if v.Contact != nil {
 		err = multierr.Append(err, enc.AddObject("contact", v.Contact))
@@ -4069,6 +4117,9 @@ func (v *ZapOptOutStruct) Equals(rhs *ZapOptOutStruct) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ZapOptOutStruct.
 func (v *ZapOptOutStruct) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("name", v.Name)
 
 	return err

--- a/gen/internal/tests/typedefs/types.go
+++ b/gen/internal/tests/typedefs/types.go
@@ -272,6 +272,9 @@ func (v *DefaultPrimitiveTypedef) Equals(rhs *DefaultPrimitiveTypedef) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of DefaultPrimitiveTypedef.
 func (v *DefaultPrimitiveTypedef) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.State != nil {
 		enc.AddString("state", (string)(*v.State))
 	}
@@ -657,6 +660,9 @@ func (v *Event) Equals(rhs *Event) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Event.
 func (v *Event) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	err = multierr.Append(err, enc.AddObject("uuid", (*I128)(v.UUID)))
 	if v.Time != nil {
 		enc.AddInt64("time", (int64)(*v.Time))
@@ -1550,6 +1556,9 @@ func (v *Transition) Equals(rhs *Transition) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Transition.
 func (v *Transition) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("fromState", (string)(v.FromState))
 	enc.AddString("toState", (string)(v.ToState))
 	if v.Events != nil {
@@ -1749,6 +1758,9 @@ func (v *I128) Equals(rhs *I128) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of I128.
 func (v *I128) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddInt64("high", v.High)
 	enc.AddInt64("low", v.Low)
 	return err

--- a/gen/internal/tests/unions/types.go
+++ b/gen/internal/tests/unions/types.go
@@ -463,6 +463,9 @@ func (m _Map_String_ArbitraryValue_Zapper) MarshalLogObject(enc zapcore.ObjectEn
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ArbitraryValue.
 func (v *ArbitraryValue) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.BoolValue != nil {
 		enc.AddBool("boolValue", *v.BoolValue)
 	}
@@ -690,6 +693,9 @@ func (v *Document) Equals(rhs *Document) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Document.
 func (v *Document) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Pdf != nil {
 		enc.AddString("pdf", base64.StdEncoding.EncodeToString(([]byte)(v.Pdf)))
 	}
@@ -803,5 +809,8 @@ func (v *EmptyUnion) Equals(rhs *EmptyUnion) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of EmptyUnion.
 func (v *EmptyUnion) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }

--- a/gen/internal/tests/uuid_conflict/types.go
+++ b/gen/internal/tests/uuid_conflict/types.go
@@ -198,6 +198,9 @@ func (v *UUIDConflict) Equals(rhs *UUIDConflict) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of UUIDConflict.
 func (v *UUIDConflict) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("localUUID", (string)(v.LocalUUID))
 	err = multierr.Append(err, enc.AddObject("importedUUID", (*typedefs.I128)(v.ImportedUUID)))
 	return err

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -525,6 +525,10 @@ func TestQuickSuite(t *testing.T) {
 						suite.testLogging(t, give)
 					}
 				})
+
+				if isThriftNillable(typ) {
+					t.Run("Zap/Nil", suite.testLoggingNil)
+				}
 			}
 
 			if !tt.NoEquals {
@@ -664,6 +668,26 @@ func (q *quickSuite) testLogging(t *testing.T, give thriftType) {
 
 	if arr, ok := give.(zapcore.ArrayMarshaler); ok {
 		assert.NoErrorf(t, enc.AddArray("values", arr), "failed to log %v", give)
+		return
+	}
+
+	t.Fatal(
+		"Type does not implement zapcore.ObjectMarshaler or zapcore.ArrayMarshaler. "+
+			"Did you mean to add NoLog?", q.Type)
+}
+
+func (q *quickSuite) testLoggingNil(t *testing.T) {
+	enc := zapcore.NewMapObjectEncoder()
+
+	v := q.newNil(t).Interface()
+
+	if obj, ok := v.(zapcore.ObjectMarshaler); ok {
+		assert.NoErrorf(t, obj.MarshalLogObject(enc), "failed to log %v", v)
+		return
+	}
+
+	if arr, ok := v.(zapcore.ArrayMarshaler); ok {
+		assert.NoErrorf(t, enc.AddArray("values", arr), "failed to log %v", v)
 		return
 	}
 

--- a/gen/zap_test.go
+++ b/gen/zap_test.go
@@ -783,3 +783,11 @@ func TestMarshallingErrorCollation(t *testing.T) {
 		assert.Contains(t, err.Error(), `could not add item 2`)
 	})
 }
+
+func TestLogNilStruct(t *testing.T) {
+	enc := zapcore.NewMapObjectEncoder()
+
+	var x *ts.Edge
+	require.NoError(t, x.MarshalLogObject(enc))
+	assert.Empty(t, enc.Fields)
+}

--- a/internal/envelope/exception/types.go
+++ b/internal/envelope/exception/types.go
@@ -489,6 +489,9 @@ func (v *TApplicationException) Equals(rhs *TApplicationException) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of TApplicationException.
 func (v *TApplicationException) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Message != nil {
 		enc.AddString("message", *v.Message)
 	}

--- a/plugin/api/plugin_goodbye.go
+++ b/plugin/api/plugin_goodbye.go
@@ -117,6 +117,9 @@ func (v *Plugin_Goodbye_Args) Equals(rhs *Plugin_Goodbye_Args) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Plugin_Goodbye_Args.
 func (v *Plugin_Goodbye_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 
@@ -291,6 +294,9 @@ func (v *Plugin_Goodbye_Result) Equals(rhs *Plugin_Goodbye_Result) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Plugin_Goodbye_Result.
 func (v *Plugin_Goodbye_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 

--- a/plugin/api/plugin_handshake.go
+++ b/plugin/api/plugin_handshake.go
@@ -153,6 +153,9 @@ func (v *Plugin_Handshake_Args) Equals(rhs *Plugin_Handshake_Args) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Plugin_Handshake_Args.
 func (v *Plugin_Handshake_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Request != nil {
 		err = multierr.Append(err, enc.AddObject("request", v.Request))
 	}
@@ -401,6 +404,9 @@ func (v *Plugin_Handshake_Result) Equals(rhs *Plugin_Handshake_Result) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Plugin_Handshake_Result.
 func (v *Plugin_Handshake_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Success != nil {
 		err = multierr.Append(err, enc.AddObject("success", v.Success))
 	}

--- a/plugin/api/servicegenerator_generate.go
+++ b/plugin/api/servicegenerator_generate.go
@@ -153,6 +153,9 @@ func (v *ServiceGenerator_Generate_Args) Equals(rhs *ServiceGenerator_Generate_A
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ServiceGenerator_Generate_Args.
 func (v *ServiceGenerator_Generate_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Request != nil {
 		err = multierr.Append(err, enc.AddObject("request", v.Request))
 	}
@@ -401,6 +404,9 @@ func (v *ServiceGenerator_Generate_Result) Equals(rhs *ServiceGenerator_Generate
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of ServiceGenerator_Generate_Result.
 func (v *ServiceGenerator_Generate_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Success != nil {
 		err = multierr.Append(err, enc.AddObject("success", v.Success))
 	}

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -198,6 +198,9 @@ func (v *Argument) Equals(rhs *Argument) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Argument.
 func (v *Argument) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("name", v.Name)
 	err = multierr.Append(err, enc.AddObject("type", v.Type))
 	return err
@@ -846,6 +849,9 @@ func (m _Map_String_String_Zapper) MarshalLogObject(enc zapcore.ObjectEncoder) (
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Function.
 func (v *Function) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("name", v.Name)
 	enc.AddString("thriftName", v.ThriftName)
 	err = multierr.Append(err, enc.AddArray("arguments", (_List_Argument_Zapper)(v.Arguments)))
@@ -1413,6 +1419,9 @@ func (m _Map_ModuleID_Module_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of GenerateServiceRequest.
 func (v *GenerateServiceRequest) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	err = multierr.Append(err, enc.AddArray("rootServices", (_List_ServiceID_Zapper)(v.RootServices)))
 	err = multierr.Append(err, enc.AddArray("services", (_Map_ServiceID_Service_Zapper)(v.Services)))
 	err = multierr.Append(err, enc.AddArray("modules", (_Map_ModuleID_Module_Zapper)(v.Modules)))
@@ -1645,6 +1654,9 @@ func (m _Map_String_Binary_Zapper) MarshalLogObject(enc zapcore.ObjectEncoder) (
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of GenerateServiceResponse.
 func (v *GenerateServiceResponse) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.Files != nil {
 		err = multierr.Append(err, enc.AddObject("files", (_Map_String_Binary_Zapper)(v.Files)))
 	}
@@ -1747,6 +1759,9 @@ func (v *HandshakeRequest) Equals(rhs *HandshakeRequest) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of HandshakeRequest.
 func (v *HandshakeRequest) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	return err
 }
 
@@ -2041,6 +2056,9 @@ func (l _List_Feature_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err err
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of HandshakeResponse.
 func (v *HandshakeResponse) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("name", v.Name)
 	enc.AddInt32("apiVersion", v.APIVersion)
 	err = multierr.Append(err, enc.AddArray("features", (_List_Feature_Zapper)(v.Features)))
@@ -2221,6 +2239,9 @@ func (v *Module) Equals(rhs *Module) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Module.
 func (v *Module) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("importPath", v.ImportPath)
 	enc.AddString("directory", v.Directory)
 	return err
@@ -2619,6 +2640,9 @@ func (l _List_Function_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err er
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Service.
 func (v *Service) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("name", v.Name)
 	enc.AddString("thriftName", v.ThriftName)
 	if v.ParentID != nil {
@@ -3265,6 +3289,9 @@ func (v *Type) Equals(rhs *Type) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of Type.
 func (v *Type) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	if v.SimpleType != nil {
 		err = multierr.Append(err, enc.AddObject("simpleType", *v.SimpleType))
 	}
@@ -3492,6 +3519,9 @@ func (v *TypePair) Equals(rhs *TypePair) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of TypePair.
 func (v *TypePair) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	err = multierr.Append(err, enc.AddObject("left", v.Left))
 	err = multierr.Append(err, enc.AddObject("right", v.Right))
 	return err
@@ -3689,6 +3719,9 @@ func (v *TypeReference) Equals(rhs *TypeReference) bool {
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
 // fast logging of TypeReference.
 func (v *TypeReference) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
 	enc.AddString("name", v.Name)
 	enc.AddString("importPath", v.ImportPath)
 	if v.Annotations != nil {


### PR DESCRIPTION
Previously, the generated code for structs was not handling the case
when MarshalLogObject is called on a nil value.

```
var x *Foo
x.MarshalLogObject(enc)
```

This is a problem if we pass Zap a non-nil zapcore.ObjectMarshaler with
a nil value. (See https://tour.golang.org/methods/12.)

This changes the generated code to handle the nil receiver case
explicitly.

Caveat: With this change, when you attempt to log a non-nil
zapcore.ObjectMarshaler with a nil struct, it will log an empty object,
not `null`. This isn't perfect but it's better than panicking. Arguably,
attempting to log a nil value with a non-nil interface is approaching
undefined behavior territory, so graceful degradation is better than
nothing.

Resolves #390