### PR TITLE
Sanitize import aliases

### DIFF
--- a/gen/imports.go
+++ b/gen/imports.go
@@ -24,8 +24,8 @@ import (
 	"go/ast"
 	"go/token"
 	"path/filepath"
-	"strings"
-	"unicode"
+
+	"go.uber.org/thriftrw/internal/goast"
 )
 
 // importer is responsible for managing imports for the code generator and
@@ -72,33 +72,14 @@ func (i importer) Import(path string) string {
 		return filepath.Base(path)
 	}
 
-	// Find a name, preferring the base name
-	// TODO what if the package name is not the base name?
-	baseName := filepath.Base(path)
-	name := i.ns.NewName(sanitizeImportName(baseName))
-	astImport := &ast.ImportSpec{Path: stringLiteral(path)}
-	if name != baseName {
-		astImport.Name = ast.NewIdent(name)
+	name := i.ns.NewName(goast.DeterminePackageName(path))
+	astImport := &ast.ImportSpec{
+		Name: ast.NewIdent(name),
+		Path: stringLiteral(path),
 	}
 
 	i.imports[path] = astImport
 	return name
-}
-
-func sanitizeImportName(s string) string {
-	// special handling for common "foo-go" pattern
-	if strings.HasSuffix(s, "-go") {
-		s = s[:len(s)-3]
-	}
-
-	return strings.Map(func(c rune) rune {
-		switch {
-		case unicode.IsLetter(c), unicode.IsDigit(c):
-			return c
-		default:
-			return '_'
-		}
-	}, s)
 }
 
 // importDecl builds an import declation from the given list of imports.

--- a/gen/internal/tests/collision/idl.go
+++ b/gen/internal/tests/collision/idl.go
@@ -3,7 +3,7 @@
 
 package collision
 
-import "go.uber.org/thriftrw/thriftreflect"
+import thriftreflect "go.uber.org/thriftrw/thriftreflect"
 
 // ThriftModule represents the IDL file used to generate this package.
 var ThriftModule = &thriftreflect.ThriftModule{

--- a/gen/internal/tests/collision/types.go
+++ b/gen/internal/tests/collision/types.go
@@ -4,16 +4,16 @@
 package collision
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"math"
-	"strconv"
-	"strings"
+	bytes "bytes"
+	json "encoding/json"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	math "math"
+	strconv "strconv"
+	strings "strings"
 )
 
 type AccessorConflict struct {

--- a/gen/internal/tests/constants/constants.go
+++ b/gen/internal/tests/constants/constants.go
@@ -4,13 +4,13 @@
 package constants
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/containers"
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/gen/internal/tests/exceptions"
-	"go.uber.org/thriftrw/gen/internal/tests/structs"
-	"go.uber.org/thriftrw/gen/internal/tests/typedefs"
-	"go.uber.org/thriftrw/gen/internal/tests/unions"
-	"go.uber.org/thriftrw/ptr"
+	containers "go.uber.org/thriftrw/gen/internal/tests/containers"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	exceptions "go.uber.org/thriftrw/gen/internal/tests/exceptions"
+	structs "go.uber.org/thriftrw/gen/internal/tests/structs"
+	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	unions "go.uber.org/thriftrw/gen/internal/tests/unions"
+	ptr "go.uber.org/thriftrw/ptr"
 )
 
 const Home enums.RecordType = enums.RecordTypeHomeAddress

--- a/gen/internal/tests/constants/idl.go
+++ b/gen/internal/tests/constants/idl.go
@@ -4,14 +4,14 @@
 package constants
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/containers"
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/gen/internal/tests/exceptions"
-	"go.uber.org/thriftrw/gen/internal/tests/other_constants"
-	"go.uber.org/thriftrw/gen/internal/tests/structs"
-	"go.uber.org/thriftrw/gen/internal/tests/typedefs"
-	"go.uber.org/thriftrw/gen/internal/tests/unions"
-	"go.uber.org/thriftrw/thriftreflect"
+	containers "go.uber.org/thriftrw/gen/internal/tests/containers"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	exceptions "go.uber.org/thriftrw/gen/internal/tests/exceptions"
+	other_constants "go.uber.org/thriftrw/gen/internal/tests/other_constants"
+	structs "go.uber.org/thriftrw/gen/internal/tests/structs"
+	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	unions "go.uber.org/thriftrw/gen/internal/tests/unions"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 )
 
 // ThriftModule represents the IDL file used to generate this package.

