### PR TITLE
Add RootModules to api.GenerateServiceResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- Add RootModules field to api.GenerateServiceRequest.
 
 ## [1.24.0] - 2020-06-18
 ### Added

--- a/ast/mock_visitor_test.go
+++ b/ast/mock_visitor_test.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockVisitor is a mock of Visitor interface
+// MockVisitor is a mock of Visitor interface.
 type MockVisitor struct {
 	ctrl     *gomock.Controller
 	recorder *MockVisitorMockRecorder
 }
 
-// MockVisitorMockRecorder is the mock recorder for MockVisitor
+// MockVisitorMockRecorder is the mock recorder for MockVisitor.
 type MockVisitorMockRecorder struct {
 	mock *MockVisitor
 }
 
-// NewMockVisitor creates a new mock instance
+// NewMockVisitor creates a new mock instance.
 func NewMockVisitor(ctrl *gomock.Controller) *MockVisitor {
 	mock := &MockVisitor{ctrl: ctrl}
 	mock.recorder = &MockVisitorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockVisitor) EXPECT() *MockVisitorMockRecorder {
 	return m.recorder
 }
 
-// Visit mocks base method
+// Visit mocks base method.
 func (m *MockVisitor) Visit(arg0 Walker, arg1 Node) Visitor {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Visit", arg0, arg1)
@@ -40,7 +40,7 @@ func (m *MockVisitor) Visit(arg0 Walker, arg1 Node) Visitor {
 	return ret0
 }
 
-// Visit indicates an expected call of Visit
+// Visit indicates an expected call of Visit.
 func (mr *MockVisitorMockRecorder) Visit(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Visit", reflect.TypeOf((*MockVisitor)(nil).Visit), arg0, arg1)

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -123,6 +123,13 @@ func Generate(m *compile.Module, o *Options) error {
 		return nil
 	}
 
+	// Root Modules correspond to the Thrift files that ThriftRW is
+	// called with. Currently, ThriftRW can only be called with one
+	// Thrift file at a time.
+	if _, err := genBuilder.AddRootModule(m.ThriftPath); err != nil {
+		return err
+	}
+
 	// Note that we call generate directly on only those modules that we need
 	// to generate code for. If the user used --no-recurse, we're not going to
 	// generate code for included modules.

--- a/gen/mock_zap_test.go
+++ b/gen/mock_zap_test.go
@@ -11,30 +11,30 @@ import (
 	time "time"
 )
 
-// MockObjectEncoder is a mock of ObjectEncoder interface
+// MockObjectEncoder is a mock of ObjectEncoder interface.
 type MockObjectEncoder struct {
 	ctrl     *gomock.Controller
 	recorder *MockObjectEncoderMockRecorder
 }
 
-// MockObjectEncoderMockRecorder is the mock recorder for MockObjectEncoder
+// MockObjectEncoderMockRecorder is the mock recorder for MockObjectEncoder.
 type MockObjectEncoderMockRecorder struct {
 	mock *MockObjectEncoder
 }
 
-// NewMockObjectEncoder creates a new mock instance
+// NewMockObjectEncoder creates a new mock instance.
 func NewMockObjectEncoder(ctrl *gomock.Controller) *MockObjectEncoder {
 	mock := &MockObjectEncoder{ctrl: ctrl}
 	mock.recorder = &MockObjectEncoderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockObjectEncoder) EXPECT() *MockObjectEncoderMockRecorder {
 	return m.recorder
 }
 
-// AddArray mocks base method
+// AddArray mocks base method.
 func (m *MockObjectEncoder) AddArray(arg0 string, arg1 zapcore.ArrayMarshaler) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddArray", arg0, arg1)
@@ -42,169 +42,169 @@ func (m *MockObjectEncoder) AddArray(arg0 string, arg1 zapcore.ArrayMarshaler) e
 	return ret0
 }
 
-// AddArray indicates an expected call of AddArray
+// AddArray indicates an expected call of AddArray.
 func (mr *MockObjectEncoderMockRecorder) AddArray(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddArray", reflect.TypeOf((*MockObjectEncoder)(nil).AddArray), arg0, arg1)
 }
 
-// AddBinary mocks base method
+// AddBinary mocks base method.
 func (m *MockObjectEncoder) AddBinary(arg0 string, arg1 []byte) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddBinary", arg0, arg1)
 }
 
-// AddBinary indicates an expected call of AddBinary
+// AddBinary indicates an expected call of AddBinary.
 func (mr *MockObjectEncoderMockRecorder) AddBinary(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBinary", reflect.TypeOf((*MockObjectEncoder)(nil).AddBinary), arg0, arg1)
 }
 
-// AddBool mocks base method
+// AddBool mocks base method.
 func (m *MockObjectEncoder) AddBool(arg0 string, arg1 bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddBool", arg0, arg1)
 }
 
-// AddBool indicates an expected call of AddBool
+// AddBool indicates an expected call of AddBool.
 func (mr *MockObjectEncoderMockRecorder) AddBool(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddBool", reflect.TypeOf((*MockObjectEncoder)(nil).AddBool), arg0, arg1)
 }
 
-// AddByteString mocks base method
+// AddByteString mocks base method.
 func (m *MockObjectEncoder) AddByteString(arg0 string, arg1 []byte) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddByteString", arg0, arg1)
 }
 
-// AddByteString indicates an expected call of AddByteString
+// AddByteString indicates an expected call of AddByteString.
 func (mr *MockObjectEncoderMockRecorder) AddByteString(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddByteString", reflect.TypeOf((*MockObjectEncoder)(nil).AddByteString), arg0, arg1)
 }
 
-// AddComplex128 mocks base method
+// AddComplex128 mocks base method.
 func (m *MockObjectEncoder) AddComplex128(arg0 string, arg1 complex128) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddComplex128", arg0, arg1)
 }
 
-// AddComplex128 indicates an expected call of AddComplex128
+// AddComplex128 indicates an expected call of AddComplex128.
 func (mr *MockObjectEncoderMockRecorder) AddComplex128(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddComplex128", reflect.TypeOf((*MockObjectEncoder)(nil).AddComplex128), arg0, arg1)
 }
 
-// AddComplex64 mocks base method
+// AddComplex64 mocks base method.
 func (m *MockObjectEncoder) AddComplex64(arg0 string, arg1 complex64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddComplex64", arg0, arg1)
 }
 
-// AddComplex64 indicates an expected call of AddComplex64
+// AddComplex64 indicates an expected call of AddComplex64.
 func (mr *MockObjectEncoderMockRecorder) AddComplex64(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddComplex64", reflect.TypeOf((*MockObjectEncoder)(nil).AddComplex64), arg0, arg1)
 }
 
-// AddDuration mocks base method
+// AddDuration mocks base method.
 func (m *MockObjectEncoder) AddDuration(arg0 string, arg1 time.Duration) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddDuration", arg0, arg1)
 }
 
-// AddDuration indicates an expected call of AddDuration
+// AddDuration indicates an expected call of AddDuration.
 func (mr *MockObjectEncoderMockRecorder) AddDuration(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDuration", reflect.TypeOf((*MockObjectEncoder)(nil).AddDuration), arg0, arg1)
 }
 
-// AddFloat32 mocks base method
+// AddFloat32 mocks base method.
 func (m *MockObjectEncoder) AddFloat32(arg0 string, arg1 float32) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddFloat32", arg0, arg1)
 }
 
-// AddFloat32 indicates an expected call of AddFloat32
+// AddFloat32 indicates an expected call of AddFloat32.
 func (mr *MockObjectEncoderMockRecorder) AddFloat32(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddFloat32", reflect.TypeOf((*MockObjectEncoder)(nil).AddFloat32), arg0, arg1)
 }
 
