### PR TITLE
 Include annotations in Arguments as defined in the Thrift file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- Arguments now include Annotations as defined in the Thrift file.
 
 ## [1.21.0] - 2020-01-02
 ### Added

--- a/gen/plugin.go
+++ b/gen/plugin.go
@@ -210,8 +210,9 @@ func (g *generateServiceBuilder) buildFieldGroup(fs compile.FieldGroup) ([]*api.
 			return nil, err
 		}
 		args = append(args, &api.Argument{
-			Name: name,
-			Type: t,
+			Name:        name,
+			Type:        t,
+			Annotations: f.Annotations,
 		})
 	}
 	return args, nil

--- a/gen/plugin_test.go
+++ b/gen/plugin_test.go
@@ -216,6 +216,9 @@ func TestBuildFunction(t *testing.T) {
 									},
 								},
 							},
+							Annotations: map[string]string{
+								"foo": "bar",
+							},
 						},
 					},
 				},
@@ -240,6 +243,9 @@ func TestBuildFunction(t *testing.T) {
 									ImportPath: "go.uber.org/thriftrw/gen/internal/tests/keyvalue",
 								},
 							},
+						},
+						Annotations: map[string]string{
+							"foo": "bar",
 						},
 					},
 				},

--- a/idl/internal/lex.rl
+++ b/idl/internal/lex.rl
@@ -4,9 +4,7 @@ package internal
 
 import (
     "fmt"
-    "io"
     "strconv"
-    "strings"
 
     "go.uber.org/thriftrw/ast"
 )

