### PR TITLE
Add canonical import directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Added canonical import path directive to avoid checking out ThriftRW at the
+  wrong import path.
 
 ## [1.20.1] - 2019-07-30
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package main // import "go.uber.org/thriftrw"
 
 import (
 	"bytes"


### PR DESCRIPTION
I realized we never added the canonical import path directive for this
repository so people were constantly cloning it into
`$GOPATH/src/github.com/thriftrw/thriftrw-go` and failing to compile it
because the imports are all under `go.uber.org/thriftrw`.

This commit adds a canonical import path directive to avoid issues like
this.