### PR TITLE
travis: Test against supported versions of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
 
 matrix:
   include:
-  - go: 1.12.x
-  - go: 1.13.x
+  - go: oldstable
+  - go: stable
     env: LINT=1
 
 # Download modules and install tools.


### PR DESCRIPTION
Update Travis CI jobs to use Go to stable (currently 1.15.x) and oldstable
(currently 1.14.x) to CI on supported versions of Go.