### PR TITLE
Remove inline typeconvert when logging some thrift typedefs

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -245,6 +245,8 @@ func (g *generator) TextTemplate(s string, data interface{}, opts ...TemplateOpt
 		"isNotNil": func(val interface{}) bool {
 			return val != nil
 		},
+		"zapTypedefGenerateMarshaler":     curryGenerator(g.z.zapTypedefGenerateMarshaler, g),
+		"zapTypedefHasGeneratedMarshaler": curryGenerator(g.z.zapTypedefHasGeneratedMarshaler, g),
 	}
 
 	tmpl := template.New("thriftrw").Delims("<", ">").Funcs(templateFuncs)

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -3192,7 +3192,7 @@ type _List_UUID_Zapper []*typedefs.UUID
 // fast logging of _List_UUID_Zapper.
 func (l _List_UUID_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err error) {
 	for _, v := range l {
-		err = multierr.Append(err, enc.AppendObject((*typedefs.I128)(v)))
+		err = multierr.Append(err, enc.AppendObject(v))
 	}
 	return err
 }

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -75,7 +75,7 @@ func (lhs AnotherStringList) Equals(rhs AnotherStringList) bool {
 }
 
 func (v AnotherStringList) MarshalLogArray(enc zapcore.ArrayEncoder) error {
-	return ((_Set_String_sliceType_Zapper)(([]string)(v))).MarshalLogArray(enc)
+	return ((_Set_String_sliceType_Zapper)((MyStringList)(v))).MarshalLogArray(enc)
 }
 
 type Bar struct {
@@ -769,20 +769,20 @@ func (v *Bar) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	if v.OptionalStringListField != nil {
 		err = multierr.Append(err, enc.AddArray("optionalStringListField", (_Set_String_sliceType_Zapper)(v.OptionalStringListField)))
 	}
-	err = multierr.Append(err, enc.AddArray("requiredTypedefStringListField", (_Set_String_sliceType_Zapper)(([]string)(v.RequiredTypedefStringListField))))
+	err = multierr.Append(err, enc.AddArray("requiredTypedefStringListField", (_Set_String_sliceType_Zapper)(v.RequiredTypedefStringListField)))
 	if v.OptionalTypedefStringListField != nil {
-		err = multierr.Append(err, enc.AddArray("optionalTypedefStringListField", (_Set_String_sliceType_Zapper)(([]string)(v.OptionalTypedefStringListField))))
+		err = multierr.Append(err, enc.AddArray("optionalTypedefStringListField", (_Set_String_sliceType_Zapper)(v.OptionalTypedefStringListField)))
 	}
 	err = multierr.Append(err, enc.AddArray("requiredFooListField", (_Set_Foo_sliceType_Zapper)(v.RequiredFooListField)))
 	if v.OptionalFooListField != nil {
 		err = multierr.Append(err, enc.AddArray("optionalFooListField", (_Set_Foo_sliceType_Zapper)(v.OptionalFooListField)))
 	}
-	err = multierr.Append(err, enc.AddArray("requiredTypedefFooListField", (_Set_Foo_sliceType_Zapper)(([]*Foo)(v.RequiredTypedefFooListField))))
+	err = multierr.Append(err, enc.AddArray("requiredTypedefFooListField", (_Set_Foo_sliceType_Zapper)(v.RequiredTypedefFooListField)))
 	if v.OptionalTypedefFooListField != nil {
-		err = multierr.Append(err, enc.AddArray("optionalTypedefFooListField", (_Set_Foo_sliceType_Zapper)(([]*Foo)(v.OptionalTypedefFooListField))))
+		err = multierr.Append(err, enc.AddArray("optionalTypedefFooListField", (_Set_Foo_sliceType_Zapper)(v.OptionalTypedefFooListField)))
 	}
 	err = multierr.Append(err, enc.AddArray("requiredStringListListField", (_Set_Set_String_sliceType_sliceType_Zapper)(v.RequiredStringListListField)))
-	err = multierr.Append(err, enc.AddArray("requiredTypedefStringListListField", (_Set_Set_String_sliceType_sliceType_Zapper)(([][]string)(v.RequiredTypedefStringListListField))))
+	err = multierr.Append(err, enc.AddArray("requiredTypedefStringListListField", (_Set_Set_String_sliceType_sliceType_Zapper)(v.RequiredTypedefStringListListField)))
 	return err
 }
 
