### PR TITLE
gen: retype Options.Plugin for external implements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Changed
+- gen: Redefine Options.Plugin as a struct usable outside go.uber.org/thriftrw.
 
 ## [1.23.0] - 2020-03-31
 ### Added

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -290,9 +290,12 @@ func TestGenerate(t *testing.T) {
 			require.NoError(t, err)
 			defer os.RemoveAll(outputDir)
 
-			var p plugin.Handle
+			var p CodeGenerator
 			if tt.getPlugin != nil {
-				p = tt.getPlugin(mockCtrl)
+				handle := tt.getPlugin(mockCtrl)
+				p = CodeGenerator{
+					ServiceGenerator: handle.ServiceGenerator(),
+				}
 			}
 
 			err = Generate(module, &Options{

--- a/main.go
+++ b/main.go
@@ -173,13 +173,16 @@ func do() (err error) {
 		err = multierr.Append(err, pluginHandle.Close())
 	}()
 
+	codeGenerator := gen.CodeGenerator{
+		ServiceGenerator: pluginHandle.ServiceGenerator(),
+	}
 	generatorOptions := gen.Options{
 		OutputDir:        gopts.OutputDirectory,
 		PackagePrefix:    gopts.PackagePrefix,
 		ThriftRoot:       gopts.ThriftRoot,
 		NoRecurse:        gopts.NoRecurse,
 		NoVersionCheck:   gopts.NoVersionCheck,
-		Plugin:           pluginHandle,
+		Plugin:           codeGenerator,
 		NoTypes:          gopts.NoTypes,
 		NoConstants:      gopts.NoConstants,
 		NoServiceHelpers: gopts.NoServiceHelpers || gopts.NoTypes,


### PR DESCRIPTION
Options.Plugin was a internal/plugin.Handle. That meant packages outside
of go.uber.org/thriftrw could not implement a plugin that gen.Generate
could use.

A new, user implementable type, struct is defined: CodeGenerator. It
currently has a single field, the service generator, but it could be
extended by adding new generator fields if we want to maintain API
compatibility (this package currently does not have an API guarantee).
Options.Plugin is now specified as a CodeGenerator.

The previous type included a io.Closer and factory for generators. This
makes more sense from a higher level as plugins are typically forked
programs talking over stdin/out. However, it's a detail the generator
does not care for. It's happy so long as it can call the Generate method
of a ServiceGenerator. Including the I/O detail breaks the abstraction
of what the plugin truly are: a callable that generates code.