-// AddFloat64 mocks base method
+// AddFloat64 mocks base method.
 func (m *MockObjectEncoder) AddFloat64(arg0 string, arg1 float64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddFloat64", arg0, arg1)
 }
 
-// AddFloat64 indicates an expected call of AddFloat64
+// AddFloat64 indicates an expected call of AddFloat64.
 func (mr *MockObjectEncoderMockRecorder) AddFloat64(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddFloat64", reflect.TypeOf((*MockObjectEncoder)(nil).AddFloat64), arg0, arg1)
 }
 
-// AddInt mocks base method
+// AddInt mocks base method.
 func (m *MockObjectEncoder) AddInt(arg0 string, arg1 int) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddInt", arg0, arg1)
 }
 
-// AddInt indicates an expected call of AddInt
+// AddInt indicates an expected call of AddInt.
 func (mr *MockObjectEncoderMockRecorder) AddInt(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInt", reflect.TypeOf((*MockObjectEncoder)(nil).AddInt), arg0, arg1)
 }
 
-// AddInt16 mocks base method
+// AddInt16 mocks base method.
 func (m *MockObjectEncoder) AddInt16(arg0 string, arg1 int16) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddInt16", arg0, arg1)
 }
 
-// AddInt16 indicates an expected call of AddInt16
+// AddInt16 indicates an expected call of AddInt16.
 func (mr *MockObjectEncoderMockRecorder) AddInt16(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInt16", reflect.TypeOf((*MockObjectEncoder)(nil).AddInt16), arg0, arg1)
 }
 
-// AddInt32 mocks base method
+// AddInt32 mocks base method.
 func (m *MockObjectEncoder) AddInt32(arg0 string, arg1 int32) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddInt32", arg0, arg1)
 }
 
-// AddInt32 indicates an expected call of AddInt32
+// AddInt32 indicates an expected call of AddInt32.
 func (mr *MockObjectEncoderMockRecorder) AddInt32(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInt32", reflect.TypeOf((*MockObjectEncoder)(nil).AddInt32), arg0, arg1)
 }
 
-// AddInt64 mocks base method
+// AddInt64 mocks base method.
 func (m *MockObjectEncoder) AddInt64(arg0 string, arg1 int64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddInt64", arg0, arg1)
 }
 
-// AddInt64 indicates an expected call of AddInt64
+// AddInt64 indicates an expected call of AddInt64.
 func (mr *MockObjectEncoderMockRecorder) AddInt64(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInt64", reflect.TypeOf((*MockObjectEncoder)(nil).AddInt64), arg0, arg1)
 }
 
-// AddInt8 mocks base method
+// AddInt8 mocks base method.
 func (m *MockObjectEncoder) AddInt8(arg0 string, arg1 int8) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddInt8", arg0, arg1)
 }
 
-// AddInt8 indicates an expected call of AddInt8
+// AddInt8 indicates an expected call of AddInt8.
 func (mr *MockObjectEncoderMockRecorder) AddInt8(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInt8", reflect.TypeOf((*MockObjectEncoder)(nil).AddInt8), arg0, arg1)
 }
 
-// AddObject mocks base method
+// AddObject mocks base method.
 func (m *MockObjectEncoder) AddObject(arg0 string, arg1 zapcore.ObjectMarshaler) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddObject", arg0, arg1)
@@ -212,13 +212,13 @@ func (m *MockObjectEncoder) AddObject(arg0 string, arg1 zapcore.ObjectMarshaler)
 	return ret0
 }
 
-// AddObject indicates an expected call of AddObject
+// AddObject indicates an expected call of AddObject.
 func (mr *MockObjectEncoderMockRecorder) AddObject(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddObject", reflect.TypeOf((*MockObjectEncoder)(nil).AddObject), arg0, arg1)
 }
 
-// AddReflected mocks base method
+// AddReflected mocks base method.
 func (m *MockObjectEncoder) AddReflected(arg0 string, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddReflected", arg0, arg1)
@@ -226,144 +226,144 @@ func (m *MockObjectEncoder) AddReflected(arg0 string, arg1 interface{}) error {
 	return ret0
 }
 
-// AddReflected indicates an expected call of AddReflected
+// AddReflected indicates an expected call of AddReflected.
 func (mr *MockObjectEncoderMockRecorder) AddReflected(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddReflected", reflect.TypeOf((*MockObjectEncoder)(nil).AddReflected), arg0, arg1)
 }
 
-// AddString mocks base method
+// AddString mocks base method.
 func (m *MockObjectEncoder) AddString(arg0, arg1 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddString", arg0, arg1)
 }
 
-// AddString indicates an expected call of AddString
+// AddString indicates an expected call of AddString.
 func (mr *MockObjectEncoderMockRecorder) AddString(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddString", reflect.TypeOf((*MockObjectEncoder)(nil).AddString), arg0, arg1)
 }
 
-// AddTime mocks base method
+// AddTime mocks base method.
 func (m *MockObjectEncoder) AddTime(arg0 string, arg1 time.Time) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddTime", arg0, arg1)
 }
 
-// AddTime indicates an expected call of AddTime
+// AddTime indicates an expected call of AddTime.
 func (mr *MockObjectEncoderMockRecorder) AddTime(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTime", reflect.TypeOf((*MockObjectEncoder)(nil).AddTime), arg0, arg1)
 }
 
-// AddUint mocks base method
+// AddUint mocks base method.
 func (m *MockObjectEncoder) AddUint(arg0 string, arg1 uint) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddUint", arg0, arg1)
 }
 
-// AddUint indicates an expected call of AddUint
+// AddUint indicates an expected call of AddUint.
 func (mr *MockObjectEncoderMockRecorder) AddUint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUint", reflect.TypeOf((*MockObjectEncoder)(nil).AddUint), arg0, arg1)
 }
 
-// AddUint16 mocks base method
+// AddUint16 mocks base method.
 func (m *MockObjectEncoder) AddUint16(arg0 string, arg1 uint16) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddUint16", arg0, arg1)
 }
 
-// AddUint16 indicates an expected call of AddUint16
+// AddUint16 indicates an expected call of AddUint16.
 func (mr *MockObjectEncoderMockRecorder) AddUint16(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUint16", reflect.TypeOf((*MockObjectEncoder)(nil).AddUint16), arg0, arg1)
 }
 
-// AddUint32 mocks base method
+// AddUint32 mocks base method.
 func (m *MockObjectEncoder) AddUint32(arg0 string, arg1 uint32) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddUint32", arg0, arg1)
 }
 
-// AddUint32 indicates an expected call of AddUint32
+// AddUint32 indicates an expected call of AddUint32.
 func (mr *MockObjectEncoderMockRecorder) AddUint32(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUint32", reflect.TypeOf((*MockObjectEncoder)(nil).AddUint32), arg0, arg1)
 }
 
-// AddUint64 mocks base method
+// AddUint64 mocks base method.
 func (m *MockObjectEncoder) AddUint64(arg0 string, arg1 uint64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddUint64", arg0, arg1)
 }
 
-// AddUint64 indicates an expected call of AddUint64
+// AddUint64 indicates an expected call of AddUint64.
 func (mr *MockObjectEncoderMockRecorder) AddUint64(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUint64", reflect.TypeOf((*MockObjectEncoder)(nil).AddUint64), arg0, arg1)
 }
 
-// AddUint8 mocks base method
+// AddUint8 mocks base method.
 func (m *MockObjectEncoder) AddUint8(arg0 string, arg1 byte) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddUint8", arg0, arg1)
 }
 