@@ -1127,7 +1127,7 @@ func (lhs MyStringList) Equals(rhs MyStringList) bool {
 }
 
 func (v MyStringList) MarshalLogArray(enc zapcore.ArrayEncoder) error {
-	return ((_Set_String_sliceType_Zapper)(([]string)(v))).MarshalLogArray(enc)
+	return ((_Set_String_sliceType_Zapper)((StringList)(v))).MarshalLogArray(enc)
 }
 
 type StringList []string

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -2366,7 +2366,7 @@ func (v *Node) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	}
 	enc.AddInt32("value", v.Value)
 	if v.Tail != nil {
-		err = multierr.Append(err, enc.AddObject("tail", (*Node)(v.Tail)))
+		err = multierr.Append(err, enc.AddObject("tail", v.Tail))
 	}
 	return err
 }

--- a/gen/internal/tests/thrift/typedefs.thrift
+++ b/gen/internal/tests/thrift/typedefs.thrift
@@ -11,6 +11,8 @@ typedef string State
 
 typedef i128 UUID  // alias of struct
 
+typedef UUID MyUUID // alias of alias
+
 typedef list<Event> EventGroup  // alias fo collection
 
 struct i128 {
@@ -21,6 +23,10 @@ struct i128 {
 struct Event {
     1: required UUID uuid  // required typedef
     2: optional Timestamp time  // optional typedef
+}
+
+struct TransitiveTypedefField {
+    1: required MyUUID defUUID  // required typedef of alias
 }
 
 struct DefaultPrimitiveTypedef {

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -995,6 +995,39 @@ func (v MyEnum) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return ((enums.EnumWithValues)(v)).MarshalLogObject(enc)
 }
 
+type MyUUID UUID
+
+// ToWire translates MyUUID into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+func (v *MyUUID) ToWire() (wire.Value, error) {
+	x := (*UUID)(v)
+	return x.ToWire()
+}
+
+// String returns a readable string representation of MyUUID.
+func (v *MyUUID) String() string {
+	x := (*UUID)(v)
+	return fmt.Sprint(x)
+}
+
+// FromWire deserializes MyUUID from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+func (v *MyUUID) FromWire(w wire.Value) error {
+	return (*UUID)(v).FromWire(w)
+}
+
+// Equals returns true if this MyUUID is equal to the provided
+// MyUUID.
+func (lhs *MyUUID) Equals(rhs *MyUUID) bool {
+	return (*UUID)(lhs).Equals((*UUID)(rhs))
+}
+
+func (v *MyUUID) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	return ((*I128)(v)).MarshalLogObject(enc)
+}
+
 type PDF []byte
 
 // ToWire translates PDF into a Thrift-level intermediate
@@ -1645,6 +1678,150 @@ func (v *Transition) IsSetEvents() bool {
 	return v != nil && v.Events != nil
 }
 
