### PR TITLE
Enable users to pass in !omitempty to avoid the default addition of omitempty

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,41 @@ release.
 [cov-img]: https://codecov.io/gh/thriftrw/thriftrw-go/branch/dev/graph/badge.svg
 [ci]: https://travis-ci.com/thriftrw/thriftrw-go
 [cov]: https://codecov.io/gh/thriftrw/thriftrw-go
+
+## Development
+
+To install dependencies and build the project run:
+
+```
+make build
+```
+
+### Testing
+
+To run the entire test suite, run:
+
+```
+make test
+```
+
+#### Integration tests
+
+A lot of the codebase has its logic exercised via integration tests residing in `gen/internal/tests`.
+In other words, since ThriftRW is a code generation library, the way to test that code generation behavior is
+implemented correctly is to create a real Thrift struct definition, run code generation, and assert that the output is correct.
+
+Step by step, this process is:
+
+1. Create or use a Thrift struct in `gen/internal/tests/thrift`.  For example, in `gen/internal/tests/thrift/structs.thrift`, you can find
+`struct GoTags` that is used to exercise go.tag generation behavior, or `struct NotOmitEmpty` that is used to exercise behavior 
+when a field is tagged with `!omitempty`
+1. Run `make generate`.  This will generate the go struct from your definition, and place it in `gen/internal/tests/structs/structs.go`
+1. Write your test in one of the `*_test.go` files that is pertinent to the feature you are adding.  Oftentimes, these tests 
+take in the generated go structs as inputs, and assert on various aspects of code generation like struct tags or json marshaling/unmarshaling behavior.
+1. Also remember to add your struct to `gen/quick_test.go` so that your new struct and all of its generic methods (e.g., ToWire, FromWire, String, Equals, etc.) 
+can be exercised for code coverage
+
+*Note*: Code coverage is measured across packages, rather than per package.  This is because `go test` is run with the `-coverpkg=./...` flag,
+which tells the code coverage tool to measure coverage for this package and all packages in the subdirectories.
+
+

--- a/gen/field.go
+++ b/gen/field.go
@@ -187,19 +187,20 @@ func compileJSONTag(f *compile.FieldSpec, name string, opts ...string) *structta
 	// If both "!omitempty" and "omitempty" are present, then "omitempty" is removed.
 	hasNotOmitempty := t.HasOption(notOmitempty)
 	hasOmitempty := t.HasOption(omitempty)
