### PR TITLE
`func <T>Ptr(v <T>) *<T>` for primitive typedefs

### DIFF
--- a/ast/basetypeid_string.go
+++ b/ast/basetypeid_string.go
@@ -24,6 +24,20 @@ package ast
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[BoolTypeID-1]
+	_ = x[I8TypeID-2]
+	_ = x[I16TypeID-3]
+	_ = x[I32TypeID-4]
+	_ = x[I64TypeID-5]
+	_ = x[DoubleTypeID-6]
+	_ = x[StringTypeID-7]
+	_ = x[BinaryTypeID-8]
+}
+
 const _BaseTypeID_name = "BoolTypeIDI8TypeIDI16TypeIDI32TypeIDI64TypeIDDoubleTypeIDStringTypeIDBinaryTypeID"
 
 var _BaseTypeID_index = [...]uint8{0, 10, 18, 27, 36, 45, 57, 69, 81}

--- a/gen/internal/tests/collision/types.go
+++ b/gen/internal/tests/collision/types.go
@@ -446,6 +446,11 @@ func (v *AccessorNoConflict) IsSetGetName() bool {
 
 type LittlePotatoe int64
 
+// LittlePotatoePtr returns a pointer to a LittlePotatoe
+func LittlePotatoePtr(v LittlePotatoe) *LittlePotatoe {
+	return &v
+}
+
 // ToWire translates LittlePotatoe into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1658,6 +1663,11 @@ func (v *WithDefault) IsSetPouet() bool {
 }
 
 type LittlePotatoe2 float64
+
+// LittlePotatoe2Ptr returns a pointer to a LittlePotatoe2
+func LittlePotatoe2Ptr(v LittlePotatoe2) *LittlePotatoe2 {
+	return &v
+}
 
 // ToWire translates LittlePotatoe2 into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized

--- a/gen/internal/tests/services/types.go
+++ b/gen/internal/tests/services/types.go
@@ -340,6 +340,11 @@ func (v *InternalError) Error() string {
 
 type Key string
 
+// KeyPtr returns a pointer to a Key
+func KeyPtr(v Key) *Key {
+	return &v
+}
+
 // ToWire translates Key into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.

--- a/gen/internal/tests/typedefs/types.go
+++ b/gen/internal/tests/typedefs/types.go
@@ -947,6 +947,11 @@ func _EnumWithValues_Read(w wire.Value) (enums.EnumWithValues, error) {
 
 type MyEnum enums.EnumWithValues
 
+// MyEnumPtr returns a pointer to a MyEnum
+func MyEnumPtr(v MyEnum) *MyEnum {
+	return &v
+}
+
 // ToWire translates MyEnum into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1217,6 +1222,11 @@ func (v PointMap) MarshalLogArray(enc zapcore.ArrayEncoder) error {
 
 type State string
 
+// StatePtr returns a pointer to a State
+func StatePtr(v State) *State {
+	return &v
+}
+
 // ToWire translates State into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1376,6 +1386,11 @@ func (v StateMap) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 //
 // Deprecated: Use ISOTime instead.
 type Timestamp int64
+
+// TimestampPtr returns a pointer to a Timestamp
+func TimestampPtr(v Timestamp) *Timestamp {
+	return &v
+}
 
 // ToWire translates Timestamp into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized

--- a/gen/internal/tests/uuid_conflict/types.go
+++ b/gen/internal/tests/uuid_conflict/types.go
@@ -15,6 +15,11 @@ import (
 
 type UUID string
 
+// UUIDPtr returns a pointer to a UUID
+func UUIDPtr(v UUID) *UUID {
+	return &v
+}
+
 // ToWire translates UUID into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.

--- a/gen/typedef.go
+++ b/gen/typedef.go
@@ -64,6 +64,14 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 
 		<$v := newVar "v">
 		<$x := newVar "x">
+
+		<- if isPrimitiveType .>
+		// <typeName .>Ptr returns a pointer to a <$typedefType>
+		func <typeName .>Ptr(<$v> <$typedefType>) *<$typedefType>{
+			return &<$v>
+		}
+		<- end>
+
 		// ToWire translates <typeName .> into a Thrift-level intermediate
 		// representation. This intermediate representation may be serialized
 		// into bytes using a ThriftRW protocol implementation.

--- a/gen/typedef_test.go
+++ b/gen/typedef_test.go
@@ -538,3 +538,7 @@ func TestTypedefAccessors(t *testing.T) {
 		})
 	})
 }