+type TransitiveTypedefField struct {
+	DefUUID *MyUUID `json:"defUUID,required"`
+}
+
+// ToWire translates a TransitiveTypedefField struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *TransitiveTypedefField) ToWire() (wire.Value, error) {
+	var (
+		fields [1]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.DefUUID == nil {
+		return w, errors.New("field DefUUID of TransitiveTypedefField is required")
+	}
+	w, err = v.DefUUID.ToWire()
+	if err != nil {
+		return w, err
+	}
+	fields[i] = wire.Field{ID: 1, Value: w}
+	i++
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _MyUUID_Read(w wire.Value) (*MyUUID, error) {
+	var x MyUUID
+	err := x.FromWire(w)
+	return &x, err
+}
+
+// FromWire deserializes a TransitiveTypedefField struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a TransitiveTypedefField struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v TransitiveTypedefField
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *TransitiveTypedefField) FromWire(w wire.Value) error {
+	var err error
+
+	defUUIDIsSet := false
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 1:
+			if field.Value.Type() == wire.TStruct {
+				v.DefUUID, err = _MyUUID_Read(field.Value)
+				if err != nil {
+					return err
+				}
+				defUUIDIsSet = true
+			}
+		}
+	}
+
+	if !defUUIDIsSet {
+		return errors.New("field DefUUID of TransitiveTypedefField is required")
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a TransitiveTypedefField
+// struct.
+func (v *TransitiveTypedefField) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [1]string
+	i := 0
+	fields[i] = fmt.Sprintf("DefUUID: %v", v.DefUUID)
+	i++
+
+	return fmt.Sprintf("TransitiveTypedefField{%v}", strings.Join(fields[:i], ", "))
+}
+
+// Equals returns true if all the fields of this TransitiveTypedefField match the
+// provided TransitiveTypedefField.
+//
+// This function performs a deep comparison.
+func (v *TransitiveTypedefField) Equals(rhs *TransitiveTypedefField) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !v.DefUUID.Equals(rhs.DefUUID) {
+		return false
+	}
+
+	return true
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of TransitiveTypedefField.
+func (v *TransitiveTypedefField) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	err = multierr.Append(err, enc.AddObject("defUUID", (*I128)(v.DefUUID)))
+	return err
+}
+
+// GetDefUUID returns the value of DefUUID if it is set or its
+// zero value if it is unset.
+func (v *TransitiveTypedefField) GetDefUUID() (o *MyUUID) {
+	if v != nil {
+		o = v.DefUUID
+	}
+	return
+}
+
+// IsSetDefUUID returns true if DefUUID is not nil.
+func (v *TransitiveTypedefField) IsSetDefUUID() bool {
+	return v != nil && v.DefUUID != nil
+}
+
 type UUID I128
 
 // ToWire translates UUID into a Thrift-level intermediate
@@ -1849,7 +2026,7 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "typedefs",
 	Package:  "go.uber.org/thriftrw/gen/internal/tests/typedefs",
 	FilePath: "typedefs.thrift",
-	SHA1:     "c44a85a79e17ab1c29e271bdef1909abe37fbb97",
+	SHA1:     "333cb75491c993220f7695108fa91a4a8a299a48",
 	Includes: []*thriftreflect.ThriftModule{
 		enums.ThriftModule,
 		structs.ThriftModule,
@@ -1857,4 +2034,4 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Raw: rawIDL,
 }
 