-	if (isReferenceType(f.Type) || isStructType(f.Type) || isPrimitiveType(f.Type)) &&
-		!f.Required && !hasNotOmitempty && !hasOmitempty {
-		t.Options = append(t.Options, omitempty)
-	} else if hasNotOmitempty && hasOmitempty {
-		newOptions := make([]string, 0)
-		for _, option := range t.Options {
-			if option == omitempty {
-				continue
+	if (isReferenceType(f.Type) || isStructType(f.Type) || isPrimitiveType(f.Type)) && !f.Required {
+		if !hasNotOmitempty && !hasOmitempty {
+			t.Options = append(t.Options, omitempty)
+		} else if hasNotOmitempty && hasOmitempty {
+			newOptions := make([]string, 0)
+			for _, option := range t.Options {
+				if option == omitempty {
+					continue
+				}
+				newOptions = append(newOptions, option)
 			}
-			newOptions = append(newOptions, option)
-		}
 
-		t.Options = newOptions
+			t.Options = newOptions
+		}
 	}
 
 	if f.Required && !t.HasOption("required") {

--- a/gen/field.go
+++ b/gen/field.go
@@ -189,9 +189,13 @@ func compileJSONTag(f *compile.FieldSpec, name string, opts ...string) *structta
 	hasOmitempty := t.HasOption(omitempty)
 	if (isReferenceType(f.Type) || isStructType(f.Type) || isPrimitiveType(f.Type)) && !f.Required {
 		if !hasNotOmitempty && !hasOmitempty {
+			// Add omitempty if it's not there and the user
+			// has not opted out with !omitempty.
 			t.Options = append(t.Options, omitempty)
 		} else if hasNotOmitempty && hasOmitempty {
-			newOptions := make([]string, 0)
+			// !omitempty takes precedence so remove omitempty
+			// if present.
+			newOptions := make([]string, 0, len(t.Options))
 			for _, option := range t.Options {
 				if option == omitempty {
 					continue

--- a/gen/field.go
+++ b/gen/field.go
@@ -185,9 +185,9 @@ func compileJSONTag(f *compile.FieldSpec, name string, opts ...string) *structta
 	//
 	// If the field is marked with "!omitempty", then "omitempty" will not be added.
 	// If both "!omitempty" and "omitempty" are present, then "omitempty" is removed.
-	hasNotOmitempty := t.HasOption(notOmitempty)
-	hasOmitempty := t.HasOption(omitempty)
 	if (isReferenceType(f.Type) || isStructType(f.Type) || isPrimitiveType(f.Type)) && !f.Required {
+		hasNotOmitempty := t.HasOption(notOmitempty)
+		hasOmitempty := t.HasOption(omitempty)
 		if !hasNotOmitempty && !hasOmitempty {
 			// Add omitempty if it's not there and the user
 			// has not opted out with !omitempty.

--- a/gen/field.go
+++ b/gen/field.go
@@ -34,6 +34,9 @@ const (
 
 	// key for tag set on all generated go structs used by encoding/json
 	jsonTagKey = "json"
+
+	omitempty    = "omitempty"
+	notOmitempty = "!omitempty"
 )
 
 var reservedIdentifiers = map[string]struct{}{
@@ -179,9 +182,16 @@ func compileJSONTag(f *compile.FieldSpec, name string, opts ...string) *structta
 	// should be omitted from the encoding if the field has an empty value,
 	// defined as false, 0, a nil pointer, a nil interface value, and any empty
 	// array, slice, map, or string.
+	//
+	// If the field is marked with "!omitempty", then "omitempty" will not be added
+	// For example:
+	//
+	// struct MyStruct {
+	//   1: optional list<Option> options  (go.tag='json:"options,!omitempty"')
+	// }
 	if (isReferenceType(f.Type) || isStructType(f.Type) || isPrimitiveType(f.Type)) &&
-		!f.Required && !t.HasOption("omitempty") {
-		t.Options = append(t.Options, "omitempty")
+		!f.Required && !t.HasOption(notOmitempty) && !t.HasOption(omitempty) {
+		t.Options = append(t.Options, omitempty)
 	}
 
 	if f.Required && !t.HasOption("required") {

--- a/gen/field_test.go
+++ b/gen/field_test.go
@@ -105,7 +105,7 @@ func TestCompileJSONTag(t *testing.T) {
 		{
 			desc: "required with !omitempty",
 			required: true,
-			options: []string{notOmitEmpty},
+			options: []string{notOmitempty},
 			wantOmitEmpty: false,
 		},
 	}

--- a/gen/field_test.go
+++ b/gen/field_test.go
@@ -90,11 +90,13 @@ func TestCompileJSONTag(t *testing.T) {
 			desc:          "optional fields",
 			required:      false,
 			wantOmitempty: true,
-		}, {
+		},
+		{
 			desc:          "required fields",
 			required:      true,
 			wantOmitempty: false,
-		}, {
+		},
+		{
 			desc:          "optional with !omitempty",
 			required:      false,
 			options:       []string{notOmitempty},

--- a/gen/field_test.go
+++ b/gen/field_test.go
@@ -106,7 +106,7 @@ func TestCompileJSONTag(t *testing.T) {
 			desc: "required with !omitempty",
 			required: true,
 			options: []string{notOmitempty},
-			wantOmitEmpty: false,
+			wantOmitempty: false,
 		},
 	}
 

--- a/gen/field_test.go
+++ b/gen/field_test.go
@@ -102,6 +102,12 @@ func TestCompileJSONTag(t *testing.T) {
 			options:       []string{notOmitempty},
 			wantOmitempty: false,
 		},
+		{
+			desc: "required with !omitempty",
+			required: true,
+			options: []string{notOmitEmpty},
+			wantOmitEmpty: false,
+		},
 	}
 
 	fieldName := "numbers"

--- a/gen/field_test.go
+++ b/gen/field_test.go
@@ -103,9 +103,9 @@ func TestCompileJSONTag(t *testing.T) {
 			wantOmitempty: false,
 		},
 		{
-			desc: "required with !omitempty",
-			required: true,
-			options: []string{notOmitempty},
+			desc:          "required with !omitempty",
+			required:      true,
+			options:       []string{notOmitempty},
 			wantOmitempty: false,
 		},
 	}

--- a/gen/field_test.go
+++ b/gen/field_test.go
@@ -76,3 +76,59 @@ func TestFieldLabelConflict(t *testing.T) {
 		})
 	}
 }
+
+func TestCompileJSONTag_ForOptionalFields_OmitemptyIsAdded(t *testing.T) {
+	required := false
+	fieldSpec := &compile.FieldSpec{
+		ID:   0,
+		Name: "numbers",
+		Type: &compile.ListSpec{
+			ValueSpec: &compile.I64Spec{},
+		},
+		Required:    required,
+		Doc:         "",
+		Default:     nil,
+		Annotations: compile.Annotations{goTagKey: `json:"numbers"`},
+	}
+	name := "numbers"
+	options := make([]string, 0)
+	result := compileJSONTag(fieldSpec, name, options...)
+	require.True(t, result.HasOption(omitempty))
+}
+
+func TestCompileJSONTag_ForRequiredFields_OmitemptyIsNotAdded(t *testing.T) {
+	required := true
+	fieldSpec := &compile.FieldSpec{
+		ID:   0,
+		Name: "numbers",
+		Type: &compile.ListSpec{
+			ValueSpec: &compile.I64Spec{},
+		},
+		Required:    required,
+		Doc:         "",
+		Default:     nil,
+		Annotations: compile.Annotations{goTagKey: `json:"numbers"`},
+	}
+	name := "numbers"
+	options := make([]string, 0)
+	result := compileJSONTag(fieldSpec, name, options...)
+	require.False(t, result.HasOption(omitempty))
+}
+
+func TestCompileJSONTag_WhenNotOmitemptyIsPresent_OmitemptyIsNotAdded(t *testing.T) {
+	fieldSpec := &compile.FieldSpec{
+		ID:   0,
+		Name: "numbers",
+		Type: &compile.ListSpec{
+			ValueSpec: &compile.I64Spec{},
+		},
+		Required:    false,
+		Doc:         "",
+		Default:     nil,
+		Annotations: compile.Annotations{goTagKey: `json:"numbers,!omitempty"`},
+	}
+	name := "numbers"
+	options := []string{notOmitempty}
+	result := compileJSONTag(fieldSpec, name, options...)
+	require.False(t, result.HasOption(omitempty))
+}

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -2133,6 +2133,7 @@ type NotOmitEmpty struct {
 	NotOmitEmptyMap                      map[string]string `json:"notOmitEmptyMap,!omitempty"`
 	NotOmitEmptyListMixedWithOmitEmpty   []string          `json:"notOmitEmptyListMixedWithOmitEmpty,!omitempty"`
 	NotOmitEmptyListMixedWithOmitEmptyV2 []string          `json:"notOmitEmptyListMixedWithOmitEmptyV2,!omitempty"`
+	OmitEmptyString                      *string           `json:"omitEmptyString,omitempty"`
 }
 
 type _Map_String_String_MapItemList map[string]string
@@ -2187,7 +2188,7 @@ func (_Map_String_String_MapItemList) Close() {}
 //   }
 func (v *NotOmitEmpty) ToWire() (wire.Value, error) {
 	var (
-		fields [7]wire.Field
+		fields [8]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -2247,6 +2248,14 @@ func (v *NotOmitEmpty) ToWire() (wire.Value, error) {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 7, Value: w}
+		i++
+	}
+	if v.OmitEmptyString != nil {
+		w, err = wire.NewValueString(*(v.OmitEmptyString)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 8, Value: w}
 		i++
 	}
 
@@ -2365,6 +2374,16 @@ func (v *NotOmitEmpty) FromWire(w wire.Value) error {
 				}
 
 			}
+		case 8:
+			if field.Value.Type() == wire.TBinary {
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.OmitEmptyString = &x
+				if err != nil {
+					return err
+				}
+
+			}
 		}
 	}
 
@@ -2378,7 +2397,7 @@ func (v *NotOmitEmpty) String() string {
 		return "<nil>"
 	}
 
-	var fields [7]string
+	var fields [8]string
 	i := 0
 	if v.NotOmitEmptyString != nil {
 		fields[i] = fmt.Sprintf("NotOmitEmptyString: %v", *(v.NotOmitEmptyString))
@@ -2406,6 +2425,10 @@ func (v *NotOmitEmpty) String() string {
 	}
 	if v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
 		fields[i] = fmt.Sprintf("NotOmitEmptyListMixedWithOmitEmptyV2: %v", v.NotOmitEmptyListMixedWithOmitEmptyV2)
+		i++
+	}
+	if v.OmitEmptyString != nil {
+		fields[i] = fmt.Sprintf("OmitEmptyString: %v", *(v.OmitEmptyString))
 		i++
 	}
 
@@ -2460,6 +2483,9 @@ func (v *NotOmitEmpty) Equals(rhs *NotOmitEmpty) bool {
 	if !((v.NotOmitEmptyListMixedWithOmitEmptyV2 == nil && rhs.NotOmitEmptyListMixedWithOmitEmptyV2 == nil) || (v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil && rhs.NotOmitEmptyListMixedWithOmitEmptyV2 != nil && _List_String_Equals(v.NotOmitEmptyListMixedWithOmitEmptyV2, rhs.NotOmitEmptyListMixedWithOmitEmptyV2))) {
 		return false
 	}
+	if !_String_EqualsPtr(v.OmitEmptyString, rhs.OmitEmptyString) {
+		return false
+	}
 
 	return true
 }
@@ -2501,6 +2527,9 @@ func (v *NotOmitEmpty) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	}
 	if v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
 		err = multierr.Append(err, enc.AddArray("NotOmitEmptyListMixedWithOmitEmptyV2", (_List_String_Zapper)(v.NotOmitEmptyListMixedWithOmitEmptyV2)))
+	}
+	if v.OmitEmptyString != nil {
+		enc.AddString("OmitEmptyString", *v.OmitEmptyString)
 	}
 	return err
 }
@@ -2608,6 +2637,21 @@ func (v *NotOmitEmpty) GetNotOmitEmptyListMixedWithOmitEmptyV2() (o []string) {
 // IsSetNotOmitEmptyListMixedWithOmitEmptyV2 returns true if NotOmitEmptyListMixedWithOmitEmptyV2 is not nil.
 func (v *NotOmitEmpty) IsSetNotOmitEmptyListMixedWithOmitEmptyV2() bool {
 	return v != nil && v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil
+}
+
+// GetOmitEmptyString returns the value of OmitEmptyString if it is set or its
+// zero value if it is unset.
+func (v *NotOmitEmpty) GetOmitEmptyString() (o string) {
+	if v != nil && v.OmitEmptyString != nil {
+		return *v.OmitEmptyString
+	}
+
+	return
+}
+
+// IsSetOmitEmptyString returns true if OmitEmptyString is not nil.
+func (v *NotOmitEmpty) IsSetOmitEmptyString() bool {
+	return v != nil && v.OmitEmptyString != nil
 }
 
 type Omit struct {
@@ -5107,11 +5151,11 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "structs",
 	Package:  "go.uber.org/thriftrw/gen/internal/tests/structs",
 	FilePath: "structs.thrift",
-	SHA1:     "28983d45f529715c3505b015e07d413ec560b277",
+	SHA1:     "5f0b5839ee412bcb992781ccea5ed7e9d4e34725",
 	Includes: []*thriftreflect.ThriftModule{
 		enums.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "include \"./enums.thrift\"\n\nstruct EmptyStruct {}\n\n//////////////////////////////////////////////////////////////////////////////\n// Structs with primitives\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are required.\n */\nstruct PrimitiveRequiredStruct {\n    1: required bool boolField\n    2: required byte byteField\n    3: required i16 int16Field\n    4: required i32 int32Field\n    5: required i64 int64Field\n    6: required double doubleField\n    7: required string stringField\n    8: required binary binaryField\n}\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are optional.\n */\nstruct PrimitiveOptionalStruct {\n    1: optional bool boolField\n    2: optional byte byteField\n    3: optional i16 int16Field\n    4: optional i32 int32Field\n    5: optional i64 int64Field\n    6: optional double doubleField\n    7: optional string stringField\n    8: optional binary binaryField\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Required)\n\n/**\n * A point in 2D space.\n */\nstruct Point {\n    1: required double x\n    2: required double y\n}\n\n/**\n * Size of something.\n */\nstruct Size {\n    /**\n     * Width in pixels.\n     */\n    1: required double width\n    /** Height in pixels. */\n    2: required double height\n}\n\nstruct Frame {\n    1: required Point topLeft\n    2: required Size size\n}\n\nstruct Edge {\n    1: required Point startPoint\n    2: required Point endPoint\n}\n\n/**\n * A graph is comprised of zero or more edges.\n */\nstruct Graph {\n    /**\n     * List of edges in the graph.\n     *\n     * May be empty.\n     */\n    1: required list<Edge> edges\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Optional)\n\nstruct ContactInfo {\n    1: required string emailAddress\n}\n\nstruct PersonalInfo {\n    1: optional i32 age\n}\n\nstruct User {\n    1: required string name\n    2: optional ContactInfo contact\n    3: optional PersonalInfo personal\n}\n\ntypedef map<string, User> UserMap\n\n//////////////////////////////////////////////////////////////////////////////\n// self-referential struct\n\ntypedef Node List\n\n/**\n * Node is linked list of values.\n * All values are 32-bit integers.\n */\nstruct Node {\n    1: required i32 value\n    2: optional List tail\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// JSON tagged structs\n\nstruct Rename {\n    1: required string Default (go.tag = 'json:\"default\"')\n    2: required string camelCase (go.tag = 'json:\"snake_case\"')\n}\n\nstruct Omit {\n    1: required string serialized\n    2: required string hidden (go.tag = 'json:\"-\"')\n}\n\nstruct GoTags {\n        1: required string Foo (go.tag = 'json:\"-\" foo:\"bar\"')\n        2: optional string Bar (go.tag = 'bar:\"foo\"')\n        3: required string FooBar (go.tag = 'json:\"foobar,option1,option2\" bar:\"foo,option1\" foo:\"foobar\"')\n        4: required string FooBarWithSpace (go.tag = 'json:\"foobarWithSpace\" foo:\"foo bar foobar barfoo\"')\n        5: optional string FooBarWithOmitEmpty (go.tag = 'json:\"foobarWithOmitEmpty,omitempty\"')\n        6: required string FooBarWithRequired (go.tag = 'json:\"foobarWithRequired,required\"')\n}\n\nstruct NotOmitEmpty {\n    1: optional string NotOmitEmptyString (go.tag = 'json:\"notOmitEmptyString,!omitempty\"')\n    2: optional string NotOmitEmptyInt (go.tag = 'json:\"notOmitEmptyInt,!omitempty\"')\n    3: optional string NotOmitEmptyBool (go.tag = 'json:\"notOmitEmptyBool,!omitempty\"')\n    4: optional list<string> NotOmitEmptyList (go.tag = 'json:\"notOmitEmptyList,!omitempty\"')\n    5: optional map<string, string> NotOmitEmptyMap (go.tag = 'json:\"notOmitEmptyMap,!omitempty\"')\n    6: optional list<string> NotOmitEmptyListMixedWithOmitEmpty (go.tag = 'json:\"notOmitEmptyListMixedWithOmitEmpty,!omitempty,omitempty\"')\n    7: optional list<string> NotOmitEmptyListMixedWithOmitEmptyV2 (go.tag = 'json:\"notOmitEmptyListMixedWithOmitEmptyV2,omitempty,!omitempty\"')\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Default values\n\nstruct DefaultsStruct {\n    1: required i32 requiredPrimitive = 100\n    2: optional i32 optionalPrimitive = 200\n\n    3: required enums.EnumDefault requiredEnum = enums.EnumDefault.Bar\n    4: optional enums.EnumDefault optionalEnum = 2\n\n    5: required list<string> requiredList = [\"hello\", \"world\"]\n    6: optional list<double> optionalList = [1, 2.0, 3]\n\n    7: required Frame requiredStruct = {\n        \"topLeft\": {\"x\": 1, \"y\": 2},\n        \"size\": {\"width\": 100, \"height\": 200},\n    }\n    8: optional Edge optionalStruct = {\n        \"startPoint\": {\"x\": 1, \"y\": 2},\n        \"endPoint\":   {\"x\": 3, \"y\": 4},\n    }\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Opt-out of Zap\n\nstruct ZapOptOutStruct {\n    1: required string name\n    2: required string optout (go.nolog)\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Field jabels\n\nstruct StructLabels {\n    // reserved keyword as label\n    1: optional bool isRequired (go.label = \"required\")\n\n    // go.tag's JSON tag takes precedence over go.label\n    2: optional string foo (go.label = \"bar\", go.tag = 'json:\"not_bar\"')\n\n    // Empty label\n    3: optional string qux (go.label = \"\")\n\n    // All-caps label\n    4: optional string quux (go.label = \"QUUX\")\n}\n"
+const rawIDL = "include \"./enums.thrift\"\n\nstruct EmptyStruct {}\n\n//////////////////////////////////////////////////////////////////////////////\n// Structs with primitives\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are required.\n */\nstruct PrimitiveRequiredStruct {\n    1: required bool boolField\n    2: required byte byteField\n    3: required i16 int16Field\n    4: required i32 int32Field\n    5: required i64 int64Field\n    6: required double doubleField\n    7: required string stringField\n    8: required binary binaryField\n}\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are optional.\n */\nstruct PrimitiveOptionalStruct {\n    1: optional bool boolField\n    2: optional byte byteField\n    3: optional i16 int16Field\n    4: optional i32 int32Field\n    5: optional i64 int64Field\n    6: optional double doubleField\n    7: optional string stringField\n    8: optional binary binaryField\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Required)\n\n/**\n * A point in 2D space.\n */\nstruct Point {\n    1: required double x\n    2: required double y\n}\n\n/**\n * Size of something.\n */\nstruct Size {\n    /**\n     * Width in pixels.\n     */\n    1: required double width\n    /** Height in pixels. */\n    2: required double height\n}\n\nstruct Frame {\n    1: required Point topLeft\n    2: required Size size\n}\n\nstruct Edge {\n    1: required Point startPoint\n    2: required Point endPoint\n}\n\n/**\n * A graph is comprised of zero or more edges.\n */\nstruct Graph {\n    /**\n     * List of edges in the graph.\n     *\n     * May be empty.\n     */\n    1: required list<Edge> edges\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Optional)\n\nstruct ContactInfo {\n    1: required string emailAddress\n}\n\nstruct PersonalInfo {\n    1: optional i32 age\n}\n\nstruct User {\n    1: required string name\n    2: optional ContactInfo contact\n    3: optional PersonalInfo personal\n}\n\ntypedef map<string, User> UserMap\n\n//////////////////////////////////////////////////////////////////////////////\n// self-referential struct\n\ntypedef Node List\n\n/**\n * Node is linked list of values.\n * All values are 32-bit integers.\n */\nstruct Node {\n    1: required i32 value\n    2: optional List tail\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// JSON tagged structs\n\nstruct Rename {\n    1: required string Default (go.tag = 'json:\"default\"')\n    2: required string camelCase (go.tag = 'json:\"snake_case\"')\n}\n\nstruct Omit {\n    1: required string serialized\n    2: required string hidden (go.tag = 'json:\"-\"')\n}\n\nstruct GoTags {\n        1: required string Foo (go.tag = 'json:\"-\" foo:\"bar\"')\n        2: optional string Bar (go.tag = 'bar:\"foo\"')\n        3: required string FooBar (go.tag = 'json:\"foobar,option1,option2\" bar:\"foo,option1\" foo:\"foobar\"')\n        4: required string FooBarWithSpace (go.tag = 'json:\"foobarWithSpace\" foo:\"foo bar foobar barfoo\"')\n        5: optional string FooBarWithOmitEmpty (go.tag = 'json:\"foobarWithOmitEmpty,omitempty\"')\n        6: required string FooBarWithRequired (go.tag = 'json:\"foobarWithRequired,required\"')\n}\n\nstruct NotOmitEmpty {\n    1: optional string NotOmitEmptyString (go.tag = 'json:\"notOmitEmptyString,!omitempty\"')\n    2: optional string NotOmitEmptyInt (go.tag = 'json:\"notOmitEmptyInt,!omitempty\"')\n    3: optional string NotOmitEmptyBool (go.tag = 'json:\"notOmitEmptyBool,!omitempty\"')\n    4: optional list<string> NotOmitEmptyList (go.tag = 'json:\"notOmitEmptyList,!omitempty\"')\n    5: optional map<string, string> NotOmitEmptyMap (go.tag = 'json:\"notOmitEmptyMap,!omitempty\"')\n    6: optional list<string> NotOmitEmptyListMixedWithOmitEmpty (go.tag = 'json:\"notOmitEmptyListMixedWithOmitEmpty,!omitempty,omitempty\"')\n    7: optional list<string> NotOmitEmptyListMixedWithOmitEmptyV2 (go.tag = 'json:\"notOmitEmptyListMixedWithOmitEmptyV2,omitempty,!omitempty\"')\n    8: optional string OmitEmptyString (go.tag = 'json:\"omitEmptyString,omitempty\"') // to test that there can be a mix of fields that do and don't have !omitempty\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Default values\n\nstruct DefaultsStruct {\n    1: required i32 requiredPrimitive = 100\n    2: optional i32 optionalPrimitive = 200\n\n    3: required enums.EnumDefault requiredEnum = enums.EnumDefault.Bar\n    4: optional enums.EnumDefault optionalEnum = 2\n\n    5: required list<string> requiredList = [\"hello\", \"world\"]\n    6: optional list<double> optionalList = [1, 2.0, 3]\n\n    7: required Frame requiredStruct = {\n        \"topLeft\": {\"x\": 1, \"y\": 2},\n        \"size\": {\"width\": 100, \"height\": 200},\n    }\n    8: optional Edge optionalStruct = {\n        \"startPoint\": {\"x\": 1, \"y\": 2},\n        \"endPoint\":   {\"x\": 3, \"y\": 4},\n    }\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Opt-out of Zap\n\nstruct ZapOptOutStruct {\n    1: required string name\n    2: required string optout (go.nolog)\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Field jabels\n\nstruct StructLabels {\n    // reserved keyword as label\n    1: optional bool isRequired (go.label = \"required\")\n\n    // go.tag's JSON tag takes precedence over go.label\n    2: optional string foo (go.label = \"bar\", go.tag = 'json:\"not_bar\"')\n\n    // Empty label\n    3: optional string qux (go.label = \"\")\n\n    // All-caps label\n    4: optional string quux (go.label = \"QUUX\")\n}\n"

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -2125,6 +2125,407 @@ func (v *Node) IsSetTail() bool {
 	return v != nil && v.Tail != nil
 }
 
+type NotOmitEmpty struct {
+	NotOmitEmptyString *string           `json:"notOmitEmptyString,!omitempty"`
+	NotOmitEmptyInt    *string           `json:"notOmitEmptyInt,!omitempty"`
+	NotOmitEmptyBool   *string           `json:"notOmitEmptyBool,!omitempty"`
+	NotOmitEmptyList   []string          `json:"notOmitEmptyList,!omitempty"`
+	NotOmitEmptyMap    map[string]string `json:"notOmitEmptyMap,!omitempty"`
+}
+
+type _Map_String_String_MapItemList map[string]string
+
+func (m _Map_String_String_MapItemList) ForEach(f func(wire.MapItem) error) error {
+	for k, v := range m {
+		kw, err := wire.NewValueString(k), error(nil)
+		if err != nil {
+			return err
+		}
+
+		vw, err := wire.NewValueString(v), error(nil)
+		if err != nil {
+			return err
+		}
+		err = f(wire.MapItem{Key: kw, Value: vw})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m _Map_String_String_MapItemList) Size() int {
+	return len(m)
+}
+
+func (_Map_String_String_MapItemList) KeyType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_String_MapItemList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_Map_String_String_MapItemList) Close() {}
+
+// ToWire translates a NotOmitEmpty struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *NotOmitEmpty) ToWire() (wire.Value, error) {
+	var (
+		fields [5]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.NotOmitEmptyString != nil {
+		w, err = wire.NewValueString(*(v.NotOmitEmptyString)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 1, Value: w}
+		i++
+	}
+	if v.NotOmitEmptyInt != nil {
+		w, err = wire.NewValueString(*(v.NotOmitEmptyInt)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 2, Value: w}
+		i++
+	}
+	if v.NotOmitEmptyBool != nil {
+		w, err = wire.NewValueString(*(v.NotOmitEmptyBool)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 3, Value: w}
+		i++
+	}
+	if v.NotOmitEmptyList != nil {
+		w, err = wire.NewValueList(_List_String_ValueList(v.NotOmitEmptyList)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 4, Value: w}
+		i++
+	}
+	if v.NotOmitEmptyMap != nil {
+		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.NotOmitEmptyMap)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 5, Value: w}
+		i++
+	}
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
+	if m.KeyType() != wire.TBinary {
+		return nil, nil
+	}
+
+	if m.ValueType() != wire.TBinary {
+		return nil, nil
+	}
+
+	o := make(map[string]string, m.Size())
+	err := m.ForEach(func(x wire.MapItem) error {
+		k, err := x.Key.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+
+		v, err := x.Value.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+
+		o[k] = v
+		return nil
+	})
+	m.Close()
+	return o, err
+}
+
+// FromWire deserializes a NotOmitEmpty struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a NotOmitEmpty struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v NotOmitEmpty
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *NotOmitEmpty) FromWire(w wire.Value) error {
+	var err error
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 1:
+			if field.Value.Type() == wire.TBinary {
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.NotOmitEmptyString = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if field.Value.Type() == wire.TBinary {
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.NotOmitEmptyInt = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if field.Value.Type() == wire.TBinary {
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.NotOmitEmptyBool = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 4:
+			if field.Value.Type() == wire.TList {
+				v.NotOmitEmptyList, err = _List_String_Read(field.Value.GetList())
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if field.Value.Type() == wire.TMap {
+				v.NotOmitEmptyMap, err = _Map_String_String_Read(field.Value.GetMap())
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a NotOmitEmpty
+// struct.
+func (v *NotOmitEmpty) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [5]string
+	i := 0
+	if v.NotOmitEmptyString != nil {
+		fields[i] = fmt.Sprintf("NotOmitEmptyString: %v", *(v.NotOmitEmptyString))
+		i++
+	}
+	if v.NotOmitEmptyInt != nil {
+		fields[i] = fmt.Sprintf("NotOmitEmptyInt: %v", *(v.NotOmitEmptyInt))
+		i++
+	}
+	if v.NotOmitEmptyBool != nil {
+		fields[i] = fmt.Sprintf("NotOmitEmptyBool: %v", *(v.NotOmitEmptyBool))
+		i++
+	}
+	if v.NotOmitEmptyList != nil {
+		fields[i] = fmt.Sprintf("NotOmitEmptyList: %v", v.NotOmitEmptyList)
+		i++
+	}
+	if v.NotOmitEmptyMap != nil {
+		fields[i] = fmt.Sprintf("NotOmitEmptyMap: %v", v.NotOmitEmptyMap)
+		i++
+	}
+
+	return fmt.Sprintf("NotOmitEmpty{%v}", strings.Join(fields[:i], ", "))
+}
+
+func _Map_String_String_Equals(lhs, rhs map[string]string) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	for lk, lv := range lhs {
+		rv, ok := rhs[lk]
+		if !ok {
+			return false
+		}
+		if !(lv == rv) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equals returns true if all the fields of this NotOmitEmpty match the
+// provided NotOmitEmpty.
+//
+// This function performs a deep comparison.
+func (v *NotOmitEmpty) Equals(rhs *NotOmitEmpty) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !_String_EqualsPtr(v.NotOmitEmptyString, rhs.NotOmitEmptyString) {
+		return false
+	}
+	if !_String_EqualsPtr(v.NotOmitEmptyInt, rhs.NotOmitEmptyInt) {
+		return false
+	}
+	if !_String_EqualsPtr(v.NotOmitEmptyBool, rhs.NotOmitEmptyBool) {
+		return false
+	}
+	if !((v.NotOmitEmptyList == nil && rhs.NotOmitEmptyList == nil) || (v.NotOmitEmptyList != nil && rhs.NotOmitEmptyList != nil && _List_String_Equals(v.NotOmitEmptyList, rhs.NotOmitEmptyList))) {
+		return false
+	}
+	if !((v.NotOmitEmptyMap == nil && rhs.NotOmitEmptyMap == nil) || (v.NotOmitEmptyMap != nil && rhs.NotOmitEmptyMap != nil && _Map_String_String_Equals(v.NotOmitEmptyMap, rhs.NotOmitEmptyMap))) {
+		return false
+	}
+
+	return true
+}
+
+type _Map_String_String_Zapper map[string]string
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of _Map_String_String_Zapper.
+func (m _Map_String_String_Zapper) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	for k, v := range m {
+		enc.AddString((string)(k), v)
+	}
+	return err
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of NotOmitEmpty.
+func (v *NotOmitEmpty) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	if v.NotOmitEmptyString != nil {
+		enc.AddString("NotOmitEmptyString", *v.NotOmitEmptyString)
+	}
+	if v.NotOmitEmptyInt != nil {
+		enc.AddString("NotOmitEmptyInt", *v.NotOmitEmptyInt)
+	}
+	if v.NotOmitEmptyBool != nil {
+		enc.AddString("NotOmitEmptyBool", *v.NotOmitEmptyBool)
+	}
+	if v.NotOmitEmptyList != nil {
+		err = multierr.Append(err, enc.AddArray("NotOmitEmptyList", (_List_String_Zapper)(v.NotOmitEmptyList)))
+	}
+	if v.NotOmitEmptyMap != nil {
+		err = multierr.Append(err, enc.AddObject("NotOmitEmptyMap", (_Map_String_String_Zapper)(v.NotOmitEmptyMap)))
+	}
+	return err
+}
+
+// GetNotOmitEmptyString returns the value of NotOmitEmptyString if it is set or its
+// zero value if it is unset.
+func (v *NotOmitEmpty) GetNotOmitEmptyString() (o string) {
+	if v != nil && v.NotOmitEmptyString != nil {
+		return *v.NotOmitEmptyString
+	}
+
+	return
+}
+
+// IsSetNotOmitEmptyString returns true if NotOmitEmptyString is not nil.
+func (v *NotOmitEmpty) IsSetNotOmitEmptyString() bool {
+	return v != nil && v.NotOmitEmptyString != nil
+}
+
+// GetNotOmitEmptyInt returns the value of NotOmitEmptyInt if it is set or its
+// zero value if it is unset.
+func (v *NotOmitEmpty) GetNotOmitEmptyInt() (o string) {
+	if v != nil && v.NotOmitEmptyInt != nil {
+		return *v.NotOmitEmptyInt
+	}
+
+	return
+}
+
+// IsSetNotOmitEmptyInt returns true if NotOmitEmptyInt is not nil.
+func (v *NotOmitEmpty) IsSetNotOmitEmptyInt() bool {
+	return v != nil && v.NotOmitEmptyInt != nil
+}
+
+// GetNotOmitEmptyBool returns the value of NotOmitEmptyBool if it is set or its
+// zero value if it is unset.
+func (v *NotOmitEmpty) GetNotOmitEmptyBool() (o string) {
+	if v != nil && v.NotOmitEmptyBool != nil {
+		return *v.NotOmitEmptyBool
+	}
+
+	return
+}
+
+// IsSetNotOmitEmptyBool returns true if NotOmitEmptyBool is not nil.
+func (v *NotOmitEmpty) IsSetNotOmitEmptyBool() bool {
+	return v != nil && v.NotOmitEmptyBool != nil
+}
+
+// GetNotOmitEmptyList returns the value of NotOmitEmptyList if it is set or its
+// zero value if it is unset.
+func (v *NotOmitEmpty) GetNotOmitEmptyList() (o []string) {
+	if v != nil && v.NotOmitEmptyList != nil {
+		return v.NotOmitEmptyList
+	}
+
+	return
+}
+
+// IsSetNotOmitEmptyList returns true if NotOmitEmptyList is not nil.
+func (v *NotOmitEmpty) IsSetNotOmitEmptyList() bool {
+	return v != nil && v.NotOmitEmptyList != nil
+}
+
+// GetNotOmitEmptyMap returns the value of NotOmitEmptyMap if it is set or its
+// zero value if it is unset.
+func (v *NotOmitEmpty) GetNotOmitEmptyMap() (o map[string]string) {
+	if v != nil && v.NotOmitEmptyMap != nil {
+		return v.NotOmitEmptyMap
+	}
+
+	return
+}
+
+// IsSetNotOmitEmptyMap returns true if NotOmitEmptyMap is not nil.
+func (v *NotOmitEmpty) IsSetNotOmitEmptyMap() bool {
+	return v != nil && v.NotOmitEmptyMap != nil
+}
+
 type Omit struct {
 	Serialized string `json:"serialized,required"`
 	Hidden     string `json:"-"`
@@ -4622,11 +5023,11 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "structs",
 	Package:  "go.uber.org/thriftrw/gen/internal/tests/structs",
 	FilePath: "structs.thrift",
-	SHA1:     "dab5c0bea66d50915769e8c6c2f125dc93b16738",
+	SHA1:     "57d0eda8ed948148c823a9d8d934e9a048c44124",
 	Includes: []*thriftreflect.ThriftModule{
 		enums.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "include \"./enums.thrift\"\n\nstruct EmptyStruct {}\n\n//////////////////////////////////////////////////////////////////////////////\n// Structs with primitives\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are required.\n */\nstruct PrimitiveRequiredStruct {\n    1: required bool boolField\n    2: required byte byteField\n    3: required i16 int16Field\n    4: required i32 int32Field\n    5: required i64 int64Field\n    6: required double doubleField\n    7: required string stringField\n    8: required binary binaryField\n}\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are optional.\n */\nstruct PrimitiveOptionalStruct {\n    1: optional bool boolField\n    2: optional byte byteField\n    3: optional i16 int16Field\n    4: optional i32 int32Field\n    5: optional i64 int64Field\n    6: optional double doubleField\n    7: optional string stringField\n    8: optional binary binaryField\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Required)\n\n/**\n * A point in 2D space.\n */\nstruct Point {\n    1: required double x\n    2: required double y\n}\n\n/**\n * Size of something.\n */\nstruct Size {\n    /**\n     * Width in pixels.\n     */\n    1: required double width\n    /** Height in pixels. */\n    2: required double height\n}\n\nstruct Frame {\n    1: required Point topLeft\n    2: required Size size\n}\n\nstruct Edge {\n    1: required Point startPoint\n    2: required Point endPoint\n}\n\n/**\n * A graph is comprised of zero or more edges.\n */\nstruct Graph {\n    /**\n     * List of edges in the graph.\n     *\n     * May be empty.\n     */\n    1: required list<Edge> edges\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Optional)\n\nstruct ContactInfo {\n    1: required string emailAddress\n}\n\nstruct PersonalInfo {\n    1: optional i32 age\n}\n\nstruct User {\n    1: required string name\n    2: optional ContactInfo contact\n    3: optional PersonalInfo personal\n}\n\ntypedef map<string, User> UserMap\n\n//////////////////////////////////////////////////////////////////////////////\n// self-referential struct\n\ntypedef Node List\n\n/**\n * Node is linked list of values.\n * All values are 32-bit integers.\n */\nstruct Node {\n    1: required i32 value\n    2: optional List tail\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// JSON tagged structs\n\nstruct Rename {\n    1: required string Default (go.tag = 'json:\"default\"')\n    2: required string camelCase (go.tag = 'json:\"snake_case\"')\n}\n\nstruct Omit {\n    1: required string serialized\n    2: required string hidden (go.tag = 'json:\"-\"')\n}\n\nstruct GoTags {\n        1: required string Foo (go.tag = 'json:\"-\" foo:\"bar\"')\n        2: optional string Bar (go.tag = 'bar:\"foo\"')\n        3: required string FooBar (go.tag = 'json:\"foobar,option1,option2\" bar:\"foo,option1\" foo:\"foobar\"')\n        4: required string FooBarWithSpace (go.tag = 'json:\"foobarWithSpace\" foo:\"foo bar foobar barfoo\"')\n        5: optional string FooBarWithOmitEmpty (go.tag = 'json:\"foobarWithOmitEmpty,omitempty\"')\n        6: required string FooBarWithRequired (go.tag = 'json:\"foobarWithRequired,required\"')\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Default values\n\nstruct DefaultsStruct {\n    1: required i32 requiredPrimitive = 100\n    2: optional i32 optionalPrimitive = 200\n\n    3: required enums.EnumDefault requiredEnum = enums.EnumDefault.Bar\n    4: optional enums.EnumDefault optionalEnum = 2\n\n    5: required list<string> requiredList = [\"hello\", \"world\"]\n    6: optional list<double> optionalList = [1, 2.0, 3]\n\n    7: required Frame requiredStruct = {\n        \"topLeft\": {\"x\": 1, \"y\": 2},\n        \"size\": {\"width\": 100, \"height\": 200},\n    }\n    8: optional Edge optionalStruct = {\n        \"startPoint\": {\"x\": 1, \"y\": 2},\n        \"endPoint\":   {\"x\": 3, \"y\": 4},\n    }\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Opt-out of Zap\n\nstruct ZapOptOutStruct {\n    1: required string name\n    2: required string optout (go.nolog)\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Field jabels\n\nstruct StructLabels {\n    // reserved keyword as label\n    1: optional bool isRequired (go.label = \"required\")\n\n    // go.tag's JSON tag takes precedence over go.label\n    2: optional string foo (go.label = \"bar\", go.tag = 'json:\"not_bar\"')\n\n    // Empty label\n    3: optional string qux (go.label = \"\")\n\n    // All-caps label\n    4: optional string quux (go.label = \"QUUX\")\n}\n"
+const rawIDL = "include \"./enums.thrift\"\n\nstruct EmptyStruct {}\n\n//////////////////////////////////////////////////////////////////////////////\n// Structs with primitives\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are required.\n */\nstruct PrimitiveRequiredStruct {\n    1: required bool boolField\n    2: required byte byteField\n    3: required i16 int16Field\n    4: required i32 int32Field\n    5: required i64 int64Field\n    6: required double doubleField\n    7: required string stringField\n    8: required binary binaryField\n}\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are optional.\n */\nstruct PrimitiveOptionalStruct {\n    1: optional bool boolField\n    2: optional byte byteField\n    3: optional i16 int16Field\n    4: optional i32 int32Field\n    5: optional i64 int64Field\n    6: optional double doubleField\n    7: optional string stringField\n    8: optional binary binaryField\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Required)\n\n/**\n * A point in 2D space.\n */\nstruct Point {\n    1: required double x\n    2: required double y\n}\n\n/**\n * Size of something.\n */\nstruct Size {\n    /**\n     * Width in pixels.\n     */\n    1: required double width\n    /** Height in pixels. */\n    2: required double height\n}\n\nstruct Frame {\n    1: required Point topLeft\n    2: required Size size\n}\n\nstruct Edge {\n    1: required Point startPoint\n    2: required Point endPoint\n}\n\n/**\n * A graph is comprised of zero or more edges.\n */\nstruct Graph {\n    /**\n     * List of edges in the graph.\n     *\n     * May be empty.\n     */\n    1: required list<Edge> edges\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Optional)\n\nstruct ContactInfo {\n    1: required string emailAddress\n}\n\nstruct PersonalInfo {\n    1: optional i32 age\n}\n\nstruct User {\n    1: required string name\n    2: optional ContactInfo contact\n    3: optional PersonalInfo personal\n}\n\ntypedef map<string, User> UserMap\n\n//////////////////////////////////////////////////////////////////////////////\n// self-referential struct\n\ntypedef Node List\n\n/**\n * Node is linked list of values.\n * All values are 32-bit integers.\n */\nstruct Node {\n    1: required i32 value\n    2: optional List tail\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// JSON tagged structs\n\nstruct Rename {\n    1: required string Default (go.tag = 'json:\"default\"')\n    2: required string camelCase (go.tag = 'json:\"snake_case\"')\n}\n\nstruct Omit {\n    1: required string serialized\n    2: required string hidden (go.tag = 'json:\"-\"')\n}\n\nstruct GoTags {\n        1: required string Foo (go.tag = 'json:\"-\" foo:\"bar\"')\n        2: optional string Bar (go.tag = 'bar:\"foo\"')\n        3: required string FooBar (go.tag = 'json:\"foobar,option1,option2\" bar:\"foo,option1\" foo:\"foobar\"')\n        4: required string FooBarWithSpace (go.tag = 'json:\"foobarWithSpace\" foo:\"foo bar foobar barfoo\"')\n        5: optional string FooBarWithOmitEmpty (go.tag = 'json:\"foobarWithOmitEmpty,omitempty\"')\n        6: required string FooBarWithRequired (go.tag = 'json:\"foobarWithRequired,required\"')\n}\n\nstruct NotOmitEmpty {\n    1: optional string NotOmitEmptyString (go.tag = 'json:\"notOmitEmptyString,!omitempty\"')\n    2: optional string NotOmitEmptyInt (go.tag = 'json:\"notOmitEmptyInt,!omitempty\"')\n    3: optional string NotOmitEmptyBool (go.tag = 'json:\"notOmitEmptyBool,!omitempty\"')\n    4: optional list<string> NotOmitEmptyList (go.tag = 'json:\"notOmitEmptyList,!omitempty\"')\n    5: optional map<string, string> NotOmitEmptyMap (go.tag = 'json:\"notOmitEmptyMap,!omitempty\"')\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Default values\n\nstruct DefaultsStruct {\n    1: required i32 requiredPrimitive = 100\n    2: optional i32 optionalPrimitive = 200\n\n    3: required enums.EnumDefault requiredEnum = enums.EnumDefault.Bar\n    4: optional enums.EnumDefault optionalEnum = 2\n\n    5: required list<string> requiredList = [\"hello\", \"world\"]\n    6: optional list<double> optionalList = [1, 2.0, 3]\n\n    7: required Frame requiredStruct = {\n        \"topLeft\": {\"x\": 1, \"y\": 2},\n        \"size\": {\"width\": 100, \"height\": 200},\n    }\n    8: optional Edge optionalStruct = {\n        \"startPoint\": {\"x\": 1, \"y\": 2},\n        \"endPoint\":   {\"x\": 3, \"y\": 4},\n    }\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Opt-out of Zap\n\nstruct ZapOptOutStruct {\n    1: required string name\n    2: required string optout (go.nolog)\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Field jabels\n\nstruct StructLabels {\n    // reserved keyword as label\n    1: optional bool isRequired (go.label = \"required\")\n\n    // go.tag's JSON tag takes precedence over go.label\n    2: optional string foo (go.label = \"bar\", go.tag = 'json:\"not_bar\"')\n\n    // Empty label\n    3: optional string qux (go.label = \"\")\n\n    // All-caps label\n    4: optional string quux (go.label = \"QUUX\")\n}\n"

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -2126,11 +2126,13 @@ func (v *Node) IsSetTail() bool {
 }
 
 type NotOmitEmpty struct {
-	NotOmitEmptyString *string           `json:"notOmitEmptyString,!omitempty"`
-	NotOmitEmptyInt    *string           `json:"notOmitEmptyInt,!omitempty"`
-	NotOmitEmptyBool   *string           `json:"notOmitEmptyBool,!omitempty"`
-	NotOmitEmptyList   []string          `json:"notOmitEmptyList,!omitempty"`
-	NotOmitEmptyMap    map[string]string `json:"notOmitEmptyMap,!omitempty"`
+	NotOmitEmptyString                   *string           `json:"notOmitEmptyString,!omitempty"`
+	NotOmitEmptyInt                      *string           `json:"notOmitEmptyInt,!omitempty"`
+	NotOmitEmptyBool                     *string           `json:"notOmitEmptyBool,!omitempty"`
+	NotOmitEmptyList                     []string          `json:"notOmitEmptyList,!omitempty"`
+	NotOmitEmptyMap                      map[string]string `json:"notOmitEmptyMap,!omitempty"`
+	NotOmitEmptyListMixedWithOmitEmpty   []string          `json:"notOmitEmptyListMixedWithOmitEmpty,!omitempty"`
+	NotOmitEmptyListMixedWithOmitEmptyV2 []string          `json:"notOmitEmptyListMixedWithOmitEmptyV2,!omitempty"`
 }
 
 type _Map_String_String_MapItemList map[string]string
@@ -2185,7 +2187,7 @@ func (_Map_String_String_MapItemList) Close() {}
 //   }
 func (v *NotOmitEmpty) ToWire() (wire.Value, error) {
 	var (
-		fields [5]wire.Field
+		fields [7]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -2229,6 +2231,22 @@ func (v *NotOmitEmpty) ToWire() (wire.Value, error) {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 5, Value: w}
+		i++
+	}
+	if v.NotOmitEmptyListMixedWithOmitEmpty != nil {
+		w, err = wire.NewValueList(_List_String_ValueList(v.NotOmitEmptyListMixedWithOmitEmpty)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 6, Value: w}
+		i++
+	}
+	if v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
+		w, err = wire.NewValueList(_List_String_ValueList(v.NotOmitEmptyListMixedWithOmitEmptyV2)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 7, Value: w}
 		i++
 	}
 
@@ -2331,6 +2349,22 @@ func (v *NotOmitEmpty) FromWire(w wire.Value) error {
 				}
 
 			}
+		case 6:
+			if field.Value.Type() == wire.TList {
+				v.NotOmitEmptyListMixedWithOmitEmpty, err = _List_String_Read(field.Value.GetList())
+				if err != nil {
+					return err
+				}
+
+			}
+		case 7:
+			if field.Value.Type() == wire.TList {
+				v.NotOmitEmptyListMixedWithOmitEmptyV2, err = _List_String_Read(field.Value.GetList())
+				if err != nil {
+					return err
+				}
+
+			}
 		}
 	}
 
@@ -2344,7 +2378,7 @@ func (v *NotOmitEmpty) String() string {
 		return "<nil>"
 	}
 
-	var fields [5]string
+	var fields [7]string
 	i := 0
 	if v.NotOmitEmptyString != nil {
 		fields[i] = fmt.Sprintf("NotOmitEmptyString: %v", *(v.NotOmitEmptyString))
@@ -2364,6 +2398,14 @@ func (v *NotOmitEmpty) String() string {
 	}
 	if v.NotOmitEmptyMap != nil {
 		fields[i] = fmt.Sprintf("NotOmitEmptyMap: %v", v.NotOmitEmptyMap)
+		i++
+	}
+	if v.NotOmitEmptyListMixedWithOmitEmpty != nil {
+		fields[i] = fmt.Sprintf("NotOmitEmptyListMixedWithOmitEmpty: %v", v.NotOmitEmptyListMixedWithOmitEmpty)
+		i++
+	}
+	if v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
+		fields[i] = fmt.Sprintf("NotOmitEmptyListMixedWithOmitEmptyV2: %v", v.NotOmitEmptyListMixedWithOmitEmptyV2)
 		i++
 	}
 
@@ -2412,6 +2454,12 @@ func (v *NotOmitEmpty) Equals(rhs *NotOmitEmpty) bool {
 	if !((v.NotOmitEmptyMap == nil && rhs.NotOmitEmptyMap == nil) || (v.NotOmitEmptyMap != nil && rhs.NotOmitEmptyMap != nil && _Map_String_String_Equals(v.NotOmitEmptyMap, rhs.NotOmitEmptyMap))) {
 		return false
 	}
+	if !((v.NotOmitEmptyListMixedWithOmitEmpty == nil && rhs.NotOmitEmptyListMixedWithOmitEmpty == nil) || (v.NotOmitEmptyListMixedWithOmitEmpty != nil && rhs.NotOmitEmptyListMixedWithOmitEmpty != nil && _List_String_Equals(v.NotOmitEmptyListMixedWithOmitEmpty, rhs.NotOmitEmptyListMixedWithOmitEmpty))) {
+		return false
+	}
+	if !((v.NotOmitEmptyListMixedWithOmitEmptyV2 == nil && rhs.NotOmitEmptyListMixedWithOmitEmptyV2 == nil) || (v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil && rhs.NotOmitEmptyListMixedWithOmitEmptyV2 != nil && _List_String_Equals(v.NotOmitEmptyListMixedWithOmitEmptyV2, rhs.NotOmitEmptyListMixedWithOmitEmptyV2))) {
+		return false
+	}
 
 	return true
 }
@@ -2447,6 +2495,12 @@ func (v *NotOmitEmpty) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	}
 	if v.NotOmitEmptyMap != nil {
 		err = multierr.Append(err, enc.AddObject("NotOmitEmptyMap", (_Map_String_String_Zapper)(v.NotOmitEmptyMap)))
+	}
+	if v.NotOmitEmptyListMixedWithOmitEmpty != nil {
+		err = multierr.Append(err, enc.AddArray("NotOmitEmptyListMixedWithOmitEmpty", (_List_String_Zapper)(v.NotOmitEmptyListMixedWithOmitEmpty)))
+	}
+	if v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
+		err = multierr.Append(err, enc.AddArray("NotOmitEmptyListMixedWithOmitEmptyV2", (_List_String_Zapper)(v.NotOmitEmptyListMixedWithOmitEmptyV2)))
 	}
 	return err
 }
@@ -2524,6 +2578,36 @@ func (v *NotOmitEmpty) GetNotOmitEmptyMap() (o map[string]string) {
 // IsSetNotOmitEmptyMap returns true if NotOmitEmptyMap is not nil.
 func (v *NotOmitEmpty) IsSetNotOmitEmptyMap() bool {
 	return v != nil && v.NotOmitEmptyMap != nil
+}
+
+// GetNotOmitEmptyListMixedWithOmitEmpty returns the value of NotOmitEmptyListMixedWithOmitEmpty if it is set or its
+// zero value if it is unset.
+func (v *NotOmitEmpty) GetNotOmitEmptyListMixedWithOmitEmpty() (o []string) {
+	if v != nil && v.NotOmitEmptyListMixedWithOmitEmpty != nil {
+		return v.NotOmitEmptyListMixedWithOmitEmpty
+	}
+
+	return
+}
+
+// IsSetNotOmitEmptyListMixedWithOmitEmpty returns true if NotOmitEmptyListMixedWithOmitEmpty is not nil.
+func (v *NotOmitEmpty) IsSetNotOmitEmptyListMixedWithOmitEmpty() bool {
+	return v != nil && v.NotOmitEmptyListMixedWithOmitEmpty != nil
+}
+
+// GetNotOmitEmptyListMixedWithOmitEmptyV2 returns the value of NotOmitEmptyListMixedWithOmitEmptyV2 if it is set or its
+// zero value if it is unset.
+func (v *NotOmitEmpty) GetNotOmitEmptyListMixedWithOmitEmptyV2() (o []string) {
+	if v != nil && v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
+		return v.NotOmitEmptyListMixedWithOmitEmptyV2
+	}
+
+	return
+}
+
+// IsSetNotOmitEmptyListMixedWithOmitEmptyV2 returns true if NotOmitEmptyListMixedWithOmitEmptyV2 is not nil.
+func (v *NotOmitEmpty) IsSetNotOmitEmptyListMixedWithOmitEmptyV2() bool {
+	return v != nil && v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil
 }
 
 type Omit struct {
@@ -5023,11 +5107,11 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "structs",
 	Package:  "go.uber.org/thriftrw/gen/internal/tests/structs",
 	FilePath: "structs.thrift",
-	SHA1:     "57d0eda8ed948148c823a9d8d934e9a048c44124",
+	SHA1:     "28983d45f529715c3505b015e07d413ec560b277",
 	Includes: []*thriftreflect.ThriftModule{
 		enums.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "include \"./enums.thrift\"\n\nstruct EmptyStruct {}\n\n//////////////////////////////////////////////////////////////////////////////\n// Structs with primitives\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are required.\n */\nstruct PrimitiveRequiredStruct {\n    1: required bool boolField\n    2: required byte byteField\n    3: required i16 int16Field\n    4: required i32 int32Field\n    5: required i64 int64Field\n    6: required double doubleField\n    7: required string stringField\n    8: required binary binaryField\n}\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are optional.\n */\nstruct PrimitiveOptionalStruct {\n    1: optional bool boolField\n    2: optional byte byteField\n    3: optional i16 int16Field\n    4: optional i32 int32Field\n    5: optional i64 int64Field\n    6: optional double doubleField\n    7: optional string stringField\n    8: optional binary binaryField\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Required)\n\n/**\n * A point in 2D space.\n */\nstruct Point {\n    1: required double x\n    2: required double y\n}\n\n/**\n * Size of something.\n */\nstruct Size {\n    /**\n     * Width in pixels.\n     */\n    1: required double width\n    /** Height in pixels. */\n    2: required double height\n}\n\nstruct Frame {\n    1: required Point topLeft\n    2: required Size size\n}\n\nstruct Edge {\n    1: required Point startPoint\n    2: required Point endPoint\n}\n\n/**\n * A graph is comprised of zero or more edges.\n */\nstruct Graph {\n    /**\n     * List of edges in the graph.\n     *\n     * May be empty.\n     */\n    1: required list<Edge> edges\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Optional)\n\nstruct ContactInfo {\n    1: required string emailAddress\n}\n\nstruct PersonalInfo {\n    1: optional i32 age\n}\n\nstruct User {\n    1: required string name\n    2: optional ContactInfo contact\n    3: optional PersonalInfo personal\n}\n\ntypedef map<string, User> UserMap\n\n//////////////////////////////////////////////////////////////////////////////\n// self-referential struct\n\ntypedef Node List\n\n/**\n * Node is linked list of values.\n * All values are 32-bit integers.\n */\nstruct Node {\n    1: required i32 value\n    2: optional List tail\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// JSON tagged structs\n\nstruct Rename {\n    1: required string Default (go.tag = 'json:\"default\"')\n    2: required string camelCase (go.tag = 'json:\"snake_case\"')\n}\n\nstruct Omit {\n    1: required string serialized\n    2: required string hidden (go.tag = 'json:\"-\"')\n}\n\nstruct GoTags {\n        1: required string Foo (go.tag = 'json:\"-\" foo:\"bar\"')\n        2: optional string Bar (go.tag = 'bar:\"foo\"')\n        3: required string FooBar (go.tag = 'json:\"foobar,option1,option2\" bar:\"foo,option1\" foo:\"foobar\"')\n        4: required string FooBarWithSpace (go.tag = 'json:\"foobarWithSpace\" foo:\"foo bar foobar barfoo\"')\n        5: optional string FooBarWithOmitEmpty (go.tag = 'json:\"foobarWithOmitEmpty,omitempty\"')\n        6: required string FooBarWithRequired (go.tag = 'json:\"foobarWithRequired,required\"')\n}\n\nstruct NotOmitEmpty {\n    1: optional string NotOmitEmptyString (go.tag = 'json:\"notOmitEmptyString,!omitempty\"')\n    2: optional string NotOmitEmptyInt (go.tag = 'json:\"notOmitEmptyInt,!omitempty\"')\n    3: optional string NotOmitEmptyBool (go.tag = 'json:\"notOmitEmptyBool,!omitempty\"')\n    4: optional list<string> NotOmitEmptyList (go.tag = 'json:\"notOmitEmptyList,!omitempty\"')\n    5: optional map<string, string> NotOmitEmptyMap (go.tag = 'json:\"notOmitEmptyMap,!omitempty\"')\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Default values\n\nstruct DefaultsStruct {\n    1: required i32 requiredPrimitive = 100\n    2: optional i32 optionalPrimitive = 200\n\n    3: required enums.EnumDefault requiredEnum = enums.EnumDefault.Bar\n    4: optional enums.EnumDefault optionalEnum = 2\n\n    5: required list<string> requiredList = [\"hello\", \"world\"]\n    6: optional list<double> optionalList = [1, 2.0, 3]\n\n    7: required Frame requiredStruct = {\n        \"topLeft\": {\"x\": 1, \"y\": 2},\n        \"size\": {\"width\": 100, \"height\": 200},\n    }\n    8: optional Edge optionalStruct = {\n        \"startPoint\": {\"x\": 1, \"y\": 2},\n        \"endPoint\":   {\"x\": 3, \"y\": 4},\n    }\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Opt-out of Zap\n\nstruct ZapOptOutStruct {\n    1: required string name\n    2: required string optout (go.nolog)\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Field jabels\n\nstruct StructLabels {\n    // reserved keyword as label\n    1: optional bool isRequired (go.label = \"required\")\n\n    // go.tag's JSON tag takes precedence over go.label\n    2: optional string foo (go.label = \"bar\", go.tag = 'json:\"not_bar\"')\n\n    // Empty label\n    3: optional string qux (go.label = \"\")\n\n    // All-caps label\n    4: optional string quux (go.label = \"QUUX\")\n}\n"
+const rawIDL = "include \"./enums.thrift\"\n\nstruct EmptyStruct {}\n\n//////////////////////////////////////////////////////////////////////////////\n// Structs with primitives\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are required.\n */\nstruct PrimitiveRequiredStruct {\n    1: required bool boolField\n    2: required byte byteField\n    3: required i16 int16Field\n    4: required i32 int32Field\n    5: required i64 int64Field\n    6: required double doubleField\n    7: required string stringField\n    8: required binary binaryField\n}\n\n/**\n * A struct that contains primitive fields exclusively.\n *\n * All fields are optional.\n */\nstruct PrimitiveOptionalStruct {\n    1: optional bool boolField\n    2: optional byte byteField\n    3: optional i16 int16Field\n    4: optional i32 int32Field\n    5: optional i64 int64Field\n    6: optional double doubleField\n    7: optional string stringField\n    8: optional binary binaryField\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Required)\n\n/**\n * A point in 2D space.\n */\nstruct Point {\n    1: required double x\n    2: required double y\n}\n\n/**\n * Size of something.\n */\nstruct Size {\n    /**\n     * Width in pixels.\n     */\n    1: required double width\n    /** Height in pixels. */\n    2: required double height\n}\n\nstruct Frame {\n    1: required Point topLeft\n    2: required Size size\n}\n\nstruct Edge {\n    1: required Point startPoint\n    2: required Point endPoint\n}\n\n/**\n * A graph is comprised of zero or more edges.\n */\nstruct Graph {\n    /**\n     * List of edges in the graph.\n     *\n     * May be empty.\n     */\n    1: required list<Edge> edges\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Nested structs (Optional)\n\nstruct ContactInfo {\n    1: required string emailAddress\n}\n\nstruct PersonalInfo {\n    1: optional i32 age\n}\n\nstruct User {\n    1: required string name\n    2: optional ContactInfo contact\n    3: optional PersonalInfo personal\n}\n\ntypedef map<string, User> UserMap\n\n//////////////////////////////////////////////////////////////////////////////\n// self-referential struct\n\ntypedef Node List\n\n/**\n * Node is linked list of values.\n * All values are 32-bit integers.\n */\nstruct Node {\n    1: required i32 value\n    2: optional List tail\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// JSON tagged structs\n\nstruct Rename {\n    1: required string Default (go.tag = 'json:\"default\"')\n    2: required string camelCase (go.tag = 'json:\"snake_case\"')\n}\n\nstruct Omit {\n    1: required string serialized\n    2: required string hidden (go.tag = 'json:\"-\"')\n}\n\nstruct GoTags {\n        1: required string Foo (go.tag = 'json:\"-\" foo:\"bar\"')\n        2: optional string Bar (go.tag = 'bar:\"foo\"')\n        3: required string FooBar (go.tag = 'json:\"foobar,option1,option2\" bar:\"foo,option1\" foo:\"foobar\"')\n        4: required string FooBarWithSpace (go.tag = 'json:\"foobarWithSpace\" foo:\"foo bar foobar barfoo\"')\n        5: optional string FooBarWithOmitEmpty (go.tag = 'json:\"foobarWithOmitEmpty,omitempty\"')\n        6: required string FooBarWithRequired (go.tag = 'json:\"foobarWithRequired,required\"')\n}\n\nstruct NotOmitEmpty {\n    1: optional string NotOmitEmptyString (go.tag = 'json:\"notOmitEmptyString,!omitempty\"')\n    2: optional string NotOmitEmptyInt (go.tag = 'json:\"notOmitEmptyInt,!omitempty\"')\n    3: optional string NotOmitEmptyBool (go.tag = 'json:\"notOmitEmptyBool,!omitempty\"')\n    4: optional list<string> NotOmitEmptyList (go.tag = 'json:\"notOmitEmptyList,!omitempty\"')\n    5: optional map<string, string> NotOmitEmptyMap (go.tag = 'json:\"notOmitEmptyMap,!omitempty\"')\n    6: optional list<string> NotOmitEmptyListMixedWithOmitEmpty (go.tag = 'json:\"notOmitEmptyListMixedWithOmitEmpty,!omitempty,omitempty\"')\n    7: optional list<string> NotOmitEmptyListMixedWithOmitEmptyV2 (go.tag = 'json:\"notOmitEmptyListMixedWithOmitEmptyV2,omitempty,!omitempty\"')\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Default values\n\nstruct DefaultsStruct {\n    1: required i32 requiredPrimitive = 100\n    2: optional i32 optionalPrimitive = 200\n\n    3: required enums.EnumDefault requiredEnum = enums.EnumDefault.Bar\n    4: optional enums.EnumDefault optionalEnum = 2\n\n    5: required list<string> requiredList = [\"hello\", \"world\"]\n    6: optional list<double> optionalList = [1, 2.0, 3]\n\n    7: required Frame requiredStruct = {\n        \"topLeft\": {\"x\": 1, \"y\": 2},\n        \"size\": {\"width\": 100, \"height\": 200},\n    }\n    8: optional Edge optionalStruct = {\n        \"startPoint\": {\"x\": 1, \"y\": 2},\n        \"endPoint\":   {\"x\": 3, \"y\": 4},\n    }\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Opt-out of Zap\n\nstruct ZapOptOutStruct {\n    1: required string name\n    2: required string optout (go.nolog)\n}\n\n//////////////////////////////////////////////////////////////////////////////\n// Field jabels\n\nstruct StructLabels {\n    // reserved keyword as label\n    1: optional bool isRequired (go.label = \"required\")\n\n    // go.tag's JSON tag takes precedence over go.label\n    2: optional string foo (go.label = \"bar\", go.tag = 'json:\"not_bar\"')\n\n    // Empty label\n    3: optional string qux (go.label = \"\")\n\n    // All-caps label\n    4: optional string quux (go.label = \"QUUX\")\n}\n"

--- a/gen/internal/tests/thrift/structs.thrift
+++ b/gen/internal/tests/thrift/structs.thrift
@@ -137,6 +137,14 @@ struct GoTags {
         6: required string FooBarWithRequired (go.tag = 'json:"foobarWithRequired,required"')
 }
 
+struct NotOmitEmpty {
+    1: optional string NotOmitEmptyString (go.tag = 'json:"notOmitEmptyString,!omitempty"')
+    2: optional string NotOmitEmptyInt (go.tag = 'json:"notOmitEmptyInt,!omitempty"')
+    3: optional string NotOmitEmptyBool (go.tag = 'json:"notOmitEmptyBool,!omitempty"')
+    4: optional list<string> NotOmitEmptyList (go.tag = 'json:"notOmitEmptyList,!omitempty"')
+    5: optional map<string, string> NotOmitEmptyMap (go.tag = 'json:"notOmitEmptyMap,!omitempty"')
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // Default values
 

--- a/gen/internal/tests/thrift/structs.thrift
+++ b/gen/internal/tests/thrift/structs.thrift
@@ -143,6 +143,8 @@ struct NotOmitEmpty {
     3: optional string NotOmitEmptyBool (go.tag = 'json:"notOmitEmptyBool,!omitempty"')
     4: optional list<string> NotOmitEmptyList (go.tag = 'json:"notOmitEmptyList,!omitempty"')
     5: optional map<string, string> NotOmitEmptyMap (go.tag = 'json:"notOmitEmptyMap,!omitempty"')
+    6: optional list<string> NotOmitEmptyListMixedWithOmitEmpty (go.tag = 'json:"notOmitEmptyListMixedWithOmitEmpty,!omitempty,omitempty"')
+    7: optional list<string> NotOmitEmptyListMixedWithOmitEmptyV2 (go.tag = 'json:"notOmitEmptyListMixedWithOmitEmptyV2,omitempty,!omitempty"')
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/gen/internal/tests/thrift/structs.thrift
+++ b/gen/internal/tests/thrift/structs.thrift
@@ -145,6 +145,7 @@ struct NotOmitEmpty {
     5: optional map<string, string> NotOmitEmptyMap (go.tag = 'json:"notOmitEmptyMap,!omitempty"')
     6: optional list<string> NotOmitEmptyListMixedWithOmitEmpty (go.tag = 'json:"notOmitEmptyListMixedWithOmitEmpty,!omitempty,omitempty"')
     7: optional list<string> NotOmitEmptyListMixedWithOmitEmptyV2 (go.tag = 'json:"notOmitEmptyListMixedWithOmitEmptyV2,omitempty,!omitempty"')
+    8: optional string OmitEmptyString (go.tag = 'json:"omitEmptyString,omitempty"') // to test that there can be a mix of fields that do and don't have !omitempty
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -356,6 +356,7 @@ func TestQuickSuite(t *testing.T) {
 		{Sample: ts.EmptyStruct{}, Kind: thriftStruct},
 		{Sample: ts.Frame{}, Kind: thriftStruct},
 		{Sample: ts.GoTags{}, Kind: thriftStruct},
+		{Sample: ts.NotOmitEmpty{}, Kind: thriftStruct},
 		{Sample: ts.Graph{}, Kind: thriftStruct},
 		{Sample: ts.Node{}, Kind: thriftStruct},
 		{Sample: ts.Omit{}, Kind: thriftStruct},

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1193,6 +1193,56 @@ func TestStructGoTags(t *testing.T) {
 	assert.Equal(t, `json:"foobarWithRequired,required"`, string(foobarWithRequired.Tag))
 }
 
+func TestNotOmitEmpty_GoTagBehavior(t *testing.T) {
+	notOmitemptyStruct := &ts.NotOmitEmpty{
+		NotOmitEmptyString: nil,
+		NotOmitEmptyInt:    nil,
+		NotOmitEmptyBool:   nil,
+		NotOmitEmptyList:   nil,
+		NotOmitEmptyMap:    nil,
+	}
+
+	// assert that when the !omitempty tag is present in thrift, omitempty is not added to the go tags
+	notOmitEmptyString, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyString")
+	assert.Equal(t, `json:"notOmitEmptyString,!omitempty"`, string(notOmitEmptyString.Tag))
+	notOmitEmptyInt, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyInt")
+	assert.Equal(t, `json:"notOmitEmptyInt,!omitempty"`, string(notOmitEmptyInt.Tag))
+	notOmitEmptyBool, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyBool")
+	assert.Equal(t, `json:"notOmitEmptyBool,!omitempty"`, string(notOmitEmptyBool.Tag))
+	notOmitEmptyList, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyList")
+	assert.Equal(t, `json:"notOmitEmptyList,!omitempty"`, string(notOmitEmptyList.Tag))
+	notOmitEmptyMap, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyMap")
+	assert.Equal(t, `json:"notOmitEmptyMap,!omitempty"`, string(notOmitEmptyMap.Tag))
+}
+
+func TestNotOmitEmpty_MarshallingBehavior(t *testing.T) {
+	// assert that when !omitempty tag is NOT present, empty fields are omitted in the marshalled response
+	defaultStruct := &ts.PrimitiveOptionalStruct{
+		BoolField:   nil,
+		ByteField:   nil,
+		Int16Field:  nil,
+		Int32Field:  nil,
+		Int64Field:  nil,
+		DoubleField: nil,
+		StringField: nil,
+		BinaryField: nil,
+	}
+	defaultStructResult, _ := json.Marshal(defaultStruct)
+	assert.Equal(t, "{}", string(defaultStructResult))
+
+	// assert that when !omitempty tag is present, empty fields are not omitted in the marshalled response
+	notOmitemptyStruct := &ts.NotOmitEmpty{
+		NotOmitEmptyString: nil,
+		NotOmitEmptyInt:    nil,
+		NotOmitEmptyBool:   nil,
+		NotOmitEmptyList:   nil,
+		NotOmitEmptyMap:    nil,
+	}
+	expected := `{"notOmitEmptyString":null,"notOmitEmptyInt":null,"notOmitEmptyBool":null,"notOmitEmptyList":null,"notOmitEmptyMap":null}`
+	result, _ := json.Marshal(notOmitemptyStruct)
+	assert.Equal(t, expected, string(result))
+}
+
 func TestStructValidation(t *testing.T) {
 	tests := []struct {
 		desc        string

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1205,6 +1205,7 @@ func TestNotOmitEmptyStructTags(t *testing.T) {
 		{"NotOmitEmptyMap", `json:"notOmitEmptyMap,!omitempty"`},
 		{"NotOmitEmptyListMixedWithOmitEmpty", `json:"notOmitEmptyListMixedWithOmitEmpty,!omitempty"`},
 		{"NotOmitEmptyListMixedWithOmitEmptyV2", `json:"notOmitEmptyListMixedWithOmitEmptyV2,!omitempty"`},
+		{"OmitEmptyString", `json:"omitEmptyString,omitempty"`},
 	}
 
 	typ := reflect.TypeOf(ts.NotOmitEmpty{})

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1193,7 +1193,7 @@ func TestStructGoTags(t *testing.T) {
 	assert.Equal(t, `json:"foobarWithRequired,required"`, string(foobarWithRequired.Tag))
 }
 
-func TestNotOmitEmpty_GoTagBehavior(t *testing.T) {
+func TestNotOmitEmptyStructTags(t *testing.T) {
 	notOmitemptyStruct := &ts.NotOmitEmpty{
 		NotOmitEmptyString: nil,
 		NotOmitEmptyInt:    nil,

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1194,9 +1194,9 @@ func TestStructGoTags(t *testing.T) {
 }
 
 func TestNotOmitEmptyStructTags(t *testing.T) {
-	tests := []struct{
+	tests := []struct {
 		field string
-		tag string
+		tag   string
 	}{
 		{"NotOmitEmptyString", `json:"notOmitEmptyString,!omitempty"`},
 		{"NotOmitEmptyInt", `json:"notOmitEmptyInt,!omitempty"`},

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1203,6 +1203,8 @@ func TestNotOmitEmptyStructTags(t *testing.T) {
 		{"NotOmitEmptyBool", `json:"notOmitEmptyBool,!omitempty"`},
 		{"NotOmitEmptyList", `json:"notOmitEmptyList,!omitempty"`},
 		{"NotOmitEmptyMap", `json:"notOmitEmptyMap,!omitempty"`},
+		{"NotOmitEmptyListMixedWithOmitEmpty", `json:"notOmitEmptyListMixedWithOmitEmpty,!omitempty"`},
+		{"NotOmitEmptyListMixedWithOmitEmptyV2", `json:"notOmitEmptyListMixedWithOmitEmptyV2,!omitempty"`},
 	}
 
 	typ := reflect.TypeOf(ts.NotOmitEmpty{})
@@ -1225,7 +1227,7 @@ func TestOmitEmptyMarshal(t *testing.T) {
 
 	// assert that when !omitempty tag is present, empty fields are not omitted in the marshalled response
 	t.Run("!omitempty", func(t *testing.T) {
-		expected := `{"notOmitEmptyString":null,"notOmitEmptyInt":null,"notOmitEmptyBool":null,"notOmitEmptyList":null,"notOmitEmptyMap":null}`
+		expected := `{"notOmitEmptyString":null,"notOmitEmptyInt":null,"notOmitEmptyBool":null,"notOmitEmptyList":null,"notOmitEmptyMap":null,"notOmitEmptyListMixedWithOmitEmpty":null,"notOmitEmptyListMixedWithOmitEmptyV2":null}`
 		result, err := json.Marshal(ts.NotOmitEmpty{})
 		require.NoError(t, err)
 		assert.JSONEq(t, expected, string(result))

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1217,30 +1217,19 @@ func TestNotOmitEmptyStructTags(t *testing.T) {
 
 func TestOmitEmptyMarshal(t *testing.T) {
 	// assert that when !omitempty tag is NOT present, empty fields are omitted in the marshalled response
-	defaultStruct := &ts.PrimitiveOptionalStruct{
-		BoolField:   nil,
-		ByteField:   nil,
-		Int16Field:  nil,
-		Int32Field:  nil,
-		Int64Field:  nil,
-		DoubleField: nil,
-		StringField: nil,
-		BinaryField: nil,
-	}
-	defaultStructResult, _ := json.Marshal(defaultStruct)
-	assert.Equal(t, "{}", string(defaultStructResult))
+	t.Run("omitempty", func(t *testing.T) {
+		out, err := json.Marshal(ts.PrimitiveOptionalStruct{})
+		require.NoError(t, err)
+		assert.Equal(t, "{}", string(out))
+	})
 
 	// assert that when !omitempty tag is present, empty fields are not omitted in the marshalled response
-	notOmitemptyStruct := &ts.NotOmitEmpty{
-		NotOmitEmptyString: nil,
-		NotOmitEmptyInt:    nil,
-		NotOmitEmptyBool:   nil,
-		NotOmitEmptyList:   nil,
-		NotOmitEmptyMap:    nil,
-	}
-	expected := `{"notOmitEmptyString":null,"notOmitEmptyInt":null,"notOmitEmptyBool":null,"notOmitEmptyList":null,"notOmitEmptyMap":null}`
-	result, _ := json.Marshal(notOmitemptyStruct)
-	assert.Equal(t, expected, string(result))
+	t.Run("!omitempty", func(t *testing.T) {
+		expected := `{"notOmitEmptyString":null,"notOmitEmptyInt":null,"notOmitEmptyBool":null,"notOmitEmptyList":null,"notOmitEmptyMap":null}`
+		result, err := json.Marshal(ts.NotOmitEmpty{})
+		require.NoError(t, err)
+		assert.JSONEq(t, expected, string(result))
+	})
 }
 
 func TestStructValidation(t *testing.T) {

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1194,25 +1194,25 @@ func TestStructGoTags(t *testing.T) {
 }
 
 func TestNotOmitEmptyStructTags(t *testing.T) {
-	notOmitemptyStruct := &ts.NotOmitEmpty{
-		NotOmitEmptyString: nil,
-		NotOmitEmptyInt:    nil,
-		NotOmitEmptyBool:   nil,
-		NotOmitEmptyList:   nil,
-		NotOmitEmptyMap:    nil,
+	tests := []struct{
+		field string
+		tag string
+	}{
+		{"NotOmitEmptyString", `json:"notOmitEmptyString,!omitempty"`},
+		{"NotOmitEmptyInt", `json:"notOmitEmptyInt,!omitempty"`},
+		{"NotOmitEmptyBool", `json:"notOmitEmptyBool,!omitempty"`},
+		{"NotOmitEmptyList", `json:"notOmitEmptyList,!omitempty"`},
+		{"NotOmitEmptyMap", `json:"notOmitEmptyMap,!omitempty"`},
 	}
 
-	// assert that when the !omitempty tag is present in thrift, omitempty is not added to the go tags
-	notOmitEmptyString, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyString")
-	assert.Equal(t, `json:"notOmitEmptyString,!omitempty"`, string(notOmitEmptyString.Tag))
-	notOmitEmptyInt, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyInt")
-	assert.Equal(t, `json:"notOmitEmptyInt,!omitempty"`, string(notOmitEmptyInt.Tag))
-	notOmitEmptyBool, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyBool")
-	assert.Equal(t, `json:"notOmitEmptyBool,!omitempty"`, string(notOmitEmptyBool.Tag))
-	notOmitEmptyList, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyList")
-	assert.Equal(t, `json:"notOmitEmptyList,!omitempty"`, string(notOmitEmptyList.Tag))
-	notOmitEmptyMap, _ := reflect.TypeOf(notOmitemptyStruct).Elem().FieldByName("NotOmitEmptyMap")
-	assert.Equal(t, `json:"notOmitEmptyMap,!omitempty"`, string(notOmitEmptyMap.Tag))
+	typ := reflect.TypeOf(ts.NotOmitEmpty{})
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			f, ok := typ.FieldByName(tt.field)
+			require.True(t, ok)
+			assert.Equal(t, tt.tag, string(f.Tag))
+		})
+	}
 }
 
 func TestOmitEmptyMarshal(t *testing.T) {

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1207,7 +1207,7 @@ func TestNotOmitEmptyStructTags(t *testing.T) {
 
 	typ := reflect.TypeOf(ts.NotOmitEmpty{})
 	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
+		t.Run(tt.field, func(t *testing.T) {
 			f, ok := typ.FieldByName(tt.field)
 			require.True(t, ok)
 			assert.Equal(t, tt.tag, string(f.Tag))

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -1215,7 +1215,7 @@ func TestNotOmitEmptyStructTags(t *testing.T) {
 	assert.Equal(t, `json:"notOmitEmptyMap,!omitempty"`, string(notOmitEmptyMap.Tag))
 }
 
-func TestNotOmitEmpty_MarshallingBehavior(t *testing.T) {
+func TestOmitEmptyMarshal(t *testing.T) {
 	// assert that when !omitempty tag is NOT present, empty fields are omitted in the marshalled response
 	defaultStruct := &ts.PrimitiveOptionalStruct{
 		BoolField:   nil,


### PR DESCRIPTION
Hi team,

Sai To Yeung from Uber Eats Restaurant Platform Team here.   Looking to enable a feature to enable some flexibility with how ThriftRW adds in `omitempty` to all optional fields.

With this change, if a user marks a field in the thrift definition with `!omitempty`, the `omitempty` tag will not be added in the final struct.

This is to support use cases in which some clients expect the marshalled response of an empty list or map field to be `[]` or `{}` instead of the entire field being removed altogether.

Happy to provide more context via Slack.

Thanks!