-// AddUint8 indicates an expected call of AddUint8
+// AddUint8 indicates an expected call of AddUint8.
 func (mr *MockObjectEncoderMockRecorder) AddUint8(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUint8", reflect.TypeOf((*MockObjectEncoder)(nil).AddUint8), arg0, arg1)
 }
 
-// AddUintptr mocks base method
+// AddUintptr mocks base method.
 func (m *MockObjectEncoder) AddUintptr(arg0 string, arg1 uintptr) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddUintptr", arg0, arg1)
 }
 
-// AddUintptr indicates an expected call of AddUintptr
+// AddUintptr indicates an expected call of AddUintptr.
 func (mr *MockObjectEncoderMockRecorder) AddUintptr(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUintptr", reflect.TypeOf((*MockObjectEncoder)(nil).AddUintptr), arg0, arg1)
 }
 
-// OpenNamespace mocks base method
+// OpenNamespace mocks base method.
 func (m *MockObjectEncoder) OpenNamespace(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OpenNamespace", arg0)
 }
 
-// OpenNamespace indicates an expected call of OpenNamespace
+// OpenNamespace indicates an expected call of OpenNamespace.
 func (mr *MockObjectEncoderMockRecorder) OpenNamespace(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenNamespace", reflect.TypeOf((*MockObjectEncoder)(nil).OpenNamespace), arg0)
 }
 
-// MockArrayEncoder is a mock of ArrayEncoder interface
+// MockArrayEncoder is a mock of ArrayEncoder interface.
 type MockArrayEncoder struct {
 	ctrl     *gomock.Controller
 	recorder *MockArrayEncoderMockRecorder
 }
 
-// MockArrayEncoderMockRecorder is the mock recorder for MockArrayEncoder
+// MockArrayEncoderMockRecorder is the mock recorder for MockArrayEncoder.
 type MockArrayEncoderMockRecorder struct {
 	mock *MockArrayEncoder
 }
 
-// NewMockArrayEncoder creates a new mock instance
+// NewMockArrayEncoder creates a new mock instance.
 func NewMockArrayEncoder(ctrl *gomock.Controller) *MockArrayEncoder {
 	mock := &MockArrayEncoder{ctrl: ctrl}
 	mock.recorder = &MockArrayEncoderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockArrayEncoder) EXPECT() *MockArrayEncoderMockRecorder {
 	return m.recorder
 }
 
-// AppendArray mocks base method
+// AppendArray mocks base method.
 func (m *MockArrayEncoder) AppendArray(arg0 zapcore.ArrayMarshaler) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppendArray", arg0)
@@ -371,157 +371,157 @@ func (m *MockArrayEncoder) AppendArray(arg0 zapcore.ArrayMarshaler) error {
 	return ret0
 }
 
-// AppendArray indicates an expected call of AppendArray
+// AppendArray indicates an expected call of AppendArray.
 func (mr *MockArrayEncoderMockRecorder) AppendArray(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendArray", reflect.TypeOf((*MockArrayEncoder)(nil).AppendArray), arg0)
 }
 
-// AppendBool mocks base method
+// AppendBool mocks base method.
 func (m *MockArrayEncoder) AppendBool(arg0 bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendBool", arg0)
 }
 
-// AppendBool indicates an expected call of AppendBool
+// AppendBool indicates an expected call of AppendBool.
 func (mr *MockArrayEncoderMockRecorder) AppendBool(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendBool", reflect.TypeOf((*MockArrayEncoder)(nil).AppendBool), arg0)
 }
 
-// AppendByteString mocks base method
+// AppendByteString mocks base method.
 func (m *MockArrayEncoder) AppendByteString(arg0 []byte) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendByteString", arg0)
 }
 
-// AppendByteString indicates an expected call of AppendByteString
+// AppendByteString indicates an expected call of AppendByteString.
 func (mr *MockArrayEncoderMockRecorder) AppendByteString(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendByteString", reflect.TypeOf((*MockArrayEncoder)(nil).AppendByteString), arg0)
 }
 
-// AppendComplex128 mocks base method
+// AppendComplex128 mocks base method.
 func (m *MockArrayEncoder) AppendComplex128(arg0 complex128) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendComplex128", arg0)
 }
 
-// AppendComplex128 indicates an expected call of AppendComplex128
+// AppendComplex128 indicates an expected call of AppendComplex128.
 func (mr *MockArrayEncoderMockRecorder) AppendComplex128(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendComplex128", reflect.TypeOf((*MockArrayEncoder)(nil).AppendComplex128), arg0)
 }
 
-// AppendComplex64 mocks base method
+// AppendComplex64 mocks base method.
 func (m *MockArrayEncoder) AppendComplex64(arg0 complex64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendComplex64", arg0)
 }
 
-// AppendComplex64 indicates an expected call of AppendComplex64
+// AppendComplex64 indicates an expected call of AppendComplex64.
 func (mr *MockArrayEncoderMockRecorder) AppendComplex64(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendComplex64", reflect.TypeOf((*MockArrayEncoder)(nil).AppendComplex64), arg0)
 }
 
-// AppendDuration mocks base method
+// AppendDuration mocks base method.
 func (m *MockArrayEncoder) AppendDuration(arg0 time.Duration) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendDuration", arg0)
 }
 
-// AppendDuration indicates an expected call of AppendDuration
+// AppendDuration indicates an expected call of AppendDuration.
 func (mr *MockArrayEncoderMockRecorder) AppendDuration(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendDuration", reflect.TypeOf((*MockArrayEncoder)(nil).AppendDuration), arg0)
 }
 
-// AppendFloat32 mocks base method
+// AppendFloat32 mocks base method.
 func (m *MockArrayEncoder) AppendFloat32(arg0 float32) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendFloat32", arg0)
 }
 
-// AppendFloat32 indicates an expected call of AppendFloat32
+// AppendFloat32 indicates an expected call of AppendFloat32.
 func (mr *MockArrayEncoderMockRecorder) AppendFloat32(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendFloat32", reflect.TypeOf((*MockArrayEncoder)(nil).AppendFloat32), arg0)
 }
 
-// AppendFloat64 mocks base method
+// AppendFloat64 mocks base method.
 func (m *MockArrayEncoder) AppendFloat64(arg0 float64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendFloat64", arg0)
 }
 
-// AppendFloat64 indicates an expected call of AppendFloat64
+// AppendFloat64 indicates an expected call of AppendFloat64.
 func (mr *MockArrayEncoderMockRecorder) AppendFloat64(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendFloat64", reflect.TypeOf((*MockArrayEncoder)(nil).AppendFloat64), arg0)
 }
 
-// AppendInt mocks base method
+// AppendInt mocks base method.
 func (m *MockArrayEncoder) AppendInt(arg0 int) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendInt", arg0)
 }
 
-// AppendInt indicates an expected call of AppendInt
+// AppendInt indicates an expected call of AppendInt.
 func (mr *MockArrayEncoderMockRecorder) AppendInt(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendInt", reflect.TypeOf((*MockArrayEncoder)(nil).AppendInt), arg0)
 }
 
-// AppendInt16 mocks base method
+// AppendInt16 mocks base method.
 func (m *MockArrayEncoder) AppendInt16(arg0 int16) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendInt16", arg0)
 }
 
-// AppendInt16 indicates an expected call of AppendInt16
+// AppendInt16 indicates an expected call of AppendInt16.
 func (mr *MockArrayEncoderMockRecorder) AppendInt16(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendInt16", reflect.TypeOf((*MockArrayEncoder)(nil).AppendInt16), arg0)
 }
 
-// AppendInt32 mocks base method
+// AppendInt32 mocks base method.
 func (m *MockArrayEncoder) AppendInt32(arg0 int32) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendInt32", arg0)
 }
 