--- a/plugin/api.thrift
+++ b/plugin/api.thrift
@@ -130,6 +130,24 @@ struct Argument {
      * Argument type.
      */
     2: required Type type
+    /**
+     * Annotations defined on this argument.
+     *
+     * Given,
+     *
+     *   void setValue(
+     *     1: SetValueRequest req
+     *   ) throws (
+     *     1: BadRequestError badRequestError (cache = "false")
+     *   )
+     *
+     * The annotations for the Argument representing badRequestError will be,
+     *
+     *  {
+     *    "cache": "false",
+     *  }
+     */
+    3: optional map<string, string> annotations;
 }
 
 /**

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -59,7 +59,58 @@ type Argument struct {
 	Name string `json:"name,required"`
 	// Argument type.
 	Type *Type `json:"type,required"`
+	// Annotations defined on this argument.
+	//
+	// Given,
+	//
+	//   void setValue(
+	//     1: SetValueRequest req
+	//   ) throws (
+	//     1: BadRequestError badRequestError (cache = "false")
+	//   )
+	//
+	// The annotations for the Argument representing badRequestError will be,
+	//
+	//  {
+	//    "cache": "false",
+	//  }
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
+
+type _Map_String_String_MapItemList map[string]string
+
+func (m _Map_String_String_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for k, v := range m {
+		kw, err := wire.NewValueString(k), error(nil)
+		if err != nil {
+			return err
+		}
+
+		vw, err := wire.NewValueString(v), error(nil)
+		if err != nil {
+			return err
+		}
+		err = f(wire.MapItem{Key: kw, Value: vw})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_String_String_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_String_String_MapItemList) KeyType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_String_MapItemList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_String_MapItemList) Close() {}
 
 // ToWire translates a Argument struct into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
@@ -78,7 +129,7 @@ type Argument struct {
 //   }
 func (v *Argument) ToWire() (wire.Value, error) {
 	var (
-		fields [2]wire.Field
+		fields [3]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -99,6 +150,14 @@ func (v *Argument) ToWire() (wire.Value, error) {
 	}
 	fields[i] = wire.Field{ID: 2, Value: w}
 	i++
+	if v.Annotations != nil {
+		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.Annotations)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 3, Value: w}
+		i++
+	}
 
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
@@ -107,6 +166,34 @@ func _Type_Read(w wire.Value) (*Type, error) {
 	var v Type
 	err := v.FromWire(w)
 	return &v, err
+}
+
+func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
+	if m.KeyType() != wire.TBinary {
+		return nil, nil
+	}
+
+	if m.ValueType() != wire.TBinary {
+		return nil, nil
+	}
+
+	o := make(map[string]string, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
+		k, err := x.Key.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+
+		v, err := x.Value.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+
+		o[k] = v
+		return nil
+	})
+	m.Close()
+	return o, err
 }
 
 // FromWire deserializes a Argument struct from its Thrift-level
@@ -150,6 +237,14 @@ func (v *Argument) FromWire(w wire.Value) error {
 				}
 				typeIsSet = true
 			}
+		case 3:
+			if field.Value.Type() == wire.TMap {
+				v.Annotations, err = _Map_String_String_Read(field.Value.GetMap())
+				if err != nil {
+					return err
+				}
+
+			}
 		}
 	}
 
@@ -171,14 +266,35 @@ func (v *Argument) String() string {
 		return "<nil>"
 	}
 
-	var fields [2]string
+	var fields [3]string
 	i := 0
 	fields[i] = fmt.Sprintf("Name: %v", v.Name)
 	i++
 	fields[i] = fmt.Sprintf("Type: %v", v.Type)
 	i++
+	if v.Annotations != nil {
+		fields[i] = fmt.Sprintf("Annotations: %v", v.Annotations)
+		i++
+	}
 
 	return fmt.Sprintf("Argument{%v}", strings.Join(fields[:i], ", "))
+}
+
+func _Map_String_String_Equals(lhs, rhs map[string]string) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	for lk, lv := range lhs {
+		rv, ok := rhs[lk]
+		if !ok {
+			return false
+		}
+		if !(lv == rv) {
+			return false
+		}
+	}
+	return true
 }
 
 // Equals returns true if all the fields of this Argument match the
@@ -197,8 +313,22 @@ func (v *Argument) Equals(rhs *Argument) bool {
 	if !v.Type.Equals(rhs.Type) {
 		return false
 	}
+	if !((v.Annotations == nil && rhs.Annotations == nil) || (v.Annotations != nil && rhs.Annotations != nil && _Map_String_String_Equals(v.Annotations, rhs.Annotations))) {
+		return false
+	}
 
 	return true
+}
+
+type _Map_String_String_Zapper map[string]string
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of _Map_String_String_Zapper.
+func (m _Map_String_String_Zapper) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	for k, v := range m {
+		enc.AddString((string)(k), v)
+	}
+	return err
 }
 
 // MarshalLogObject implements zapcore.ObjectMarshaler, enabling
@@ -209,6 +339,9 @@ func (v *Argument) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	}
 	enc.AddString("name", v.Name)
 	err = multierr.Append(err, enc.AddObject("type", v.Type))
+	if v.Annotations != nil {
+		err = multierr.Append(err, enc.AddObject("annotations", (_Map_String_String_Zapper)(v.Annotations)))
+	}
 	return err
 }
 
@@ -233,6 +366,21 @@ func (v *Argument) GetType() (o *Type) {
 // IsSetType returns true if Type is not nil.
 func (v *Argument) IsSetType() bool {
 	return v != nil && v.Type != nil
+}
+
+// GetAnnotations returns the value of Annotations if it is set or its
+// zero value if it is unset.
+func (v *Argument) GetAnnotations() (o map[string]string) {
+	if v != nil && v.Annotations != nil {
+		return v.Annotations
+	}
+
+	return
+}
+
+// IsSetAnnotations returns true if Annotations is not nil.
+func (v *Argument) IsSetAnnotations() bool {
+	return v != nil && v.Annotations != nil
 }
 
 // Feature is a functionality offered by a ThriftRW plugin.
@@ -463,41 +611,6 @@ func (_List_Argument_ValueList) ValueType() wire.Type {
 
 func (_List_Argument_ValueList) Close() {}
 
-type _Map_String_String_MapItemList map[string]string
-
-func (m _Map_String_String_MapItemList) ForEach(f func(wire.MapItem) error) error {
-	for k, v := range m {
-		kw, err := wire.NewValueString(k), error(nil)
-		if err != nil {
-			return err
-		}
-
-		vw, err := wire.NewValueString(v), error(nil)
-		if err != nil {
-			return err
-		}
-		err = f(wire.MapItem{Key: kw, Value: vw})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m _Map_String_String_MapItemList) Size() int {
-	return len(m)
-}
-
-func (_Map_String_String_MapItemList) KeyType() wire.Type {
-	return wire.TBinary
-}
-
-func (_Map_String_String_MapItemList) ValueType() wire.Type {
-	return wire.TBinary
-}
-
-func (_Map_String_String_MapItemList) Close() {}
-
 // ToWire translates a Function struct into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -598,34 +711,6 @@ func _List_Argument_Read(l wire.ValueList) ([]*Argument, error) {
 		return nil
 	})
 	l.Close()
-	return o, err
-}
-
-func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
-	if m.KeyType() != wire.TBinary {
-		return nil, nil
-	}
-
-	if m.ValueType() != wire.TBinary {
-		return nil, nil
-	}
-
-	o := make(map[string]string, m.Size())
-	err := m.ForEach(func(x wire.MapItem) error {
-		k, err := x.Key.GetString(), error(nil)
-		if err != nil {
-			return err
-		}
-
-		v, err := x.Value.GetString(), error(nil)
-		if err != nil {
-			return err
-		}
-
-		o[k] = v
-		return nil
-	})
-	m.Close()
 	return o, err
 }
 
@@ -791,23 +876,6 @@ func _Bool_EqualsPtr(lhs, rhs *bool) bool {
 	return lhs == nil && rhs == nil
 }
 
-func _Map_String_String_Equals(lhs, rhs map[string]string) bool {
-	if len(lhs) != len(rhs) {
-		return false
-	}
-
-	for lk, lv := range lhs {
-		rv, ok := rhs[lk]
-		if !ok {
-			return false
-		}
-		if !(lv == rv) {
-			return false
-		}
-	}
-	return true
-}
-
 // Equals returns true if all the fields of this Function match the
 // provided Function.
 //
@@ -850,17 +918,6 @@ type _List_Argument_Zapper []*Argument
 func (l _List_Argument_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err error) {
 	for _, v := range l {
 		err = multierr.Append(err, enc.AppendObject(v))
-	}
-	return err
-}
-
-type _Map_String_String_Zapper map[string]string
-
-// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
-// fast logging of _Map_String_String_Zapper.
-func (m _Map_String_String_Zapper) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
-	for k, v := range m {
-		enc.AddString((string)(k), v)
 	}
 	return err
 }
@@ -4100,11 +4157,11 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "api",
 	Package:  "go.uber.org/thriftrw/plugin/api",
 	FilePath: "api.thrift",
-	SHA1:     "ebc6ad9a8a9a94030fc8552588b6fb2b006ca7cc",
+	SHA1:     "2ec53cec3e4ed0e3d00c1d88c002ea0a5af97572",
 	Raw:      rawIDL,
 }
 
-const rawIDL = "/**\n * API_VERSION is the version of the plugin API.\n *\n * This MUST be provided in the HandshakeResponse.\n */\nconst i32 API_VERSION = 4\n\n/**\n * ServiceID is an arbitrary unique identifier to reference the different\n * services in this request.\n */\ntypedef i32 ServiceID\n\n/**\n * ModuleID is an arbitrary unique identifier to reference the different\n * modules in this request.\n */\ntypedef i32 ModuleID\n\n/**\n * TypeReference is a reference to a user-defined type.\n */\nstruct TypeReference {\n    1: required string name\n    /**\n     * Import path for the package defining this type.\n     */\n    2: required string importPath\n\n    /**\n     * Annotations defined on this type.\n     *\n     * Note that these are the Thrift annotations listed after the type\n     * declaration in the Thrift file.\n     *\n     * Given,\n     *\n     *   struct User {\n     *     1: required i32 id\n     *     2: required string name\n     *   } (key = \"id\", validate)\n     *\n     * The annotations will be,\n     *\n     *   {\n     *     \"key\": \"id\",\n     *     \"validate\": \"\",\n     *   }\n     */\n    3: optional map<string, string> annotations\n\n    // TODO(abg): Should this just be using ModuleID instead of a package?\n}\n\n/**\n * SimpleType is a standalone native Go type.\n */\nenum SimpleType {\n    BOOL = 1,     // bool\n    BYTE,         // byte\n    INT8,         // int8\n    INT16,        // int16\n    INT32,        // int32\n    INT64,        // int64\n    FLOAT64,      // float64\n    STRING,       // string\n    STRUCT_EMPTY, // struct{}\n}\n\n/**\n * TypePair is a pair of two types.\n */\nstruct TypePair {\n    1: required Type left\n    2: required Type right\n}\n\n/**\n * Type is a reference to a Go type which may be native or user defined.\n */\nunion Type {\n    1: SimpleType simpleType\n    /**\n     * Slice of a type\n     *\n     * []$sliceType\n     */\n    2: Type sliceType\n    /**\n     * Slice of key-value pairs of a pair of types.\n     *\n     * []struct{Key $left, Value $right}\n     */\n    3: TypePair keyValueSliceType\n    /**\n     * Map of a pair of types.\n     *\n     * map[$left]$right\n     */\n    4: TypePair mapType\n    /**\n     * Reference to a user-defined type.\n     */\n    5: TypeReference referenceType\n    /**\n     * Pointer to a type.\n     */\n    6: Type pointerType\n}\n\n/**\n * Argument is a single Argument inside a Function.\n * For,\n *\n *      void setValue(1: string key, 2: string value)\n *\n * You get the arguments,\n *\n *      Argument{Name: \"Key\", Type: Type{SimpleType: SimpleTypeString}}\n *\n *      Argument{Name: \"Value\", Type: Type{SimpleType: SimpleTypeString}}\n */\nstruct Argument {\n    /**\n     * Name of the argument. This is also the name of the argument field\n     * inside the args/result struct for that function.\n     */\n    1: required string name\n    /**\n     * Argument type.\n     */\n    2: required Type type\n}\n\n/**\n * Function is a single function on a Thrift service.\n */\nstruct Function {\n    /**\n     * Name of the Go function.\n     */\n    1: required string name\n    /**\n     * Name of the function as defined in the Thrift file.\n     */\n    2: required string thriftName\n    /**\n     * List of arguments accepted by the function.\n     *\n     * This list is in the order specified by the user in the Thrift file.\n     */\n    3: required list<Argument> arguments\n    /**\n     * Return type of the function, if any. If this is not set, the function\n     * is a void function.\n     */\n    4: optional Type returnType\n    /**\n     * List of exceptions raised by the function.\n     *\n     * This list is in the order specified by the user in the Thrift file.\n     */\n    5: optional list<Argument> exceptions\n    /**\n     * Whether this function is oneway or not. This should be assumed to be\n     * false unless explicitly stated otherwise. If this is true, the\n     * returnType and exceptions will be null or empty.\n     */\n    6: optional bool oneWay\n    /**\n     * Annotations defined on this function.\n     *\n     * Given,\n     *\n     *   void setValue(1: SetValueRequest req) (cache = \"false\")\n     *\n     * The annotations will be,\n     *\n     *  {\n     *    \"cache\": \"false\",\n     *  }\n     */\n    7: optional map<string, string> annotations;\n}\n\n/**\n * Service is a service defined by the user in the Thrift file.\n */\nstruct Service {\n    /**\n     * Name of the Thrift service in Go code.\n     */\n    7: required string name\n    /**\n     * Name of the service as defined in the Thrift file.\n     */\n    1: required string thriftName\n    /**\n     * ID of the parent service.\n     */\n    4: optional ServiceID parentID\n    /**\n     * List of functions defined for this service.\n     */\n    5: required list<Function> functions\n    /**\n     * ID of the module where this service was declared.\n     */\n    6: required ModuleID moduleID\n    /**\n     * Annotations defined on this service.\n     *\n     * Given,\n     *\n     *   service KeyValue {\n     *   } (private = \"true\")\n     *\n     * The annotations will be,\n     *\n     *  {\n     *    \"private\": \"true\",\n     *  }\n     */\n    8: optional map<string, string> annotations;\n}\n\n/**\n * Module is a module generated from a single Thrift file. Each module\n * corresponds to exactly one Thrift file and contains all the types and\n * constants defined in that Thrift file.\n */\nstruct Module {\n    /**\n     * Import path for the package defining the types for this module.\n     */\n    1: required string importPath\n    /**\n     * Path to the directory containing the code for this module.\n     *\n     * The path is relative to the output directory into which ThriftRW is\n     * generating code. Plugins SHOULD NOT make any assumptions about the\n     * absolute location of the directory.\n     */\n    2: required string directory\n    /**\n     * Path to the Thrift file from which this module was generated.\n     */\n    3: required string thriftFilePath\n}\n\n//////////////////////////////////////////////////////////////////////////////\n\n/**\n * Feature is a functionality offered by a ThriftRW plugin.\n */\nenum Feature {\n    /**\n     * SERVICE_GENERATOR specifies that the plugin may generate arbitrary code\n     * for services defined in the Thrift file.\n     *\n     * If a plugin provides this, it MUST implement the ServiceGenerator\n     * service.\n     */\n    SERVICE_GENERATOR = 1,\n\n    // TODO: TAGGER for struct-tagging plugins\n}\n\n/**\n * HandshakeRequest is the initial request sent to the plugin as part of\n * establishing communication and feature negotiation.\n */\nstruct HandshakeRequest {\n}\n\n/**\n * HandshakeResponse is the response from the plugin for a HandshakeRequest.\n */\nstruct HandshakeResponse {\n    /**\n     * Name of the plugin. This MUST match the name of the plugin specified\n     * over the command line or the program will fail.\n     */\n    1: required string name\n    /**\n     * Version of the plugin API.\n     *\n     * This MUST be set to API_VERSION by the plugin.\n     */\n    2: required i32 apiVersion (go.name = \"APIVersion\")\n    /**\n     * List of features the plugin provides.\n     */\n    3: required list<Feature> features\n    /**\n     * Version of ThriftRW with which the plugin was built.\n     *\n     * This MUST be set to go.uber.org/thriftrw/version.Version by the plugin\n     * explicitly.\n     */\n    4: optional string libraryVersion\n}\n\nservice Plugin {\n    /**\n     * handshake performs a handshake with the plugin to negotiate the\n     * features provided by it and the version of the plugin API it expects.\n     */\n    HandshakeResponse handshake(1: HandshakeRequest request)\n\n    /**\n     * Informs the plugin process that it will not receive any more requests\n     * and it is safe for it to exit.\n     */\n    void goodbye()\n}\n\n//////////////////////////////////////////////////////////////////////////////\n\n/**\n * GenerateServiceRequest is a request to generate code for zero or more\n * Thrift services.\n */\nstruct GenerateServiceRequest {\n    /**\n     * IDs of services for which code should be generated.\n     *\n     * Note that the services map contains information about both, the\n     * services being generated and their transitive dependencies. Code should\n     * only be generated for service IDs listed here.\n     */\n    1: required list<ServiceID> rootServices\n    /**\n     * Map of service ID to service.\n     *\n     * Any service IDs present in this request will have a corresponding\n     * service definition in this map, including services for which code does\n     * not need to be generated.\n     */\n    2: required map<ServiceID, Service> services\n    /**\n     * Map of module ID to module.\n     *\n     * Any module IDs present in the request will have a corresponding module\n     * definition in this map.\n     */\n    3: required map<ModuleID, Module> modules\n    /**\n     * Prefix for import paths of generated module. In general, plugins should\n     * not need to use the package prefix unless instantiating a new\n     * Generator for more custom plugin generation.\n     */\n    4: required string packagePrefix\n    /**\n     * Directory whose descendants contain all Thrift files. In general,\n     * plugins should not need to use the thrift root unless instantiating a\n     * new Generator for more custom plugin generation.\n     */\n    5: required string thriftRoot\n}\n\n/**\n * GenerateServiceResponse is response to a GenerateServiceRequest.\n */\nstruct GenerateServiceResponse {\n    /**\n     * Map of file path to file contents.\n     *\n     * All paths MUST be relative to the output directory into which ThriftRW\n     * is generating code. Plugins SHOULD NOT make any assumptions about the\n     * absolute location of the directory.\n     *\n     * The paths MUST NOT contain the string \"..\" or the request will fail.\n     */\n    1: optional map<string, binary> files\n}\n\n/**\n * ServiceGenerator generates arbitrary code for services.\n *\n * This MUST be implemented if the SERVICE_GENERATOR feature is enabled.\n */\nservice ServiceGenerator {\n    /**\n     * Generates code for requested services.\n     */\n    GenerateServiceResponse generate(1: GenerateServiceRequest request)\n}\n"
+const rawIDL = "/**\n * API_VERSION is the version of the plugin API.\n *\n * This MUST be provided in the HandshakeResponse.\n */\nconst i32 API_VERSION = 4\n\n/**\n * ServiceID is an arbitrary unique identifier to reference the different\n * services in this request.\n */\ntypedef i32 ServiceID\n\n/**\n * ModuleID is an arbitrary unique identifier to reference the different\n * modules in this request.\n */\ntypedef i32 ModuleID\n\n/**\n * TypeReference is a reference to a user-defined type.\n */\nstruct TypeReference {\n    1: required string name\n    /**\n     * Import path for the package defining this type.\n     */\n    2: required string importPath\n\n    /**\n     * Annotations defined on this type.\n     *\n     * Note that these are the Thrift annotations listed after the type\n     * declaration in the Thrift file.\n     *\n     * Given,\n     *\n     *   struct User {\n     *     1: required i32 id\n     *     2: required string name\n     *   } (key = \"id\", validate)\n     *\n     * The annotations will be,\n     *\n     *   {\n     *     \"key\": \"id\",\n     *     \"validate\": \"\",\n     *   }\n     */\n    3: optional map<string, string> annotations\n\n    // TODO(abg): Should this just be using ModuleID instead of a package?\n}\n\n/**\n * SimpleType is a standalone native Go type.\n */\nenum SimpleType {\n    BOOL = 1,     // bool\n    BYTE,         // byte\n    INT8,         // int8\n    INT16,        // int16\n    INT32,        // int32\n    INT64,        // int64\n    FLOAT64,      // float64\n    STRING,       // string\n    STRUCT_EMPTY, // struct{}\n}\n\n/**\n * TypePair is a pair of two types.\n */\nstruct TypePair {\n    1: required Type left\n    2: required Type right\n}\n\n/**\n * Type is a reference to a Go type which may be native or user defined.\n */\nunion Type {\n    1: SimpleType simpleType\n    /**\n     * Slice of a type\n     *\n     * []$sliceType\n     */\n    2: Type sliceType\n    /**\n     * Slice of key-value pairs of a pair of types.\n     *\n     * []struct{Key $left, Value $right}\n     */\n    3: TypePair keyValueSliceType\n    /**\n     * Map of a pair of types.\n     *\n     * map[$left]$right\n     */\n    4: TypePair mapType\n    /**\n     * Reference to a user-defined type.\n     */\n    5: TypeReference referenceType\n    /**\n     * Pointer to a type.\n     */\n    6: Type pointerType\n}\n\n/**\n * Argument is a single Argument inside a Function.\n * For,\n *\n *      void setValue(1: string key, 2: string value)\n *\n * You get the arguments,\n *\n *      Argument{Name: \"Key\", Type: Type{SimpleType: SimpleTypeString}}\n *\n *      Argument{Name: \"Value\", Type: Type{SimpleType: SimpleTypeString}}\n */\nstruct Argument {\n    /**\n     * Name of the argument. This is also the name of the argument field\n     * inside the args/result struct for that function.\n     */\n    1: required string name\n    /**\n     * Argument type.\n     */\n    2: required Type type\n    /**\n     * Annotations defined on this argument.\n     *\n     * Given,\n     *\n     *   void setValue(\n     *     1: SetValueRequest req\n     *   ) throws (\n     *     1: BadRequestError badRequestError (cache = \"false\")\n     *   )\n     *\n     * The annotations for the Argument representing badRequestError will be,\n     *\n     *  {\n     *    \"cache\": \"false\",\n     *  }\n     */\n    3: optional map<string, string> annotations;\n}\n\n/**\n * Function is a single function on a Thrift service.\n */\nstruct Function {\n    /**\n     * Name of the Go function.\n     */\n    1: required string name\n    /**\n     * Name of the function as defined in the Thrift file.\n     */\n    2: required string thriftName\n    /**\n     * List of arguments accepted by the function.\n     *\n     * This list is in the order specified by the user in the Thrift file.\n     */\n    3: required list<Argument> arguments\n    /**\n     * Return type of the function, if any. If this is not set, the function\n     * is a void function.\n     */\n    4: optional Type returnType\n    /**\n     * List of exceptions raised by the function.\n     *\n     * This list is in the order specified by the user in the Thrift file.\n     */\n    5: optional list<Argument> exceptions\n    /**\n     * Whether this function is oneway or not. This should be assumed to be\n     * false unless explicitly stated otherwise. If this is true, the\n     * returnType and exceptions will be null or empty.\n     */\n    6: optional bool oneWay\n    /**\n     * Annotations defined on this function.\n     *\n     * Given,\n     *\n     *   void setValue(1: SetValueRequest req) (cache = \"false\")\n     *\n     * The annotations will be,\n     *\n     *  {\n     *    \"cache\": \"false\",\n     *  }\n     */\n    7: optional map<string, string> annotations;\n}\n\n/**\n * Service is a service defined by the user in the Thrift file.\n */\nstruct Service {\n    /**\n     * Name of the Thrift service in Go code.\n     */\n    7: required string name\n    /**\n     * Name of the service as defined in the Thrift file.\n     */\n    1: required string thriftName\n    /**\n     * ID of the parent service.\n     */\n    4: optional ServiceID parentID\n    /**\n     * List of functions defined for this service.\n     */\n    5: required list<Function> functions\n    /**\n     * ID of the module where this service was declared.\n     */\n    6: required ModuleID moduleID\n    /**\n     * Annotations defined on this service.\n     *\n     * Given,\n     *\n     *   service KeyValue {\n     *   } (private = \"true\")\n     *\n     * The annotations will be,\n     *\n     *  {\n     *    \"private\": \"true\",\n     *  }\n     */\n    8: optional map<string, string> annotations;\n}\n\n/**\n * Module is a module generated from a single Thrift file. Each module\n * corresponds to exactly one Thrift file and contains all the types and\n * constants defined in that Thrift file.\n */\nstruct Module {\n    /**\n     * Import path for the package defining the types for this module.\n     */\n    1: required string importPath\n    /**\n     * Path to the directory containing the code for this module.\n     *\n     * The path is relative to the output directory into which ThriftRW is\n     * generating code. Plugins SHOULD NOT make any assumptions about the\n     * absolute location of the directory.\n     */\n    2: required string directory\n    /**\n     * Path to the Thrift file from which this module was generated.\n     */\n    3: required string thriftFilePath\n}\n\n//////////////////////////////////////////////////////////////////////////////\n\n/**\n * Feature is a functionality offered by a ThriftRW plugin.\n */\nenum Feature {\n    /**\n     * SERVICE_GENERATOR specifies that the plugin may generate arbitrary code\n     * for services defined in the Thrift file.\n     *\n     * If a plugin provides this, it MUST implement the ServiceGenerator\n     * service.\n     */\n    SERVICE_GENERATOR = 1,\n\n    // TODO: TAGGER for struct-tagging plugins\n}\n\n/**\n * HandshakeRequest is the initial request sent to the plugin as part of\n * establishing communication and feature negotiation.\n */\nstruct HandshakeRequest {\n}\n\n/**\n * HandshakeResponse is the response from the plugin for a HandshakeRequest.\n */\nstruct HandshakeResponse {\n    /**\n     * Name of the plugin. This MUST match the name of the plugin specified\n     * over the command line or the program will fail.\n     */\n    1: required string name\n    /**\n     * Version of the plugin API.\n     *\n     * This MUST be set to API_VERSION by the plugin.\n     */\n    2: required i32 apiVersion (go.name = \"APIVersion\")\n    /**\n     * List of features the plugin provides.\n     */\n    3: required list<Feature> features\n    /**\n     * Version of ThriftRW with which the plugin was built.\n     *\n     * This MUST be set to go.uber.org/thriftrw/version.Version by the plugin\n     * explicitly.\n     */\n    4: optional string libraryVersion\n}\n\nservice Plugin {\n    /**\n     * handshake performs a handshake with the plugin to negotiate the\n     * features provided by it and the version of the plugin API it expects.\n     */\n    HandshakeResponse handshake(1: HandshakeRequest request)\n\n    /**\n     * Informs the plugin process that it will not receive any more requests\n     * and it is safe for it to exit.\n     */\n    void goodbye()\n}\n\n//////////////////////////////////////////////////////////////////////////////\n\n/**\n * GenerateServiceRequest is a request to generate code for zero or more\n * Thrift services.\n */\nstruct GenerateServiceRequest {\n    /**\n     * IDs of services for which code should be generated.\n     *\n     * Note that the services map contains information about both, the\n     * services being generated and their transitive dependencies. Code should\n     * only be generated for service IDs listed here.\n     */\n    1: required list<ServiceID> rootServices\n    /**\n     * Map of service ID to service.\n     *\n     * Any service IDs present in this request will have a corresponding\n     * service definition in this map, including services for which code does\n     * not need to be generated.\n     */\n    2: required map<ServiceID, Service> services\n    /**\n     * Map of module ID to module.\n     *\n     * Any module IDs present in the request will have a corresponding module\n     * definition in this map.\n     */\n    3: required map<ModuleID, Module> modules\n    /**\n     * Prefix for import paths of generated module. In general, plugins should\n     * not need to use the package prefix unless instantiating a new\n     * Generator for more custom plugin generation.\n     */\n    4: required string packagePrefix\n    /**\n     * Directory whose descendants contain all Thrift files. In general,\n     * plugins should not need to use the thrift root unless instantiating a\n     * new Generator for more custom plugin generation.\n     */\n    5: required string thriftRoot\n}\n\n/**\n * GenerateServiceResponse is response to a GenerateServiceRequest.\n */\nstruct GenerateServiceResponse {\n    /**\n     * Map of file path to file contents.\n     *\n     * All paths MUST be relative to the output directory into which ThriftRW\n     * is generating code. Plugins SHOULD NOT make any assumptions about the\n     * absolute location of the directory.\n     *\n     * The paths MUST NOT contain the string \"..\" or the request will fail.\n     */\n    1: optional map<string, binary> files\n}\n\n/**\n * ServiceGenerator generates arbitrary code for services.\n *\n * This MUST be implemented if the SERVICE_GENERATOR feature is enabled.\n */\nservice ServiceGenerator {\n    /**\n     * Generates code for requested services.\n     */\n    GenerateServiceResponse generate(1: GenerateServiceRequest request)\n}\n"
 
 // Plugin_Goodbye_Args represents the arguments for the Plugin.goodbye function.
 //


### PR DESCRIPTION
This is a copy of @dmtsui's PR #431, rebased on dev with one
outstanding comment incorporated.

---

Original description:

Currently annotations defined in the Thrift file on arguments and
exceptions for a function are not available in the plugin. This request
adds the annotation field to the Arguments struct to expose the
annotations for plugins to use.