+
+func TestTypedefPtr(t *testing.T) {
+	assert.Equal(t, td.State("foo"), *td.StatePtr("foo"))
+}

--- a/idl/internal/lex.go
+++ b/idl/internal/lex.go
@@ -22,7 +22,6 @@
 
 
 
-
 package internal
 
 import (
@@ -37,7 +36,6 @@ const thrift_first_final int = 19
 const thrift_error int = 0
 
 const thrift_en_main int = 19
-
 
 type lexer struct {
 	line    int
@@ -949,7 +947,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 
 		goto st19
 	tr21:
-
 		lex.lastDocstring = string(lex.data[lex.docstringStart : lex.p+1])
 		lex.linesSinceDocstring = 0
 
@@ -1306,7 +1303,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 
 		goto st19
 	tr30:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -2012,7 +2008,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto st10
 	tr13:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -2061,7 +2056,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto st13
 	tr18:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -2394,7 +2388,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr72
 	tr74:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -4282,7 +4275,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr133
 	tr135:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -4403,7 +4395,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr138
 	tr140:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -4617,7 +4608,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr145
 	tr147:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -5027,7 +5017,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr160
 	tr162:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -5648,7 +5637,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr180
 	tr182:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -6560,7 +6548,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr209
 	tr211:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -6849,7 +6836,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr220
 	tr222:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -7032,7 +7018,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr227
 	tr229:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -7225,7 +7210,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr238
 	tr240:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -8013,7 +7997,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr264
 	tr266:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -8103,7 +8086,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr268
 	tr270:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -8193,7 +8175,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr272
 	tr274:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -8252,7 +8233,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr275
 	tr277:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -8700,7 +8680,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr292
 	tr294:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -9350,7 +9329,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr311
 	tr313:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -9473,7 +9451,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr317
 	tr319:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -9850,7 +9827,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr331
 	tr333:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -10163,7 +10139,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr341
 	tr343:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -10408,7 +10383,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr350
 	tr352:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -11386,7 +11360,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr383
 	tr385:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -11740,7 +11713,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr398
 	tr400:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -11799,7 +11771,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr401
 	tr403:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -12048,7 +12019,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr410
 	tr412:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -12169,7 +12139,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr415
 	tr417:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -12679,7 +12648,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr432
 	tr434:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -12959,7 +12927,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr442
 	tr444:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -13173,7 +13140,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr450
 	tr452:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -13397,7 +13363,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr461
 	tr463:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -13803,7 +13768,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 		goto tr473
 	tr475:
-
 		lex.line++
 		lex.linesSinceDocstring++
 
@@ -16115,7 +16079,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		{
 		}
 	}
-
 
 	if lex.cs == thrift_error {
 		lex.Error(fmt.Sprintf("unknown token at index %d", lex.p))

--- a/internal/envelope/exception/idl.go
+++ b/internal/envelope/exception/idl.go
@@ -23,7 +23,7 @@
 
 package exception
 
-import "go.uber.org/thriftrw/thriftreflect"
+import thriftreflect "go.uber.org/thriftrw/thriftreflect"
 
 // ThriftModule represents the IDL file used to generate this package.
 var ThriftModule = &thriftreflect.ThriftModule{

--- a/internal/envelope/exception/types.go
+++ b/internal/envelope/exception/types.go
@@ -24,15 +24,15 @@
 package exception
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"math"
-	"strconv"
-	"strings"
+	bytes "bytes"
+	json "encoding/json"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	math "math"
+	strconv "strconv"
+	strings "strings"
 )
 
 type ExceptionType int32

--- a/plugin/api/idl.go
+++ b/plugin/api/idl.go
@@ -23,7 +23,7 @@
 
 package api
 
-import "go.uber.org/thriftrw/thriftreflect"
+import thriftreflect "go.uber.org/thriftrw/thriftreflect"
 
 // ThriftModule represents the IDL file used to generate this package.
 var ThriftModule = &thriftreflect.ThriftModule{

--- a/plugin/api/plugin_goodbye.go
+++ b/plugin/api/plugin_goodbye.go
@@ -24,10 +24,10 @@
 package api
 
 import (
-	"fmt"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	fmt "fmt"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // Plugin_Goodbye_Args represents the arguments for the Plugin.goodbye function.

--- a/plugin/api/plugin_handshake.go
+++ b/plugin/api/plugin_handshake.go
@@ -24,12 +24,12 @@
 package api
 
 import (
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // Plugin_Handshake_Args represents the arguments for the Plugin.handshake function.

--- a/plugin/api/servicegenerator_generate.go
+++ b/plugin/api/servicegenerator_generate.go
@@ -24,12 +24,12 @@
 package api
 
 import (
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"strings"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	strings "strings"
 )
 
 // ServiceGenerator_Generate_Args represents the arguments for the ServiceGenerator.generate function.

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -24,17 +24,17 @@
 package api
 
 import (
-	"bytes"
-	"encoding/base64"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"go.uber.org/multierr"
-	"go.uber.org/thriftrw/wire"
-	"go.uber.org/zap/zapcore"
-	"math"
-	"strconv"
-	"strings"
+	bytes "bytes"
+	base64 "encoding/base64"
+	json "encoding/json"
+	errors "errors"
+	fmt "fmt"
+	multierr "go.uber.org/multierr"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
+	math "math"
+	strconv "strconv"
+	strings "strings"
 )
 
 // Argument is a single Argument inside a Function.

--- a/plugin/api/types.go
+++ b/plugin/api/types.go
@@ -2499,6 +2499,11 @@ func (v *Module) GetThriftFilePath() (o string) {
 // modules in this request.
 type ModuleID int32
 
+// ModuleIDPtr returns a pointer to a ModuleID
+func ModuleIDPtr(v ModuleID) *ModuleID {
+	return &v
+}
+
 // ToWire translates ModuleID into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -2970,6 +2975,11 @@ func (v *Service) IsSetAnnotations() bool {
 // ServiceID is an arbitrary unique identifier to reference the different
 // services in this request.
 type ServiceID int32
+
+// ServiceIDPtr returns a pointer to a ServiceID
+func ServiceIDPtr(v ServiceID) *ServiceID {
+	return &v
+}
 
 // ToWire translates ServiceID into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized

--- a/wire/type_string.go
+++ b/wire/type_string.go
@@ -24,6 +24,23 @@ package wire
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[TBool-2]
+	_ = x[TI8-3]
+	_ = x[TDouble-4]
+	_ = x[TI16-6]
+	_ = x[TI32-8]
+	_ = x[TI64-10]
+	_ = x[TBinary-11]
+	_ = x[TStruct-12]
+	_ = x[TMap-13]
+	_ = x[TSet-14]
+	_ = x[TList-15]
+}
+
 const (
 	_Type_name_0 = "TBoolTI8TDouble"
 	_Type_name_1 = "TI16"


### PR DESCRIPTION
Using typedefs on a base type is a common thrift pattern used to
describe the kind of value that is within. While structs are trivial to
form a pointer to (`&Foo{"foo"}`), this is not the case with primitive
types (`type Jack string`, `&Jack("RJ45")`). This adds `<T>Ptr`
functions for primitive type aliases (`JackPtr("RJ45")`).