-// AppendInt32 indicates an expected call of AppendInt32
+// AppendInt32 indicates an expected call of AppendInt32.
 func (mr *MockArrayEncoderMockRecorder) AppendInt32(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendInt32", reflect.TypeOf((*MockArrayEncoder)(nil).AppendInt32), arg0)
 }
 
-// AppendInt64 mocks base method
+// AppendInt64 mocks base method.
 func (m *MockArrayEncoder) AppendInt64(arg0 int64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendInt64", arg0)
 }
 
-// AppendInt64 indicates an expected call of AppendInt64
+// AppendInt64 indicates an expected call of AppendInt64.
 func (mr *MockArrayEncoderMockRecorder) AppendInt64(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendInt64", reflect.TypeOf((*MockArrayEncoder)(nil).AppendInt64), arg0)
 }
 
-// AppendInt8 mocks base method
+// AppendInt8 mocks base method.
 func (m *MockArrayEncoder) AppendInt8(arg0 int8) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendInt8", arg0)
 }
 
-// AppendInt8 indicates an expected call of AppendInt8
+// AppendInt8 indicates an expected call of AppendInt8.
 func (mr *MockArrayEncoderMockRecorder) AppendInt8(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendInt8", reflect.TypeOf((*MockArrayEncoder)(nil).AppendInt8), arg0)
 }
 
-// AppendObject mocks base method
+// AppendObject mocks base method.
 func (m *MockArrayEncoder) AppendObject(arg0 zapcore.ObjectMarshaler) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppendObject", arg0)
@@ -529,13 +529,13 @@ func (m *MockArrayEncoder) AppendObject(arg0 zapcore.ObjectMarshaler) error {
 	return ret0
 }
 
-// AppendObject indicates an expected call of AppendObject
+// AppendObject indicates an expected call of AppendObject.
 func (mr *MockArrayEncoderMockRecorder) AppendObject(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendObject", reflect.TypeOf((*MockArrayEncoder)(nil).AppendObject), arg0)
 }
 
-// AppendReflected mocks base method
+// AppendReflected mocks base method.
 func (m *MockArrayEncoder) AppendReflected(arg0 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppendReflected", arg0)
@@ -543,103 +543,103 @@ func (m *MockArrayEncoder) AppendReflected(arg0 interface{}) error {
 	return ret0
 }
 
-// AppendReflected indicates an expected call of AppendReflected
+// AppendReflected indicates an expected call of AppendReflected.
 func (mr *MockArrayEncoderMockRecorder) AppendReflected(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendReflected", reflect.TypeOf((*MockArrayEncoder)(nil).AppendReflected), arg0)
 }
 
-// AppendString mocks base method
+// AppendString mocks base method.
 func (m *MockArrayEncoder) AppendString(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendString", arg0)
 }
 
-// AppendString indicates an expected call of AppendString
+// AppendString indicates an expected call of AppendString.
 func (mr *MockArrayEncoderMockRecorder) AppendString(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendString", reflect.TypeOf((*MockArrayEncoder)(nil).AppendString), arg0)
 }
 
-// AppendTime mocks base method
+// AppendTime mocks base method.
 func (m *MockArrayEncoder) AppendTime(arg0 time.Time) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendTime", arg0)
 }
 
-// AppendTime indicates an expected call of AppendTime
+// AppendTime indicates an expected call of AppendTime.
 func (mr *MockArrayEncoderMockRecorder) AppendTime(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendTime", reflect.TypeOf((*MockArrayEncoder)(nil).AppendTime), arg0)
 }
 
-// AppendUint mocks base method
+// AppendUint mocks base method.
 func (m *MockArrayEncoder) AppendUint(arg0 uint) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendUint", arg0)
 }
 
-// AppendUint indicates an expected call of AppendUint
+// AppendUint indicates an expected call of AppendUint.
 func (mr *MockArrayEncoderMockRecorder) AppendUint(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUint", reflect.TypeOf((*MockArrayEncoder)(nil).AppendUint), arg0)
 }
 
-// AppendUint16 mocks base method
+// AppendUint16 mocks base method.
 func (m *MockArrayEncoder) AppendUint16(arg0 uint16) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendUint16", arg0)
 }
 
-// AppendUint16 indicates an expected call of AppendUint16
+// AppendUint16 indicates an expected call of AppendUint16.
 func (mr *MockArrayEncoderMockRecorder) AppendUint16(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUint16", reflect.TypeOf((*MockArrayEncoder)(nil).AppendUint16), arg0)
 }
 
-// AppendUint32 mocks base method
+// AppendUint32 mocks base method.
 func (m *MockArrayEncoder) AppendUint32(arg0 uint32) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendUint32", arg0)
 }
 
-// AppendUint32 indicates an expected call of AppendUint32
+// AppendUint32 indicates an expected call of AppendUint32.
 func (mr *MockArrayEncoderMockRecorder) AppendUint32(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUint32", reflect.TypeOf((*MockArrayEncoder)(nil).AppendUint32), arg0)
 }
 
-// AppendUint64 mocks base method
+// AppendUint64 mocks base method.
 func (m *MockArrayEncoder) AppendUint64(arg0 uint64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendUint64", arg0)
 }
 
-// AppendUint64 indicates an expected call of AppendUint64
+// AppendUint64 indicates an expected call of AppendUint64.
 func (mr *MockArrayEncoderMockRecorder) AppendUint64(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUint64", reflect.TypeOf((*MockArrayEncoder)(nil).AppendUint64), arg0)
 }
 
-// AppendUint8 mocks base method
+// AppendUint8 mocks base method.
 func (m *MockArrayEncoder) AppendUint8(arg0 byte) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendUint8", arg0)
 }
 
-// AppendUint8 indicates an expected call of AppendUint8
+// AppendUint8 indicates an expected call of AppendUint8.
 func (mr *MockArrayEncoderMockRecorder) AppendUint8(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUint8", reflect.TypeOf((*MockArrayEncoder)(nil).AppendUint8), arg0)
 }
 
-// AppendUintptr mocks base method
+// AppendUintptr mocks base method.
 func (m *MockArrayEncoder) AppendUintptr(arg0 uintptr) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AppendUintptr", arg0)
 }
 
-// AppendUintptr indicates an expected call of AppendUintptr
+// AppendUintptr indicates an expected call of AppendUintptr.
 func (mr *MockArrayEncoderMockRecorder) AppendUintptr(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUintptr", reflect.TypeOf((*MockArrayEncoder)(nil).AppendUintptr), arg0)

--- a/internal/envelope/envelopetest/client.go
+++ b/internal/envelope/envelopetest/client.go
@@ -30,30 +30,30 @@ import (
 	reflect "reflect"
 )
 
-// MockTransport is a mock of Transport interface
+// MockTransport is a mock of Transport interface.
 type MockTransport struct {
 	ctrl     *gomock.Controller
 	recorder *MockTransportMockRecorder
 }
 
-// MockTransportMockRecorder is the mock recorder for MockTransport
+// MockTransportMockRecorder is the mock recorder for MockTransport.
 type MockTransportMockRecorder struct {
 	mock *MockTransport
 }
 
-// NewMockTransport creates a new mock instance
+// NewMockTransport creates a new mock instance.
 func NewMockTransport(ctrl *gomock.Controller) *MockTransport {
 	mock := &MockTransport{ctrl: ctrl}
 	mock.recorder = &MockTransportMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTransport) EXPECT() *MockTransportMockRecorder {
 	return m.recorder
 }
 
-// Send mocks base method
+// Send mocks base method.
 func (m *MockTransport) Send(arg0 []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Send", arg0)
@@ -62,36 +62,36 @@ func (m *MockTransport) Send(arg0 []byte) ([]byte, error) {
 	return ret0, ret1
 }
 
-// Send indicates an expected call of Send
+// Send indicates an expected call of Send.
 func (mr *MockTransportMockRecorder) Send(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockTransport)(nil).Send), arg0)
 }
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Send mocks base method
+// Send mocks base method.
 func (m *MockClient) Send(name string, body wire.Value) (wire.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Send", name, body)
@@ -100,7 +100,7 @@ func (m *MockClient) Send(name string, body wire.Value) (wire.Value, error) {
 	return ret0, ret1
 }
 
-// Send indicates an expected call of Send
+// Send indicates an expected call of Send.
 func (mr *MockClientMockRecorder) Send(name, body interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockClient)(nil).Send), name, body)

