### PR TITLE
Always add module to GenerateServiceResponse

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -282,6 +282,15 @@ func generateModule(
 		}
 	}
 
+	addModules := func(m *compile.Module) error {
+		_, err := builder.AddModule(m.ThriftPath)
+		return err
+	}
+
+	if err := m.Walk(addModules); err != nil {
+		return "", nil, err
+	}
+
 	// Services must be generated last because names of user-defined types take
 	// precedence over the names we pick for the service types.
 	if len(m.Services) > 0 {

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -262,6 +262,38 @@ func TestGenerate(t *testing.T) {
 	}
 }
 
+func TestGenerateModule(t *testing.T) {
+	t.Run("module data should be added to the GenerateServiceBuilder even if the Thrift module contains no service data", func(t *testing.T) {
+		thriftRoot := testdata(t, "thrift")
+
+		importer := thriftPackageImporter{
+			ImportPrefix: "go.uber.org/thriftrw/gen/internal/tests",
+			ThriftRoot:   thriftRoot,
+		}
+
+		genBuilder := newGenerateServiceBuilder(importer)
+
+		module, err := compile.Compile("internal/tests/thrift/structs.thrift")
+		require.NoError(t, err)
+		assert.Equal(t, len(module.Services), 0)
+
+		opt := &Options{
+			OutputDir:     "test/internal",
+			PackagePrefix: "go.uber.org/thriftrw/gen",
+			ThriftRoot:    thriftRoot,
+		}
+
+		_, _, err = generateModule(module, importer, genBuilder, opt)
+		require.NoError(t, err)
+
+		gen := genBuilder.Build()
+
+		assert.Equal(t, len(gen.RootServices), 0)
+		assert.Equal(t, len(gen.Services), 0)
+		assert.Equal(t, len(gen.Modules), 2)
+	})
+}
+
 func TestThriftPackageImporter(t *testing.T) {
 	importer := thriftPackageImporter{
 		ImportPrefix: "github.com/myteam/myservice",

--- a/gen/plugin.go
+++ b/gen/plugin.go
@@ -85,8 +85,8 @@ func (g *generateServiceBuilder) AddRootService(spec *compile.ServiceSpec) (api.
 	return id, err
 }
 
-// addModule adds the module for the given Thrift file to the request.
-func (g *generateServiceBuilder) addModule(thriftPath string) (api.ModuleID, error) {
+// AddModule adds the module for the given Thrift file to the request.
+func (g *generateServiceBuilder) AddModule(thriftPath string) (api.ModuleID, error) {
 	if id, ok := g.moduleIDs[thriftPath]; ok {
 		return id, nil
 	}
@@ -135,9 +135,10 @@ func (g *generateServiceBuilder) addService(spec *compile.ServiceSpec) (api.Serv
 	g.nextServiceID++
 	g.serviceIDs[spec.ThriftFile()][serviceName(spec.Name)] = serviceID
 
-	moduleID, err := g.addModule(spec.ThriftFile())
-	if err != nil {
-		return 0, err
+	// Modules must already be populated.
+	moduleID, ok := g.moduleIDs[spec.ThriftFile()]
+	if !ok {
+		return 0, fmt.Errorf("unable to lookup module ID for Thrift file: %q", spec.ThriftFile())
 	}
 
 	functions := make([]*api.Function, 0, len(spec.Functions))

--- a/gen/plugin_test.go
+++ b/gen/plugin_test.go
@@ -169,6 +169,12 @@ func TestAddRootService(t *testing.T) {
 		}
 
 		g := newGenerateServiceBuilder(importer)
+
+		if spec.Parent != nil {
+			g.AddModule(spec.Parent.ThriftFile())
+		}
+		g.AddModule(spec.ThriftFile())
+
 		if _, err := g.AddRootService(spec); assert.NoError(t, err, tt.desc) {
 			assert.Equal(t, tt.want, g.Build(), tt.desc)
 		}


### PR DESCRIPTION
Adds Thrift module data to the GenerateServiceResponse even if
the module provided to the GenerateServiceRequest contains no Thrift
Service information. This ensures that ThrifRW plugins always receive
Thirft module data even if a Thrift file has no service declarations.