--- a/gen/internal/tests/containers/idl.go
+++ b/gen/internal/tests/containers/idl.go
@@ -4,11 +4,11 @@
 package containers
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/enum_conflict"
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/gen/internal/tests/typedefs"
-	"go.uber.org/thriftrw/gen/internal/tests/uuid_conflict"
-	"go.uber.org/thriftrw/thriftreflect"
+	enum_conflict "go.uber.org/thriftrw/gen/internal/tests/enum_conflict"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	uuid_conflict "go.uber.org/thriftrw/gen/internal/tests/uuid_conflict"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 )
 
 // ThriftModule represents the IDL file used to generate this package.

--- a/gen/internal/tests/containers/types.go
+++ b/gen/internal/tests/containers/types.go
@@ -4,18 +4,18 @@
 package containers
 
 import (
-	"bytes"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/enum_conflict"
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/gen/internal/tests/typedefs"
-	"go.uber.org/thriftrw/gen/internal/tests/uuid_conflict"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	bytes "bytes"
+	base64 "encoding/base64"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	enum_conflict "go.uber.org/thriftrw/gen/internal/tests/enum_conflict"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	uuid_conflict "go.uber.org/thriftrw/gen/internal/tests/uuid_conflict"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 type ContainersOfContainers struct {

--- a/gen/internal/tests/enum_conflict/constants.go
+++ b/gen/internal/tests/enum_conflict/constants.go
@@ -3,7 +3,7 @@
 
 package enum_conflict
 
-import "go.uber.org/thriftrw/gen/internal/tests/enums"
+import enums "go.uber.org/thriftrw/gen/internal/tests/enums"
 
 const DefaultOtherRecordType enums.RecordType = enums.RecordTypeName
 

--- a/gen/internal/tests/enum_conflict/idl.go
+++ b/gen/internal/tests/enum_conflict/idl.go
@@ -4,8 +4,8 @@
 package enum_conflict
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/thriftreflect"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 )
 
 // ThriftModule represents the IDL file used to generate this package.

--- a/gen/internal/tests/enum_conflict/types.go
+++ b/gen/internal/tests/enum_conflict/types.go
@@ -4,16 +4,16 @@
 package enum_conflict
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"math"
-	"strconv"
-	"strings"
+	bytes "bytes"
+	json "encoding/json"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	math "math"
+	strconv "strconv"
+	strings "strings"
 )
 
 type RecordType int32

--- a/gen/internal/tests/enums/idl.go
+++ b/gen/internal/tests/enums/idl.go
@@ -3,7 +3,7 @@
 
 package enums
 
-import "go.uber.org/thriftrw/thriftreflect"
+import thriftreflect "go.uber.org/thriftrw/thriftreflect"
 
 // ThriftModule represents the IDL file used to generate this package.
 var ThriftModule = &thriftreflect.ThriftModule{

--- a/gen/internal/tests/enums/types.go
+++ b/gen/internal/tests/enums/types.go
@@ -4,15 +4,15 @@
 package enums
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"math"
-	"strconv"
-	"strings"
+	bytes "bytes"
+	json "encoding/json"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	math "math"
+	strconv "strconv"
+	strings "strings"
 )
 
 type EmptyEnum int32

--- a/gen/internal/tests/exceptions/idl.go
+++ b/gen/internal/tests/exceptions/idl.go
@@ -3,7 +3,7 @@
 
 package exceptions
 
-import "go.uber.org/thriftrw/thriftreflect"
+import thriftreflect "go.uber.org/thriftrw/thriftreflect"
 
 // ThriftModule represents the IDL file used to generate this package.
 var ThriftModule = &thriftreflect.ThriftModule{

--- a/gen/internal/tests/exceptions/types.go
+++ b/gen/internal/tests/exceptions/types.go
@@ -4,11 +4,11 @@
 package exceptions
 
 import (
-	"errors"
-	"fmt"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	errors "errors"
+	fmt "fmt"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // Raised when something doesn't exist.

--- a/gen/internal/tests/nozap/idl.go
+++ b/gen/internal/tests/nozap/idl.go
@@ -3,7 +3,7 @@
 
 package nozap
 
-import "go.uber.org/thriftrw/thriftreflect"
+import thriftreflect "go.uber.org/thriftrw/thriftreflect"
 
 // ThriftModule represents the IDL file used to generate this package.
 var ThriftModule = &thriftreflect.ThriftModule{

--- a/gen/internal/tests/nozap/types.go
+++ b/gen/internal/tests/nozap/types.go
@@ -4,14 +4,14 @@
 package nozap
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"go.uber.org/thriftrw/wire"
-	"math"
-	"strconv"
-	"strings"
+	bytes "bytes"
+	json "encoding/json"
+	errors "errors"
+	fmt "fmt"
+	wire "go.uber.org/thriftrw/wire"
+	math "math"
+	strconv "strconv"
+	strings "strings"
 )
 
 type EnumDefault int32

--- a/gen/internal/tests/other_constants/constants.go
+++ b/gen/internal/tests/other_constants/constants.go
@@ -3,7 +3,7 @@
 
 package other_constants
 
-import "go.uber.org/thriftrw/gen/internal/tests/structs"
+import structs "go.uber.org/thriftrw/gen/internal/tests/structs"
 
 var ListOfInts []int32 = []int32{
 	1,

--- a/gen/internal/tests/other_constants/idl.go
+++ b/gen/internal/tests/other_constants/idl.go
@@ -4,8 +4,8 @@
 package other_constants
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/structs"
-	"go.uber.org/thriftrw/thriftreflect"
+	structs "go.uber.org/thriftrw/gen/internal/tests/structs"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 )
 
 // ThriftModule represents the IDL file used to generate this package.

--- a/gen/internal/tests/services/cache_clear.go
+++ b/gen/internal/tests/services/cache_clear.go
@@ -4,10 +4,10 @@
 package services
 
 import (
-	"fmt"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	fmt "fmt"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // Cache_Clear_Args represents the arguments for the Cache.clear function.

--- a/gen/internal/tests/services/cache_clearafter.go
+++ b/gen/internal/tests/services/cache_clearafter.go
@@ -4,10 +4,10 @@
 package services
 
 import (
-	"fmt"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	fmt "fmt"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // Cache_ClearAfter_Args represents the arguments for the Cache.clearAfter function.

--- a/gen/internal/tests/services/conflictingnames_setvalue.go
+++ b/gen/internal/tests/services/conflictingnames_setvalue.go
@@ -4,11 +4,11 @@
 package services
 
 import (
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // ConflictingNames_SetValue_Args represents the arguments for the ConflictingNames.setValue function.

--- a/gen/internal/tests/services/idl.go
+++ b/gen/internal/tests/services/idl.go
@@ -4,9 +4,9 @@
 package services
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/exceptions"
-	"go.uber.org/thriftrw/gen/internal/tests/unions"
-	"go.uber.org/thriftrw/thriftreflect"
+	exceptions "go.uber.org/thriftrw/gen/internal/tests/exceptions"
+	unions "go.uber.org/thriftrw/gen/internal/tests/unions"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 )
 
 // ThriftModule represents the IDL file used to generate this package.

--- a/gen/internal/tests/services/keyvalue_deletevalue.go
+++ b/gen/internal/tests/services/keyvalue_deletevalue.go
@@ -4,13 +4,13 @@
 package services
 
 import (
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/exceptions"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	exceptions "go.uber.org/thriftrw/gen/internal/tests/exceptions"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // KeyValue_DeleteValue_Args represents the arguments for the KeyValue.deleteValue function.

--- a/gen/internal/tests/services/keyvalue_getmanyvalues.go
+++ b/gen/internal/tests/services/keyvalue_getmanyvalues.go
@@ -4,14 +4,14 @@
 package services
 
 import (
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/exceptions"
-	"go.uber.org/thriftrw/gen/internal/tests/unions"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	exceptions "go.uber.org/thriftrw/gen/internal/tests/exceptions"
+	unions "go.uber.org/thriftrw/gen/internal/tests/unions"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // KeyValue_GetManyValues_Args represents the arguments for the KeyValue.getManyValues function.

--- a/gen/internal/tests/services/keyvalue_getvalue.go
+++ b/gen/internal/tests/services/keyvalue_getvalue.go
@@ -4,14 +4,14 @@
 package services
 
 import (
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/exceptions"
-	"go.uber.org/thriftrw/gen/internal/tests/unions"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	exceptions "go.uber.org/thriftrw/gen/internal/tests/exceptions"
+	unions "go.uber.org/thriftrw/gen/internal/tests/unions"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // KeyValue_GetValue_Args represents the arguments for the KeyValue.getValue function.

--- a/gen/internal/tests/services/keyvalue_setvalue.go
+++ b/gen/internal/tests/services/keyvalue_setvalue.go
@@ -4,12 +4,12 @@
 package services
 
 import (
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/unions"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	unions "go.uber.org/thriftrw/gen/internal/tests/unions"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // KeyValue_SetValue_Args represents the arguments for the KeyValue.setValue function.

--- a/gen/internal/tests/services/keyvalue_setvaluev2.go
+++ b/gen/internal/tests/services/keyvalue_setvaluev2.go
@@ -4,13 +4,13 @@
 package services
 
 import (
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/unions"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	unions "go.uber.org/thriftrw/gen/internal/tests/unions"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // KeyValue_SetValueV2_Args represents the arguments for the KeyValue.setValueV2 function.

--- a/gen/internal/tests/services/keyvalue_size.go
+++ b/gen/internal/tests/services/keyvalue_size.go
@@ -4,11 +4,11 @@
 package services
 
 import (
-	"errors"
-	"fmt"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	errors "errors"
+	fmt "fmt"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // KeyValue_Size_Args represents the arguments for the KeyValue.size function.

--- a/gen/internal/tests/services/non_standard_service_name_non_standard_function_name.go
+++ b/gen/internal/tests/services/non_standard_service_name_non_standard_function_name.go
@@ -4,10 +4,10 @@
 package services
 
 import (
-	"fmt"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	fmt "fmt"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // NonStandardServiceName_NonStandardFunctionName_Args represents the arguments for the non_standard_service_name.non_standard_function_name function.

--- a/gen/internal/tests/services/types.go
+++ b/gen/internal/tests/services/types.go
@@ -4,13 +4,13 @@
 package services
 
 import (
-	"bytes"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	bytes "bytes"
+	base64 "encoding/base64"
+	errors "errors"
+	fmt "fmt"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 type ConflictingNamesSetValueArgs struct {

--- a/gen/internal/tests/structs/idl.go
+++ b/gen/internal/tests/structs/idl.go
@@ -4,8 +4,8 @@
 package structs
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/thriftreflect"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 )
 
 // ThriftModule represents the IDL file used to generate this package.

--- a/gen/internal/tests/structs/types.go
+++ b/gen/internal/tests/structs/types.go
@@ -4,16 +4,16 @@
 package structs
 
 import (
-	"bytes"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/ptr"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	bytes "bytes"
+	base64 "encoding/base64"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	ptr "go.uber.org/thriftrw/ptr"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 type ContactInfo struct {

--- a/gen/internal/tests/typedefs/idl.go
+++ b/gen/internal/tests/typedefs/idl.go
@@ -4,9 +4,9 @@
 package typedefs
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/gen/internal/tests/structs"
-	"go.uber.org/thriftrw/thriftreflect"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	structs "go.uber.org/thriftrw/gen/internal/tests/structs"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 )
 
 // ThriftModule represents the IDL file used to generate this package.

--- a/gen/internal/tests/typedefs/types.go
+++ b/gen/internal/tests/typedefs/types.go
@@ -4,16 +4,16 @@
 package typedefs
 
 import (
-	"bytes"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/enums"
-	"go.uber.org/thriftrw/gen/internal/tests/structs"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	bytes "bytes"
+	base64 "encoding/base64"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	structs "go.uber.org/thriftrw/gen/internal/tests/structs"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 type _Set_Binary_ValueList [][]byte

--- a/gen/internal/tests/unions/idl.go
+++ b/gen/internal/tests/unions/idl.go
@@ -4,8 +4,8 @@
 package unions
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/typedefs"
-	"go.uber.org/thriftrw/thriftreflect"
+	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 )
 
 // ThriftModule represents the IDL file used to generate this package.

--- a/gen/internal/tests/unions/types.go
+++ b/gen/internal/tests/unions/types.go
@@ -4,13 +4,13 @@
 package unions
 
 import (
-	"encoding/base64"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/typedefs"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	base64 "encoding/base64"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // ArbitraryValue allows constructing complex values without a schema.

--- a/gen/internal/tests/uuid_conflict/idl.go
+++ b/gen/internal/tests/uuid_conflict/idl.go
@@ -4,8 +4,8 @@
 package uuid_conflict
 
 import (
-	"go.uber.org/thriftrw/gen/internal/tests/typedefs"
-	"go.uber.org/thriftrw/thriftreflect"
+	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 )
 
 // ThriftModule represents the IDL file used to generate this package.

--- a/gen/internal/tests/uuid_conflict/types.go
+++ b/gen/internal/tests/uuid_conflict/types.go
@@ -4,13 +4,13 @@
 package uuid_conflict
 
 import (
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/gen/internal/tests/typedefs"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 type UUID string

--- a/internal/goast/package.go
+++ b/internal/goast/package.go
@@ -23,6 +23,7 @@ package goast
 import (
 	"path/filepath"
 	"strings"
+	"unicode"
 )
 
 // DeterminePackageName determines the name of the package at the given import
@@ -32,5 +33,13 @@ func DeterminePackageName(importPath string) string {
 	if strings.HasSuffix(packageName, "-go") {
 		packageName = packageName[:len(packageName)-3]
 	}
-	return strings.Replace(packageName, "-", "_", -1)
+
+	return strings.Map(func(c rune) rune {
+		switch {
+		case unicode.IsLetter(c), unicode.IsDigit(c):
+			return c
+		default:
+			return '_'
+		}
+	}, packageName)
 }

--- a/plugin/template_test.go
+++ b/plugin/template_test.go
@@ -34,15 +34,15 @@ func TestGoFileFromTemplate(t *testing.T) {
 			data: &api.Type{
 				ReferenceType: &api.TypeReference{
 					Name:       "Foo",
-					ImportPath: "go.uber.org/thriftrw/bar",
+					ImportPath: "go.uber.org/thriftrw/bar.git",
 				},
 			},
 			wantBody: unlines(
 				`package foo`,
 				``,
-				`import bar "go.uber.org/thriftrw/bar"`,
+				`import bar_git "go.uber.org/thriftrw/bar.git"`,
 				``,
-				`var foo bar.Foo = nil`,
+				`var foo bar_git.Foo = nil`,
 			),
 		},
 		{


### PR DESCRIPTION
Re: https://github.com/thriftrw/thriftrw-go/pull/405

The recent fix to always create an import alias did not use the same sanitization logic found in the `gen.importer.Import` method. This consolidates the `sanitizeImportName` into `goast.DeterminePackageName` so that both codepaths are correctly sanitized. This also update our test to include a `*.git` import path and notice that the `.` is appropriately transformed into a `_`.