--- a/internal/envelope/envelopetest/server.go
+++ b/internal/envelope/envelopetest/server.go
@@ -30,30 +30,30 @@ import (
 	reflect "reflect"
 )
 
-// MockHandler is a mock of Handler interface
+// MockHandler is a mock of Handler interface.
 type MockHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockHandlerMockRecorder
 }
 
-// MockHandlerMockRecorder is the mock recorder for MockHandler
+// MockHandlerMockRecorder is the mock recorder for MockHandler.
 type MockHandlerMockRecorder struct {
 	mock *MockHandler
 }
 
-// NewMockHandler creates a new mock instance
+// NewMockHandler creates a new mock instance.
 func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 	mock := &MockHandler{ctrl: ctrl}
 	mock.recorder = &MockHandlerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
 }
 
-// Handle mocks base method
+// Handle mocks base method.
 func (m *MockHandler) Handle(name string, body wire.Value) (wire.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handle", name, body)
@@ -62,7 +62,7 @@ func (m *MockHandler) Handle(name string, body wire.Value) (wire.Value, error) {
 	return ret0, ret1
 }
 
-// Handle indicates an expected call of Handle
+// Handle indicates an expected call of Handle.
 func (mr *MockHandlerMockRecorder) Handle(name, body interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockHandler)(nil).Handle), name, body)

--- a/internal/envelope/mock_protocol_test.go
+++ b/internal/envelope/mock_protocol_test.go
@@ -11,30 +11,30 @@ import (
 	reflect "reflect"
 )
 
-// MockProtocol is a mock of Protocol interface
+// MockProtocol is a mock of Protocol interface.
 type MockProtocol struct {
 	ctrl     *gomock.Controller
 	recorder *MockProtocolMockRecorder
 }
 
-// MockProtocolMockRecorder is the mock recorder for MockProtocol
+// MockProtocolMockRecorder is the mock recorder for MockProtocol.
 type MockProtocolMockRecorder struct {
 	mock *MockProtocol
 }
 
-// NewMockProtocol creates a new mock instance
+// NewMockProtocol creates a new mock instance.
 func NewMockProtocol(ctrl *gomock.Controller) *MockProtocol {
 	mock := &MockProtocol{ctrl: ctrl}
 	mock.recorder = &MockProtocolMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProtocol) EXPECT() *MockProtocolMockRecorder {
 	return m.recorder
 }
 
-// Decode mocks base method
+// Decode mocks base method.
 func (m *MockProtocol) Decode(arg0 io.ReaderAt, arg1 wire.Type) (wire.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Decode", arg0, arg1)
@@ -43,13 +43,13 @@ func (m *MockProtocol) Decode(arg0 io.ReaderAt, arg1 wire.Type) (wire.Value, err
 	return ret0, ret1
 }
 
-// Decode indicates an expected call of Decode
+// Decode indicates an expected call of Decode.
 func (mr *MockProtocolMockRecorder) Decode(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decode", reflect.TypeOf((*MockProtocol)(nil).Decode), arg0, arg1)
 }
 
-// DecodeEnveloped mocks base method
+// DecodeEnveloped mocks base method.
 func (m *MockProtocol) DecodeEnveloped(arg0 io.ReaderAt) (wire.Envelope, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DecodeEnveloped", arg0)
@@ -58,13 +58,13 @@ func (m *MockProtocol) DecodeEnveloped(arg0 io.ReaderAt) (wire.Envelope, error) 
 	return ret0, ret1
 }
 
-// DecodeEnveloped indicates an expected call of DecodeEnveloped
+// DecodeEnveloped indicates an expected call of DecodeEnveloped.
 func (mr *MockProtocolMockRecorder) DecodeEnveloped(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeEnveloped", reflect.TypeOf((*MockProtocol)(nil).DecodeEnveloped), arg0)
 }
 
-// Encode mocks base method
+// Encode mocks base method.
 func (m *MockProtocol) Encode(arg0 wire.Value, arg1 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Encode", arg0, arg1)
@@ -72,13 +72,13 @@ func (m *MockProtocol) Encode(arg0 wire.Value, arg1 io.Writer) error {
 	return ret0
 }
 
-// Encode indicates an expected call of Encode
+// Encode indicates an expected call of Encode.
 func (mr *MockProtocolMockRecorder) Encode(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encode", reflect.TypeOf((*MockProtocol)(nil).Encode), arg0, arg1)
 }
 
-// EncodeEnveloped mocks base method
+// EncodeEnveloped mocks base method.
 func (m *MockProtocol) EncodeEnveloped(arg0 wire.Envelope, arg1 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EncodeEnveloped", arg0, arg1)
@@ -86,7 +86,7 @@ func (m *MockProtocol) EncodeEnveloped(arg0 wire.Envelope, arg1 io.Writer) error
 	return ret0
 }
 
-// EncodeEnveloped indicates an expected call of EncodeEnveloped
+// EncodeEnveloped indicates an expected call of EncodeEnveloped.
 func (mr *MockProtocolMockRecorder) EncodeEnveloped(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncodeEnveloped", reflect.TypeOf((*MockProtocol)(nil).EncodeEnveloped), arg0, arg1)

--- a/internal/frame/mock_reader_test.go
+++ b/internal/frame/mock_reader_test.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockReader is a mock of Reader interface
+// MockReader is a mock of Reader interface.
 type MockReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockReaderMockRecorder
 }
 
-// MockReaderMockRecorder is the mock recorder for MockReader
+// MockReaderMockRecorder is the mock recorder for MockReader.
 type MockReaderMockRecorder struct {
 	mock *MockReader
 }
 
-// NewMockReader creates a new mock instance
+// NewMockReader creates a new mock instance.
 func NewMockReader(ctrl *gomock.Controller) *MockReader {
 	mock := &MockReader{ctrl: ctrl}
 	mock.recorder = &MockReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReader) EXPECT() *MockReaderMockRecorder {
 	return m.recorder
 }
 
-// Read mocks base method
+// Read mocks base method.
 func (m *MockReader) Read(arg0 []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", arg0)
@@ -41,36 +41,36 @@ func (m *MockReader) Read(arg0 []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Read indicates an expected call of Read
+// Read indicates an expected call of Read.
 func (mr *MockReaderMockRecorder) Read(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockReader)(nil).Read), arg0)
 }
 
-// MockReadCloser is a mock of ReadCloser interface
+// MockReadCloser is a mock of ReadCloser interface.
 type MockReadCloser struct {
 	ctrl     *gomock.Controller
 	recorder *MockReadCloserMockRecorder
 }
 
-// MockReadCloserMockRecorder is the mock recorder for MockReadCloser
+// MockReadCloserMockRecorder is the mock recorder for MockReadCloser.
 type MockReadCloserMockRecorder struct {
 	mock *MockReadCloser
 }
 
-// NewMockReadCloser creates a new mock instance
+// NewMockReadCloser creates a new mock instance.
 func NewMockReadCloser(ctrl *gomock.Controller) *MockReadCloser {
 	mock := &MockReadCloser{ctrl: ctrl}
 	mock.recorder = &MockReadCloserMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReadCloser) EXPECT() *MockReadCloserMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockReadCloser) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -78,13 +78,13 @@ func (m *MockReadCloser) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockReadCloserMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockReadCloser)(nil).Close))
 }
 
