### PR TITLE
Changed field compilation to be case-sensitive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Fixed field compilation to allow fields with similar looking names and
+  different casing.
 
 ## [1.20.0] - 2019-06-12
 ### Changed

--- a/compile/field.go
+++ b/compile/field.go
@@ -175,7 +175,7 @@ type FieldGroup []*FieldSpec
 
 // compileFields compiles a collection of AST fields into a FieldGroup.
 func compileFields(src []*ast.Field, options fieldOptions) (FieldGroup, error) {
-	fieldsNS := newNamespace(caseInsensitive)
+	fieldsNS := newNamespace(caseSensitive)
 	usedIDs := make(map[int16]string)
 
 	fields := make([]*FieldSpec, 0, len(src))

--- a/compile/struct_test.go
+++ b/compile/struct_test.go
@@ -90,6 +90,35 @@ func TestCompileStructSuccess(t *testing.T) {
 			},
 		},
 		{
+			`struct Foo {
+				1: string island
+				2: string isLand
+			}`,
+			nil,
+			defaultToOptional,
+			&StructSpec{
+				Name: "Foo",
+				File: "test.thrift",
+				Type: ast.StructType,
+				Fields: FieldGroup{
+					{
+						ID:       1,
+						Name:     "island",
+						Type:     &StringSpec{},
+						Required: false,
+						Default:  nil,
+					},
+					{
+						ID:       2,
+						Name:     "isLand",
+						Type:     &StringSpec{},
+						Required: false,
+						Default:  nil,
+					},
+				},
+			},
+		},
+		{
 			`exception KeyNotFoundError {
 				1: required string message
 				2: optional Key key


### PR DESCRIPTION
This behavior is consistent with thriftrw-node as well as Apache thrift.