### PR TITLE
Fix mutation dependent tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Generate `Default_*` methods that construct Thrift structs with defined 
+  default values pre-populated.  
+
 ### Changed
 - gen: Redefine Options.Plugin as a struct usable outside go.uber.org/thriftrw.
 

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -1514,6 +1514,17 @@ type WithDefault struct {
 	Pouet *StructCollision2 `json:"pouet,omitempty"`
 }
 
+// Default_WithDefault constructs a new WithDefault struct,
+// pre-populating any fields with defined default values.
+func Default_WithDefault() *WithDefault {
+	var v WithDefault
+	v.Pouet = &StructCollision2{
+		CollisionField:  false,
+		CollisionField2: "false indeed",
+	}
+	return &v
+}
+
 // ToWire translates a WithDefault struct into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -205,6 +205,15 @@ func _RecordType_1_ptr(v enums.RecordType) *enums.RecordType {
 	return &v
 }
 
+// Default_Records constructs a new Records struct,
+// pre-populating any fields with defined default values.
+func Default_Records() *Records {
+	var v Records
+	v.RecordType = _RecordType_ptr(DefaultRecordType)
+	v.OtherRecordType = _RecordType_1_ptr(DefaultOtherRecordType)
+	return &v
+}
+
 // ToWire translates a Records struct into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -162,6 +162,46 @@ func _EnumDefault_ptr(v enums.EnumDefault) *enums.EnumDefault {
 	return &v
 }
 
+// Default_DefaultsStruct constructs a new DefaultsStruct struct,
+// pre-populating any fields with defined default values.
+func Default_DefaultsStruct() *DefaultsStruct {
+	var v DefaultsStruct
+	v.RequiredPrimitive = ptr.Int32(100)
+	v.OptionalPrimitive = ptr.Int32(200)
+	v.RequiredEnum = _EnumDefault_ptr(enums.EnumDefaultBar)
+	v.OptionalEnum = _EnumDefault_ptr(enums.EnumDefaultBaz)
+	v.RequiredList = []string{
+		"hello",
+		"world",
+	}
+	v.OptionalList = []float64{
+		1,
+		2,
+		3,
+	}
+	v.RequiredStruct = &Frame{
+		Size: &Size{
+			Height: 200,
+			Width:  100,
+		},
+		TopLeft: &Point{
+			X: 1,
+			Y: 2,
+		},
+	}
+	v.OptionalStruct = &Edge{
+		EndPoint: &Point{
+			X: 3,
+			Y: 4,
+		},
+		StartPoint: &Point{
+			X: 1,
+			Y: 2,
+		},
+	}
+	return &v
+}
+
 type _List_String_ValueList []string
 
 func (v _List_String_ValueList) ForEach(f func(wire.Value) error) error {

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -140,6 +140,14 @@ func _State_ptr(v State) *State {
 	return &v
 }
 
+// Default_DefaultPrimitiveTypedef constructs a new DefaultPrimitiveTypedef struct,
+// pre-populating any fields with defined default values.
+func Default_DefaultPrimitiveTypedef() *DefaultPrimitiveTypedef {
+	var v DefaultPrimitiveTypedef
+	v.State = _State_ptr("hello")
+	return &v
+}
+
 // ToWire translates a DefaultPrimitiveTypedef struct into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.


### PR DESCRIPTION
Currently, the `ToWire` functionality mutates the generated thrift type to overwrite nil values with default values. We intend to change this. However, the `thriftRoundTrip` and `GetAccessor` tests depend on this mutation to pass. 

Split into two commits, this PR does the following:
1. add a `Default_*` constructor method to the generated code to provide easy access to the generated types.
2. Decouple the tests from their dependence on mutation by copying values before calling `ToWire` and using the default values exposed in the previous commit to make assertions.

The `ToWire` changes themselves can be expected in an immediate follow-up PR, based on the branch [syrie/fix_towire_mutation](https://github.com/SyrieBianco/thriftrw-go/tree/syrie/fix_towire_mutation)