### PR TITLE
Do not mutate receiver in ToWire call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Generate `Default_*` methods that construct Thrift structs with defined 
   default values pre-populated.  
 
-### Changed
+### Changed  
 - gen: Redefine Options.Plugin as a struct usable outside go.uber.org/thriftrw.
+
+### Fixed
+- Serializing generated Thrift objects no longer mutates them with default
+  values for unspecified fields.
 
 ## [1.23.0] - 2020-03-31
 ### Added

--- a/gen/field.go
+++ b/gen/field.go
@@ -330,14 +330,17 @@ func (f fieldGroupGenerator) ToWire(g Generator) error {
 						<$i>++
 				<- else ->
 					<- if .Default ->
-						if <$f> == nil {
-							<$f> = <constantValuePtr .Default .Type>
+						<- $fval := printf "%s%s" $v $fname ->
+						<$fval> := <$f>
+						if <$fval> == nil {
+							<$fval> = <constantValuePtr .Default .Type>
 						}
 						{
+							<$wVal>, err = <toWirePtr .Type $fval>
 					<- else ->
 						if <$f> != nil {
-					<- end>
 							<$wVal>, err = <toWirePtr .Type $f>
+					<- end>
 							if err != nil {
 								return <$wVal>, err
 							}

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -1548,14 +1548,15 @@ func (v *WithDefault) ToWire() (wire.Value, error) {
 		err    error
 	)
 
-	if v.Pouet == nil {
-		v.Pouet = &StructCollision2{
+	vPouet := v.Pouet
+	if vPouet == nil {
+		vPouet = &StructCollision2{
 			CollisionField:  false,
 			CollisionField2: "false indeed",
 		}
 	}
 	{
-		w, err = v.Pouet.ToWire()
+		w, err = vPouet.ToWire()
 		if err != nil {
 			return w, err
 		}

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -237,22 +237,24 @@ func (v *Records) ToWire() (wire.Value, error) {
 		err    error
 	)
 
-	if v.RecordType == nil {
-		v.RecordType = _RecordType_ptr(DefaultRecordType)
+	vRecordType := v.RecordType
+	if vRecordType == nil {
+		vRecordType = _RecordType_ptr(DefaultRecordType)
 	}
 	{
-		w, err = v.RecordType.ToWire()
+		w, err = vRecordType.ToWire()
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 1, Value: w}
 		i++
 	}
-	if v.OtherRecordType == nil {
-		v.OtherRecordType = _RecordType_1_ptr(DefaultOtherRecordType)
+	vOtherRecordType := v.OtherRecordType
+	if vOtherRecordType == nil {
+		vOtherRecordType = _RecordType_1_ptr(DefaultOtherRecordType)
 	}
 	{
-		w, err = v.OtherRecordType.ToWire()
+		w, err = vOtherRecordType.ToWire()
 		if err != nil {
 			return w, err
 		}

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -277,81 +277,88 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 		err    error
 	)
 
-	if v.RequiredPrimitive == nil {
-		v.RequiredPrimitive = ptr.Int32(100)
+	vRequiredPrimitive := v.RequiredPrimitive
+	if vRequiredPrimitive == nil {
+		vRequiredPrimitive = ptr.Int32(100)
 	}
 	{
-		w, err = wire.NewValueI32(*(v.RequiredPrimitive)), error(nil)
+		w, err = wire.NewValueI32(*(vRequiredPrimitive)), error(nil)
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 1, Value: w}
 		i++
 	}
-	if v.OptionalPrimitive == nil {
-		v.OptionalPrimitive = ptr.Int32(200)
+	vOptionalPrimitive := v.OptionalPrimitive
+	if vOptionalPrimitive == nil {
+		vOptionalPrimitive = ptr.Int32(200)
 	}
 	{
-		w, err = wire.NewValueI32(*(v.OptionalPrimitive)), error(nil)
+		w, err = wire.NewValueI32(*(vOptionalPrimitive)), error(nil)
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 2, Value: w}
 		i++
 	}
-	if v.RequiredEnum == nil {
-		v.RequiredEnum = _EnumDefault_ptr(enums.EnumDefaultBar)
+	vRequiredEnum := v.RequiredEnum
+	if vRequiredEnum == nil {
+		vRequiredEnum = _EnumDefault_ptr(enums.EnumDefaultBar)
 	}
 	{
-		w, err = v.RequiredEnum.ToWire()
+		w, err = vRequiredEnum.ToWire()
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 3, Value: w}
 		i++
 	}
-	if v.OptionalEnum == nil {
-		v.OptionalEnum = _EnumDefault_ptr(enums.EnumDefaultBaz)
+	vOptionalEnum := v.OptionalEnum
+	if vOptionalEnum == nil {
+		vOptionalEnum = _EnumDefault_ptr(enums.EnumDefaultBaz)
 	}
 	{
-		w, err = v.OptionalEnum.ToWire()
+		w, err = vOptionalEnum.ToWire()
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 4, Value: w}
 		i++
 	}
-	if v.RequiredList == nil {
-		v.RequiredList = []string{
+	vRequiredList := v.RequiredList
+	if vRequiredList == nil {
+		vRequiredList = []string{
 			"hello",
 			"world",
 		}
 	}
 	{
-		w, err = wire.NewValueList(_List_String_ValueList(v.RequiredList)), error(nil)
+		w, err = wire.NewValueList(_List_String_ValueList(vRequiredList)), error(nil)
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 5, Value: w}
 		i++
 	}
-	if v.OptionalList == nil {
-		v.OptionalList = []float64{
+	vOptionalList := v.OptionalList
+	if vOptionalList == nil {
+		vOptionalList = []float64{
 			1,
 			2,
 			3,
 		}
 	}
 	{
-		w, err = wire.NewValueList(_List_Double_ValueList(v.OptionalList)), error(nil)
+		w, err = wire.NewValueList(_List_Double_ValueList(vOptionalList)), error(nil)
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 6, Value: w}
 		i++
 	}
-	if v.RequiredStruct == nil {
-		v.RequiredStruct = &Frame{
+	vRequiredStruct := v.RequiredStruct
+	if vRequiredStruct == nil {
+		vRequiredStruct = &Frame{
 			Size: &Size{
 				Height: 200,
 				Width:  100,
@@ -363,15 +370,16 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 		}
 	}
 	{
-		w, err = v.RequiredStruct.ToWire()
+		w, err = vRequiredStruct.ToWire()
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 7, Value: w}
 		i++
 	}
-	if v.OptionalStruct == nil {
-		v.OptionalStruct = &Edge{
+	vOptionalStruct := v.OptionalStruct
+	if vOptionalStruct == nil {
+		vOptionalStruct = &Edge{
 			EndPoint: &Point{
 				X: 3,
 				Y: 4,
@@ -383,7 +391,7 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 		}
 	}
 	{
-		w, err = v.OptionalStruct.ToWire()
+		w, err = vOptionalStruct.ToWire()
 		if err != nil {
 			return w, err
 		}

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -171,11 +171,12 @@ func (v *DefaultPrimitiveTypedef) ToWire() (wire.Value, error) {
 		err    error
 	)
 
-	if v.State == nil {
-		v.State = _State_ptr("hello")
+	vState := v.State
+	if vState == nil {
+		vState = _State_ptr("hello")
 	}
 	{
-		w, err = v.State.ToWire()
+		w, err = vState.ToWire()
 		if err != nil {
 			return w, err
 		}


### PR DESCRIPTION
Avoid mutating the receiver with default values in `ToWire` calls
by changing the template to use a local variable to store defaults
rather than writing to the object. Also, fix tests accoringly.

*Note*: this change should be rolled out with caution, because,
as many of our own tests depended on this behavior (see #445),
it is possible that users might be broken by this change.