-// Read mocks base method
+// Read mocks base method.
 func (m *MockReadCloser) Read(arg0 []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", arg0)
@@ -93,7 +93,7 @@ func (m *MockReadCloser) Read(arg0 []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Read indicates an expected call of Read
+// Read indicates an expected call of Read.
 func (mr *MockReadCloserMockRecorder) Read(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockReadCloser)(nil).Read), arg0)

--- a/internal/frame/mock_writer_test.go
+++ b/internal/frame/mock_writer_test.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockWriter is a mock of Writer interface
+// MockWriter is a mock of Writer interface.
 type MockWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockWriterMockRecorder
 }
 
-// MockWriterMockRecorder is the mock recorder for MockWriter
+// MockWriterMockRecorder is the mock recorder for MockWriter.
 type MockWriterMockRecorder struct {
 	mock *MockWriter
 }
 
-// NewMockWriter creates a new mock instance
+// NewMockWriter creates a new mock instance.
 func NewMockWriter(ctrl *gomock.Controller) *MockWriter {
 	mock := &MockWriter{ctrl: ctrl}
 	mock.recorder = &MockWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWriter) EXPECT() *MockWriterMockRecorder {
 	return m.recorder
 }
 
-// Write mocks base method
+// Write mocks base method.
 func (m *MockWriter) Write(arg0 []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0)
@@ -41,36 +41,36 @@ func (m *MockWriter) Write(arg0 []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Write indicates an expected call of Write
+// Write indicates an expected call of Write.
 func (mr *MockWriterMockRecorder) Write(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockWriter)(nil).Write), arg0)
 }
 
-// MockWriteCloser is a mock of WriteCloser interface
+// MockWriteCloser is a mock of WriteCloser interface.
 type MockWriteCloser struct {
 	ctrl     *gomock.Controller
 	recorder *MockWriteCloserMockRecorder
 }
 
-// MockWriteCloserMockRecorder is the mock recorder for MockWriteCloser
+// MockWriteCloserMockRecorder is the mock recorder for MockWriteCloser.
 type MockWriteCloserMockRecorder struct {
 	mock *MockWriteCloser
 }
 
-// NewMockWriteCloser creates a new mock instance
+// NewMockWriteCloser creates a new mock instance.
 func NewMockWriteCloser(ctrl *gomock.Controller) *MockWriteCloser {
 	mock := &MockWriteCloser{ctrl: ctrl}
 	mock.recorder = &MockWriteCloserMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWriteCloser) EXPECT() *MockWriteCloserMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockWriteCloser) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -78,13 +78,13 @@ func (m *MockWriteCloser) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockWriteCloserMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockWriteCloser)(nil).Close))
 }
 
-// Write mocks base method
+// Write mocks base method.
 func (m *MockWriteCloser) Write(arg0 []byte) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0)
@@ -93,7 +93,7 @@ func (m *MockWriteCloser) Write(arg0 []byte) (int, error) {
 	return ret0, ret1
 }
 
-// Write indicates an expected call of Write
+// Write indicates an expected call of Write.
 func (mr *MockWriteCloserMockRecorder) Write(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockWriteCloser)(nil).Write), arg0)

--- a/internal/plugin/handletest/mock.go
+++ b/internal/plugin/handletest/mock.go
@@ -31,30 +31,30 @@ import (
 	reflect "reflect"
 )
 
-// MockHandle is a mock of Handle interface
+// MockHandle is a mock of Handle interface.
 type MockHandle struct {
 	ctrl     *gomock.Controller
 	recorder *MockHandleMockRecorder
 }
 
-// MockHandleMockRecorder is the mock recorder for MockHandle
+// MockHandleMockRecorder is the mock recorder for MockHandle.
 type MockHandleMockRecorder struct {
 	mock *MockHandle
 }
 
-// NewMockHandle creates a new mock instance
+// NewMockHandle creates a new mock instance.
 func NewMockHandle(ctrl *gomock.Controller) *MockHandle {
 	mock := &MockHandle{ctrl: ctrl}
 	mock.recorder = &MockHandleMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHandle) EXPECT() *MockHandleMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockHandle) Close() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Close")
@@ -62,13 +62,13 @@ func (m *MockHandle) Close() error {
 	return ret0
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockHandleMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockHandle)(nil).Close))
 }
 
-// Name mocks base method
+// Name mocks base method.
 func (m *MockHandle) Name() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
@@ -76,13 +76,13 @@ func (m *MockHandle) Name() string {
 	return ret0
 }
 
-// Name indicates an expected call of Name
+// Name indicates an expected call of Name.
 func (mr *MockHandleMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHandle)(nil).Name))
 }
 
-// ServiceGenerator mocks base method
+// ServiceGenerator mocks base method.
 func (m *MockHandle) ServiceGenerator() plugin.ServiceGenerator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ServiceGenerator")
@@ -90,36 +90,36 @@ func (m *MockHandle) ServiceGenerator() plugin.ServiceGenerator {
 	return ret0
 }
 
-// ServiceGenerator indicates an expected call of ServiceGenerator
+// ServiceGenerator indicates an expected call of ServiceGenerator.
 func (mr *MockHandleMockRecorder) ServiceGenerator() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceGenerator", reflect.TypeOf((*MockHandle)(nil).ServiceGenerator))
 }
 
-// MockServiceGenerator is a mock of ServiceGenerator interface
+// MockServiceGenerator is a mock of ServiceGenerator interface.
 type MockServiceGenerator struct {
 	ctrl     *gomock.Controller
 	recorder *MockServiceGeneratorMockRecorder
 }
 
-// MockServiceGeneratorMockRecorder is the mock recorder for MockServiceGenerator
+// MockServiceGeneratorMockRecorder is the mock recorder for MockServiceGenerator.
 type MockServiceGeneratorMockRecorder struct {
 	mock *MockServiceGenerator
 }
 
-// NewMockServiceGenerator creates a new mock instance
+// NewMockServiceGenerator creates a new mock instance.
 func NewMockServiceGenerator(ctrl *gomock.Controller) *MockServiceGenerator {
 	mock := &MockServiceGenerator{ctrl: ctrl}
 	mock.recorder = &MockServiceGeneratorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockServiceGenerator) EXPECT() *MockServiceGeneratorMockRecorder {
 	return m.recorder
 }
 
-// Generate mocks base method
+// Generate mocks base method.
 func (m *MockServiceGenerator) Generate(arg0 *api.GenerateServiceRequest) (*api.GenerateServiceResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Generate", arg0)
@@ -128,13 +128,13 @@ func (m *MockServiceGenerator) Generate(arg0 *api.GenerateServiceRequest) (*api.
 	return ret0, ret1
 }
 
-// Generate indicates an expected call of Generate
+// Generate indicates an expected call of Generate.
 func (mr *MockServiceGeneratorMockRecorder) Generate(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockServiceGenerator)(nil).Generate), arg0)
 }
 
-// Handle mocks base method
+// Handle mocks base method.
 func (m *MockServiceGenerator) Handle() plugin.Handle {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handle")
@@ -142,7 +142,7 @@ func (m *MockServiceGenerator) Handle() plugin.Handle {
 	return ret0
 }
 
-// Handle indicates an expected call of Handle
+// Handle indicates an expected call of Handle.
 func (mr *MockServiceGeneratorMockRecorder) Handle() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockServiceGenerator)(nil).Handle))

