### PR TITLE
compile/service: fix nil deref for exception

### DIFF
--- a/compile/service.go
+++ b/compile/service.go
@@ -313,7 +313,12 @@ func (rs *ResultSpec) Link(scope Scope) (err error) {
 	// verify that everything listed under throws is an exception.
 	for _, exception := range rs.Exceptions {
 		spec, ok := exception.Type.(*StructSpec)
-		if !ok || spec.Type != ast.ExceptionType {
+		if !ok {
+			return notAnExceptionError{
+				FieldName: exception.ThriftName(),
+			}
+		}
+		if spec.Type != ast.ExceptionType {
 			return notAnExceptionError{
 				FieldName: exception.ThriftName(),
 				TypeName:  spec.ThriftName(),

--- a/compile/service.go
+++ b/compile/service.go
@@ -313,15 +313,10 @@ func (rs *ResultSpec) Link(scope Scope) (err error) {
 	// verify that everything listed under throws is an exception.
 	for _, exception := range rs.Exceptions {
 		spec, ok := exception.Type.(*StructSpec)
-		if !ok {
+		if !ok || spec.Type != ast.ExceptionType {
 			return notAnExceptionError{
 				FieldName: exception.ThriftName(),
-			}
-		}
-		if spec.Type != ast.ExceptionType {
-			return notAnExceptionError{
-				FieldName: exception.ThriftName(),
-				TypeName:  spec.ThriftName(),
+				TypeName:  exception.Type.ThriftName(),
 			}
 		}
 	}

--- a/compile/service_test.go
+++ b/compile/service_test.go
@@ -432,6 +432,27 @@ func TestLinkServiceFailure(t *testing.T) {
 			},
 		},
 		{
+			"unexpected exception type",
+			`
+				service Foo {
+					void foo()
+						throws (
+							1: i64 a
+						)
+				}
+			`,
+			scope(
+				"SomeException", &StructSpec{
+					Name:   "SomeException",
+					Type:   ast.ExceptionType,
+					Fields: make(FieldGroup, 0),
+				},
+			),
+			[]string{
+				`field "a" with type "" is not an exception`,
+			},
+		},
+		{
 			"unknown return type",
 			"service Foo { Baz bar() }",
 			nil,

--- a/compile/service_test.go
+++ b/compile/service_test.go
@@ -449,7 +449,7 @@ func TestLinkServiceFailure(t *testing.T) {
 				},
 			),
 			[]string{
-				`field "a" with type "" is not an exception`,
+				`field "a" with type "i64" is not an exception`,
 			},
 		},
 		{


### PR DESCRIPTION
If you attempt to use a type that isn't user defined as an exception,
the system panics instead of returning an error.

This change fixes the issue and adds a failing test case.