-const rawIDL = "include \"./structs.thrift\"\ninclude \"./enums.thrift\"\n\n/**\n * Number of seconds since epoch.\n *\n * Deprecated: Use ISOTime instead.\n */\ntypedef i64 Timestamp  // alias of primitive\ntypedef string State\n\ntypedef i128 UUID  // alias of struct\n\ntypedef list<Event> EventGroup  // alias fo collection\n\nstruct i128 {\n    1: required i64 high\n    2: required i64 low\n}\n\nstruct Event {\n    1: required UUID uuid  // required typedef\n    2: optional Timestamp time  // optional typedef\n}\n\nstruct DefaultPrimitiveTypedef {\n    1: optional State state = \"hello\"\n}\n\nstruct Transition {\n    1: required State fromState\n    2: required State toState\n    3: optional EventGroup events\n}\n\ntypedef binary PDF  // alias of []byte\n\ntypedef set<structs.Frame> FrameGroup\n\ntypedef map<structs.Point, structs.Point> PointMap\n\ntypedef set<binary> BinarySet\n\ntypedef map<structs.Edge, structs.Edge> EdgeMap\n\ntypedef map<State, i64> StateMap\n\ntypedef enums.EnumWithValues MyEnum\n"
+const rawIDL = "include \"./structs.thrift\"\ninclude \"./enums.thrift\"\n\n/**\n * Number of seconds since epoch.\n *\n * Deprecated: Use ISOTime instead.\n */\ntypedef i64 Timestamp  // alias of primitive\ntypedef string State\n\ntypedef i128 UUID  // alias of struct\n\ntypedef UUID MyUUID // alias of alias\n\ntypedef list<Event> EventGroup  // alias fo collection\n\nstruct i128 {\n    1: required i64 high\n    2: required i64 low\n}\n\nstruct Event {\n    1: required UUID uuid  // required typedef\n    2: optional Timestamp time  // optional typedef\n}\n\nstruct TransitiveTypedefField {\n    1: required MyUUID defUUID  // required typedef of alias\n}\n\nstruct DefaultPrimitiveTypedef {\n    1: optional State state = \"hello\"\n}\n\nstruct Transition {\n    1: required State fromState\n    2: required State toState\n    3: optional EventGroup events\n}\n\ntypedef binary PDF  // alias of []byte\n\ntypedef set<structs.Frame> FrameGroup\n\ntypedef map<structs.Point, structs.Point> PointMap\n\ntypedef set<binary> BinarySet\n\ntypedef map<structs.Edge, structs.Edge> EdgeMap\n\ntypedef map<State, i64> StateMap\n\ntypedef enums.EnumWithValues MyEnum\n"

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -678,7 +678,7 @@ func (v *Event) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	if v == nil {
 		return nil
 	}
-	err = multierr.Append(err, enc.AddObject("uuid", (*I128)(v.UUID)))
+	err = multierr.Append(err, enc.AddObject("uuid", v.UUID))
 	if v.Time != nil {
 		enc.AddInt64("time", (int64)(*v.Time))
 	}
@@ -1025,7 +1025,7 @@ func (lhs *MyUUID) Equals(rhs *MyUUID) bool {
 }
 
 func (v *MyUUID) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	return ((*I128)(v)).MarshalLogObject(enc)
+	return ((*UUID)(v)).MarshalLogObject(enc)
 }
 
 type PDF []byte
@@ -1640,7 +1640,7 @@ func (v *Transition) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	enc.AddString("fromState", (string)(v.FromState))
 	enc.AddString("toState", (string)(v.ToState))
 	if v.Events != nil {
-		err = multierr.Append(err, enc.AddArray("events", (_List_Event_Zapper)(([]*Event)(v.Events))))
+		err = multierr.Append(err, enc.AddArray("events", (_List_Event_Zapper)(v.Events)))
 	}
 	return err
 }
@@ -1804,7 +1804,7 @@ func (v *TransitiveTypedefField) MarshalLogObject(enc zapcore.ObjectEncoder) (er
 	if v == nil {
 		return nil
 	}
-	err = multierr.Append(err, enc.AddObject("defUUID", (*I128)(v.DefUUID)))
+	err = multierr.Append(err, enc.AddObject("defUUID", v.DefUUID))
 	return err
 }
 

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -208,7 +208,7 @@ func (v *UUIDConflict) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 		return nil
 	}
 	enc.AddString("localUUID", (string)(v.LocalUUID))