--- a/plugin/api.thrift
+++ b/plugin/api.thrift
@@ -375,6 +375,14 @@ struct GenerateServiceRequest {
      * new Generator for more custom plugin generation.
      */
     5: required string thriftRoot
+    /**
+     *  IDs of Modules for which code should be generated.
+     *
+     *  Note that the modules map contains information about both, the
+     *  modules being generated and their transitive dependencies. Code should
+     *  only be generated for module IDs listed here.
+     */
+    6: optional list<ModuleID> rootModules
 }
 
 /**

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -30,30 +30,30 @@ import (
 	reflect "reflect"
 )
 
-// MockPlugin is a mock of Plugin interface
+// MockPlugin is a mock of Plugin interface.
 type MockPlugin struct {
 	ctrl     *gomock.Controller
 	recorder *MockPluginMockRecorder
 }
 
-// MockPluginMockRecorder is the mock recorder for MockPlugin
+// MockPluginMockRecorder is the mock recorder for MockPlugin.
 type MockPluginMockRecorder struct {
 	mock *MockPlugin
 }
 
-// NewMockPlugin creates a new mock instance
+// NewMockPlugin creates a new mock instance.
 func NewMockPlugin(ctrl *gomock.Controller) *MockPlugin {
 	mock := &MockPlugin{ctrl: ctrl}
 	mock.recorder = &MockPluginMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPlugin) EXPECT() *MockPluginMockRecorder {
 	return m.recorder
 }
 
-// Goodbye mocks base method
+// Goodbye mocks base method.
 func (m *MockPlugin) Goodbye() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Goodbye")
@@ -61,13 +61,13 @@ func (m *MockPlugin) Goodbye() error {
 	return ret0
 }
 
-// Goodbye indicates an expected call of Goodbye
+// Goodbye indicates an expected call of Goodbye.
 func (mr *MockPluginMockRecorder) Goodbye() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Goodbye", reflect.TypeOf((*MockPlugin)(nil).Goodbye))
 }
 
-// Handshake mocks base method
+// Handshake mocks base method.
 func (m *MockPlugin) Handshake(arg0 *api.HandshakeRequest) (*api.HandshakeResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handshake", arg0)
@@ -76,36 +76,36 @@ func (m *MockPlugin) Handshake(arg0 *api.HandshakeRequest) (*api.HandshakeRespon
 	return ret0, ret1
 }
 
-// Handshake indicates an expected call of Handshake
+// Handshake indicates an expected call of Handshake.
 func (mr *MockPluginMockRecorder) Handshake(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handshake", reflect.TypeOf((*MockPlugin)(nil).Handshake), arg0)
 }
 
-// MockServiceGenerator is a mock of ServiceGenerator interface
+// MockServiceGenerator is a mock of ServiceGenerator interface.
 type MockServiceGenerator struct {
 	ctrl     *gomock.Controller
 	recorder *MockServiceGeneratorMockRecorder
 }
 
-// MockServiceGeneratorMockRecorder is the mock recorder for MockServiceGenerator
+// MockServiceGeneratorMockRecorder is the mock recorder for MockServiceGenerator.
 type MockServiceGeneratorMockRecorder struct {
 	mock *MockServiceGenerator
 }
 
-// NewMockServiceGenerator creates a new mock instance
+// NewMockServiceGenerator creates a new mock instance.
 func NewMockServiceGenerator(ctrl *gomock.Controller) *MockServiceGenerator {
 	mock := &MockServiceGenerator{ctrl: ctrl}
 	mock.recorder = &MockServiceGeneratorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockServiceGenerator) EXPECT() *MockServiceGeneratorMockRecorder {
 	return m.recorder
 }
 
-// Generate mocks base method
+// Generate mocks base method.
 func (m *MockServiceGenerator) Generate(arg0 *api.GenerateServiceRequest) (*api.GenerateServiceResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Generate", arg0)
@@ -114,7 +114,7 @@ func (m *MockServiceGenerator) Generate(arg0 *api.GenerateServiceRequest) (*api.
 	return ret0, ret1
 }
 
-// Generate indicates an expected call of Generate
+// Generate indicates an expected call of Generate.
 func (mr *MockServiceGeneratorMockRecorder) Generate(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockServiceGenerator)(nil).Generate), arg0)

--- a/thrifttest/mock_protocol.go
+++ b/thrifttest/mock_protocol.go
@@ -32,30 +32,30 @@ import (
 	reflect "reflect"
 )
 
-// MockProtocol is a mock of Protocol interface
+// MockProtocol is a mock of Protocol interface.
 type MockProtocol struct {
 	ctrl     *gomock.Controller
 	recorder *MockProtocolMockRecorder
 }
 
-// MockProtocolMockRecorder is the mock recorder for MockProtocol
+// MockProtocolMockRecorder is the mock recorder for MockProtocol.
 type MockProtocolMockRecorder struct {
 	mock *MockProtocol
 }
 
-// NewMockProtocol creates a new mock instance
+// NewMockProtocol creates a new mock instance.
 func NewMockProtocol(ctrl *gomock.Controller) *MockProtocol {
 	mock := &MockProtocol{ctrl: ctrl}
 	mock.recorder = &MockProtocolMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProtocol) EXPECT() *MockProtocolMockRecorder {
 	return m.recorder
 }
 
-// Decode mocks base method
+// Decode mocks base method.
 func (m *MockProtocol) Decode(arg0 io.ReaderAt, arg1 wire.Type) (wire.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Decode", arg0, arg1)
@@ -64,13 +64,13 @@ func (m *MockProtocol) Decode(arg0 io.ReaderAt, arg1 wire.Type) (wire.Value, err
 	return ret0, ret1
 }
 
-// Decode indicates an expected call of Decode
+// Decode indicates an expected call of Decode.
 func (mr *MockProtocolMockRecorder) Decode(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decode", reflect.TypeOf((*MockProtocol)(nil).Decode), arg0, arg1)
 }
 
-// DecodeEnveloped mocks base method
+// DecodeEnveloped mocks base method.
 func (m *MockProtocol) DecodeEnveloped(arg0 io.ReaderAt) (wire.Envelope, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DecodeEnveloped", arg0)
@@ -79,13 +79,13 @@ func (m *MockProtocol) DecodeEnveloped(arg0 io.ReaderAt) (wire.Envelope, error) 
 	return ret0, ret1
 }
 
-// DecodeEnveloped indicates an expected call of DecodeEnveloped
+// DecodeEnveloped indicates an expected call of DecodeEnveloped.
 func (mr *MockProtocolMockRecorder) DecodeEnveloped(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeEnveloped", reflect.TypeOf((*MockProtocol)(nil).DecodeEnveloped), arg0)
 }
 
-// Encode mocks base method
+// Encode mocks base method.
 func (m *MockProtocol) Encode(arg0 wire.Value, arg1 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Encode", arg0, arg1)
@@ -93,13 +93,13 @@ func (m *MockProtocol) Encode(arg0 wire.Value, arg1 io.Writer) error {
 	return ret0
 }
 
-// Encode indicates an expected call of Encode
+// Encode indicates an expected call of Encode.
 func (mr *MockProtocolMockRecorder) Encode(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encode", reflect.TypeOf((*MockProtocol)(nil).Encode), arg0, arg1)
 }
 
-// EncodeEnveloped mocks base method
+// EncodeEnveloped mocks base method.
 func (m *MockProtocol) EncodeEnveloped(arg0 wire.Envelope, arg1 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EncodeEnveloped", arg0, arg1)
@@ -107,36 +107,36 @@ func (m *MockProtocol) EncodeEnveloped(arg0 wire.Envelope, arg1 io.Writer) error
 	return ret0
 }
 
-// EncodeEnveloped indicates an expected call of EncodeEnveloped
+// EncodeEnveloped indicates an expected call of EncodeEnveloped.
 func (mr *MockProtocolMockRecorder) EncodeEnveloped(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncodeEnveloped", reflect.TypeOf((*MockProtocol)(nil).EncodeEnveloped), arg0, arg1)
 }
 
-// MockEnvelopeAgnosticProtocol is a mock of EnvelopeAgnosticProtocol interface
+// MockEnvelopeAgnosticProtocol is a mock of EnvelopeAgnosticProtocol interface.
 type MockEnvelopeAgnosticProtocol struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnvelopeAgnosticProtocolMockRecorder
 }
 
-// MockEnvelopeAgnosticProtocolMockRecorder is the mock recorder for MockEnvelopeAgnosticProtocol
+// MockEnvelopeAgnosticProtocolMockRecorder is the mock recorder for MockEnvelopeAgnosticProtocol.
 type MockEnvelopeAgnosticProtocolMockRecorder struct {
 	mock *MockEnvelopeAgnosticProtocol
 }
 
-// NewMockEnvelopeAgnosticProtocol creates a new mock instance
+// NewMockEnvelopeAgnosticProtocol creates a new mock instance.
 func NewMockEnvelopeAgnosticProtocol(ctrl *gomock.Controller) *MockEnvelopeAgnosticProtocol {
 	mock := &MockEnvelopeAgnosticProtocol{ctrl: ctrl}
 	mock.recorder = &MockEnvelopeAgnosticProtocolMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEnvelopeAgnosticProtocol) EXPECT() *MockEnvelopeAgnosticProtocolMockRecorder {
 	return m.recorder
 }
 
-// Decode mocks base method
+// Decode mocks base method.
 func (m *MockEnvelopeAgnosticProtocol) Decode(arg0 io.ReaderAt, arg1 wire.Type) (wire.Value, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Decode", arg0, arg1)
@@ -145,13 +145,13 @@ func (m *MockEnvelopeAgnosticProtocol) Decode(arg0 io.ReaderAt, arg1 wire.Type) 
 	return ret0, ret1
 }
 
-// Decode indicates an expected call of Decode
+// Decode indicates an expected call of Decode.
 func (mr *MockEnvelopeAgnosticProtocolMockRecorder) Decode(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decode", reflect.TypeOf((*MockEnvelopeAgnosticProtocol)(nil).Decode), arg0, arg1)
 }
 
-// DecodeEnveloped mocks base method
+// DecodeEnveloped mocks base method.
 func (m *MockEnvelopeAgnosticProtocol) DecodeEnveloped(arg0 io.ReaderAt) (wire.Envelope, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DecodeEnveloped", arg0)
@@ -160,13 +160,13 @@ func (m *MockEnvelopeAgnosticProtocol) DecodeEnveloped(arg0 io.ReaderAt) (wire.E
 	return ret0, ret1
 }
 
-// DecodeEnveloped indicates an expected call of DecodeEnveloped
+// DecodeEnveloped indicates an expected call of DecodeEnveloped.
 func (mr *MockEnvelopeAgnosticProtocolMockRecorder) DecodeEnveloped(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeEnveloped", reflect.TypeOf((*MockEnvelopeAgnosticProtocol)(nil).DecodeEnveloped), arg0)
 }
 
-// DecodeRequest mocks base method
+// DecodeRequest mocks base method.
 func (m *MockEnvelopeAgnosticProtocol) DecodeRequest(arg0 wire.EnvelopeType, arg1 io.ReaderAt) (wire.Value, protocol.Responder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DecodeRequest", arg0, arg1)
@@ -176,13 +176,13 @@ func (m *MockEnvelopeAgnosticProtocol) DecodeRequest(arg0 wire.EnvelopeType, arg
 	return ret0, ret1, ret2
 }
 
-// DecodeRequest indicates an expected call of DecodeRequest
+// DecodeRequest indicates an expected call of DecodeRequest.
 func (mr *MockEnvelopeAgnosticProtocolMockRecorder) DecodeRequest(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeRequest", reflect.TypeOf((*MockEnvelopeAgnosticProtocol)(nil).DecodeRequest), arg0, arg1)
 }
 
-// Encode mocks base method
+// Encode mocks base method.
 func (m *MockEnvelopeAgnosticProtocol) Encode(arg0 wire.Value, arg1 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Encode", arg0, arg1)
@@ -190,13 +190,13 @@ func (m *MockEnvelopeAgnosticProtocol) Encode(arg0 wire.Value, arg1 io.Writer) e
 	return ret0
 }
 
-// Encode indicates an expected call of Encode
+// Encode indicates an expected call of Encode.
 func (mr *MockEnvelopeAgnosticProtocolMockRecorder) Encode(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encode", reflect.TypeOf((*MockEnvelopeAgnosticProtocol)(nil).Encode), arg0, arg1)
 }
 
-// EncodeEnveloped mocks base method
+// EncodeEnveloped mocks base method.
 func (m *MockEnvelopeAgnosticProtocol) EncodeEnveloped(arg0 wire.Envelope, arg1 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EncodeEnveloped", arg0, arg1)
@@ -204,36 +204,36 @@ func (m *MockEnvelopeAgnosticProtocol) EncodeEnveloped(arg0 wire.Envelope, arg1 
 	return ret0
 }
 
-// EncodeEnveloped indicates an expected call of EncodeEnveloped
+// EncodeEnveloped indicates an expected call of EncodeEnveloped.
 func (mr *MockEnvelopeAgnosticProtocolMockRecorder) EncodeEnveloped(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncodeEnveloped", reflect.TypeOf((*MockEnvelopeAgnosticProtocol)(nil).EncodeEnveloped), arg0, arg1)
 }
 
-// MockResponder is a mock of Responder interface
+// MockResponder is a mock of Responder interface.
 type MockResponder struct {
 	ctrl     *gomock.Controller
 	recorder *MockResponderMockRecorder
 }
 
-// MockResponderMockRecorder is the mock recorder for MockResponder
+// MockResponderMockRecorder is the mock recorder for MockResponder.
 type MockResponderMockRecorder struct {
 	mock *MockResponder
 }
 
-// NewMockResponder creates a new mock instance
+// NewMockResponder creates a new mock instance.
 func NewMockResponder(ctrl *gomock.Controller) *MockResponder {
 	mock := &MockResponder{ctrl: ctrl}
 	mock.recorder = &MockResponderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockResponder) EXPECT() *MockResponderMockRecorder {
 	return m.recorder
 }
 
-// EncodeResponse mocks base method
+// EncodeResponse mocks base method.
 func (m *MockResponder) EncodeResponse(arg0 wire.Value, arg1 wire.EnvelopeType, arg2 io.Writer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EncodeResponse", arg0, arg1, arg2)
@@ -241,7 +241,7 @@ func (m *MockResponder) EncodeResponse(arg0 wire.Value, arg1 wire.EnvelopeType, 
 	return ret0
 }
 
-// EncodeResponse indicates an expected call of EncodeResponse
+// EncodeResponse indicates an expected call of EncodeResponse.
 func (mr *MockResponderMockRecorder) EncodeResponse(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncodeResponse", reflect.TypeOf((*MockResponder)(nil).EncodeResponse), arg0, arg1, arg2)


### PR DESCRIPTION
Even if a Thrift file has no service declaration and therefore no
req.RootServices entries, it's stil useful to have Module information
for the Thrift Files that ThriftRW is invoked with.

To provide an example of where this Module information can be
useful, the Directory field of a Module can help place ThriftRW
plugin generated code for Thrift files that don't contain service
declarations next to where ThriftRW has already generated its code
for that module.