-	err = multierr.Append(err, enc.AddObject("importedUUID", (*typedefs.I128)(v.ImportedUUID)))
+	err = multierr.Append(err, enc.AddObject("importedUUID", v.ImportedUUID))
 	return err
 }
 

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -455,6 +455,7 @@ func TestQuickSuite(t *testing.T) {
 		{Sample: td.StateMap{}, Kind: thriftTypedef},
 		{Sample: td.Timestamp(0), NoLog: true, Kind: thriftTypedef},
 		{Sample: td.UUID{}, Kind: thriftTypedef},
+		{Sample: td.MyUUID{}, Kind: thriftTypedef},
 		{Sample: tl.LittlePotatoe(0), NoLog: true, Kind: thriftTypedef},
 		{Sample: tl.LittlePotatoe2(0.0), NoLog: true, Kind: thriftTypedef},
 		{Sample: tul.UUID(""), NoLog: true, Kind: thriftTypedef},

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -456,6 +456,7 @@ func TestQuickSuite(t *testing.T) {
 		{Sample: td.Timestamp(0), NoLog: true, Kind: thriftTypedef},
 		{Sample: td.UUID{}, Kind: thriftTypedef},
 		{Sample: td.MyUUID{}, Kind: thriftTypedef},
+		{Sample: td.TransitiveTypedefField{}, Kind: thriftStruct},
 		{Sample: tl.LittlePotatoe(0), NoLog: true, Kind: thriftTypedef},
 		{Sample: tl.LittlePotatoe2(0.0), NoLog: true, Kind: thriftTypedef},
 		{Sample: tul.UUID(""), NoLog: true, Kind: thriftTypedef},

--- a/gen/typedef.go
+++ b/gen/typedef.go
@@ -114,20 +114,18 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 		</* We want the behavior of the underlying type for typedefs: in the case that
 				they are objects or arrays, we need to cast to the underlying object or array;
 				else, zapMarshaler in zap.go will take care of it. */>
-		<if (eq (zapEncoder .Target) "Object") ->
+		<if (zapTypedefHasGeneratedMarshaler .Target) ->
 			<$zapcore := import "go.uber.org/zap/zapcore">
 			<$enc := newVar "enc">
+			<if (eq (zapEncoder .Target) "Object") ->
 			func (<$v> <$typedefType>) MarshalLogObject(<$enc> <$zapcore>.ObjectEncoder) error {
-				return (<zapMarshaler . $v>).MarshalLogObject(<$enc>)
+				return (<zapTypedefGenerateMarshaler . $v>).MarshalLogObject(<$enc>)
 			}
-		<- end>
-
-		<if (eq (zapEncoder .Target) "Array") ->
-			<$zapcore := import "go.uber.org/zap/zapcore">
-			<$enc := newVar "enc">
+			<- else if (eq (zapEncoder .Target) "Array") ->
 			func (<$v> <$typedefType>) MarshalLogArray(<$enc> <$zapcore>.ArrayEncoder) error {
-				return (<zapMarshaler . $v>).MarshalLogArray(<$enc>)
+				return (<zapTypedefGenerateMarshaler . $v>).MarshalLogArray(<$enc>)
 			}
+			<- end>
 		<- end>
 		<- end>
 		`,

--- a/gen/zap.go
+++ b/gen/zap.go
@@ -101,11 +101,11 @@ func (z *zapGenerator) zapTypedefHasGeneratedMarshaler(g Generator, spec compile
 // to the next value. This should be used when generating the code for the Zap
 // marshal implementation of the typedef.
 func (z *zapGenerator) zapTypedefGenerateMarshaler(g Generator, spec *compile.TypedefSpec, fieldValue string) (string, error) {
-	rootName, err := typeReference(g, spec.Target)
+	targetName, err := typeReference(g, spec.Target)
 	if err != nil {
 		return "", err
 	}
-	return z.zapMarshalerGenerator(g, spec, fmt.Sprintf("(%v)(%v)", rootName, fieldValue))
+	return z.zapMarshalerGenerator(g, spec, fmt.Sprintf("(%v)(%v)", targetName, fieldValue))
 }
 
 // zapMarshaler takes a TypeSpec, evaluates whether there are underlying elements

--- a/gen/zap.go
+++ b/gen/zap.go
@@ -86,6 +86,28 @@ func (z *zapGenerator) zapEncoder(g Generator, spec compile.TypeSpec) string {
 	panic(root)
 }
 
+// zapTypedefHasGeneratedMarshaler defines if a typedef will have generated code
+// zapcore.ObjectMarshaler or zapcore.ArrayMarshaler.
+func (z *zapGenerator) zapTypedefHasGeneratedMarshaler(g Generator, spec compile.TypeSpec) bool {
+	switch z.zapEncoder(g, spec) {
+	case "Array", "Object":
+		return true
+	default:
+		return false
+	}
+}
+
+// zapTypedefGenerateMarshaler is similar to zapMarshaler but always converts a typedef
+// to the next value. This should be used when generating the code for the Zap
+// marshal implementation of the typedef.
+func (z *zapGenerator) zapTypedefGenerateMarshaler(g Generator, spec *compile.TypedefSpec, fieldValue string) (string, error) {
+	rootName, err := typeReference(g, spec.Target)
+	if err != nil {
+		return "", err
+	}
+	return z.zapMarshalerGenerator(g, spec, fmt.Sprintf("(%v)(%v)", rootName, fieldValue))
+}
+
 // zapMarshaler takes a TypeSpec, evaluates whether there are underlying elements
 // that require more Zap implementation to log everything, and returns a string
 // that properly casts the fieldValue, if needed, for logging.
@@ -96,21 +118,25 @@ func (z *zapGenerator) zapEncoder(g Generator, spec compile.TypeSpec) string {
 //   enc.Add<zapEncoder .Type>("foo", <zapMarshaler .Type "v">)
 //
 func (z *zapGenerator) zapMarshaler(g Generator, spec compile.TypeSpec, fieldValue string) (string, error) {
-	root := compile.RootTypeSpec(spec)
-
-	if _, ok := spec.(*compile.TypedefSpec); ok {
-		// For typedefs, cast to the root type and rely on that functionality.
-		rootName, err := typeReference(g, root)
+	// For typedefs, cast to the root type and rely on that functionality if the
+	// typedef doesn't have generated Zap marshal methods.
+	if _, ok := spec.(*compile.TypedefSpec); ok && !z.zapTypedefHasGeneratedMarshaler(g, spec) {
+		rootName, err := typeReference(g, compile.RootTypeSpec(spec))
 		if err != nil {
 			return "", err
 		}
 		fieldValue = fmt.Sprintf("(%v)(%v)", rootName, fieldValue)
 	}
 
+	return z.zapMarshalerGenerator(g, spec, fieldValue)
+}
+
+func (z *zapGenerator) zapMarshalerGenerator(g Generator, spec compile.TypeSpec, fieldValue string) (string, error) {
 	if isPrimitiveType(spec) {
 		return fieldValue, nil
 	}
 
+	root := compile.RootTypeSpec(spec)
 	switch t := root.(type) {
 	case *compile.BinarySpec:
 		// There is no AppendBinary for ArrayEncoder, so we opt for encoding it ourselves and


### PR DESCRIPTION
https://github.com/thriftrw/thriftrw-go/pull/366 added fast zap logging
by generating extra `MarshalLog...` methods on generated types. For
typedefs in thrift, other types that log them will cast to the
underlying type in their `MarshalLog...` method, causing the generated
code to need to import multiple go packages generated from both direct
and indirect thrift dependencies.

This should not be necessary, as typedefs of complex types (anything
that cannot be mapped directly to a go stdlb type) get their own
`MarshalLog...` methods, which cast to underlying type when necessary.

This PR changes the logging for typedef'ed fields to:
- cast to the underlying type inline when the underlying thrift type
directly maps to a go type.
- defer to the typedef's generated `MarshalLog...` method otherwise.

This results in having more predictable importpaths (eg knowing that one
thrift import will lead to one go import in generated code) makes
implementing good bazel rules for thriftrw easier.

See internal issue GO-362 for a more elaborate example of how the
current behaviour complicates our Bazel setup.
