### PR TITLE
[WIP] Encode and decode structs lazily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,3 +134,4 @@ cover:
 .PHONY: clean
 clean:
 	go clean
+	rm $(GOBIN)/thriftrw

--- a/envelope/envelope.go
+++ b/envelope/envelope.go
@@ -71,5 +71,7 @@ func ReadReply(p protocol.Protocol, r io.ReaderAt) (_ wire.Value, seqID int32, _
 		return envelope.Value, envelope.SeqID, fmt.Errorf("failed to decode exception: %v", err)
 	}
 
-	return envelope.Value, envelope.SeqID, ex
+	// Once FromWire is called, envelope.Value is no longer usable.
+	value, _ := ex.ToWire()
+	return value, envelope.SeqID, ex
 }

--- a/gen/field.go
+++ b/gen/field.go
@@ -393,7 +393,6 @@ func (f fieldGroupGenerator) FromWire(g Generator) error {
 		//   }
 		//   return &<$v>, nil
 		func (<$v> *<.Name>) FromWire(<$w> <$wire>.Value) error {
-			<if len .Fields> var err error <end>
 			<$f := newVar "field">
 
 			<$isSet := newNamespace>
@@ -403,7 +402,8 @@ func (f fieldGroupGenerator) FromWire(g Generator) error {
 				<- end>
 			<end>
 
-			for _, <$f> := range <$w>.GetStruct().Fields {
+			fields := <$w>.GetFieldList()
+			err := fields.ForEach(func(<$f> <$wire>.Field) (err error) {
 				switch <$f>.ID {
 				<range .Fields ->
 				case <.ID>:
@@ -424,7 +424,12 @@ func (f fieldGroupGenerator) FromWire(g Generator) error {
 					}
 				<end ->
 				}
+				return nil
+			})
+			if err != nil {
+				return err
 			}
+			fields.Close()
 
 			<$structName := .Name>
 			<range .Fields>

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -51,8 +51,7 @@ type _fieldList_AccessorConflict AccessorConflict
 
 func (fl *_fieldList_AccessorConflict) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*AccessorConflict)(fl)
+		v   = (*AccessorConflict)(fl)
 		w   wire.Value
 		err error
 	)
@@ -65,7 +64,6 @@ func (fl *_fieldList_AccessorConflict) ForEach(writeField func(wire.Field) error
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.GetName2 != nil {
 		w, err = wire.NewValueString(*(v.GetName2)), error(nil)
@@ -75,7 +73,6 @@ func (fl *_fieldList_AccessorConflict) ForEach(writeField func(wire.Field) error
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.IsSetName2 != nil {
 		w, err = wire.NewValueBool(*(v.IsSetName2)), error(nil)
@@ -85,7 +82,6 @@ func (fl *_fieldList_AccessorConflict) ForEach(writeField func(wire.Field) error
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -315,8 +311,7 @@ type _fieldList_AccessorNoConflict AccessorNoConflict
 
 func (fl *_fieldList_AccessorNoConflict) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*AccessorNoConflict)(fl)
+		v   = (*AccessorNoConflict)(fl)
 		w   wire.Value
 		err error
 	)
@@ -329,7 +324,6 @@ func (fl *_fieldList_AccessorNoConflict) ForEach(writeField func(wire.Field) err
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.GetName != nil {
 		w, err = wire.NewValueString(*(v.GetName)), error(nil)
@@ -339,7 +333,6 @@ func (fl *_fieldList_AccessorNoConflict) ForEach(writeField func(wire.Field) err
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -848,8 +841,7 @@ type _fieldList_PrimitiveContainers PrimitiveContainers
 
 func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*PrimitiveContainers)(fl)
+		v   = (*PrimitiveContainers)(fl)
 		w   wire.Value
 		err error
 	)
@@ -862,7 +854,6 @@ func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) er
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.B != nil {
 		w, err = wire.NewValueSet(_Set_String_mapType_ValueList(v.B)), error(nil)
@@ -872,7 +863,6 @@ func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) er
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.C != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.C)), error(nil)
@@ -882,7 +872,6 @@ func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) er
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -1230,8 +1219,7 @@ type _fieldList_StructCollision StructCollision
 
 func (fl *_fieldList_StructCollision) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*StructCollision)(fl)
+		v   = (*StructCollision)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1243,7 +1231,6 @@ func (fl *_fieldList_StructCollision) ForEach(writeField func(wire.Field) error)
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.CollisionField2), error(nil)
 	if err != nil {
@@ -1252,7 +1239,6 @@ func (fl *_fieldList_StructCollision) ForEach(writeField func(wire.Field) error)
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -1406,6 +1392,18 @@ type UnionCollision struct {
 //     return err
 //   }
 func (v *UnionCollision) ToWire() (wire.Value, error) {
+	var i int
+	if v.CollisionField != nil {
+		i++
+	}
+	if v.CollisionField2 != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("UnionCollision should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_UnionCollision)(v)), nil
 }
 
@@ -1413,8 +1411,7 @@ type _fieldList_UnionCollision UnionCollision
 
 func (fl *_fieldList_UnionCollision) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*UnionCollision)(fl)
+		v   = (*UnionCollision)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1427,7 +1424,6 @@ func (fl *_fieldList_UnionCollision) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.CollisionField2 != nil {
 		w, err = wire.NewValueString(*(v.CollisionField2)), error(nil)
@@ -1437,11 +1433,6 @@ func (fl *_fieldList_UnionCollision) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("UnionCollision should have exactly one field: got %v fields", i)
 	}
 
 	return nil
@@ -1637,8 +1628,7 @@ type _fieldList_WithDefault WithDefault
 
 func (fl *_fieldList_WithDefault) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*WithDefault)(fl)
+		v   = (*WithDefault)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1658,7 +1648,6 @@ func (fl *_fieldList_WithDefault) ForEach(writeField func(wire.Field) error) err
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -2032,8 +2021,7 @@ type _fieldList_StructCollision2 StructCollision2
 
 func (fl *_fieldList_StructCollision2) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*StructCollision2)(fl)
+		v   = (*StructCollision2)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2045,7 +2033,6 @@ func (fl *_fieldList_StructCollision2) ForEach(writeField func(wire.Field) error
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.CollisionField2), error(nil)
 	if err != nil {
@@ -2054,7 +2041,6 @@ func (fl *_fieldList_StructCollision2) ForEach(writeField func(wire.Field) error
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -2208,6 +2194,18 @@ type UnionCollision2 struct {
 //     return err
 //   }
 func (v *UnionCollision2) ToWire() (wire.Value, error) {
+	var i int
+	if v.CollisionField != nil {
+		i++
+	}
+	if v.CollisionField2 != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("UnionCollision2 should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_UnionCollision2)(v)), nil
 }
 
@@ -2215,8 +2213,7 @@ type _fieldList_UnionCollision2 UnionCollision2
 
 func (fl *_fieldList_UnionCollision2) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*UnionCollision2)(fl)
+		v   = (*UnionCollision2)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2229,7 +2226,6 @@ func (fl *_fieldList_UnionCollision2) ForEach(writeField func(wire.Field) error)
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.CollisionField2 != nil {
 		w, err = wire.NewValueString(*(v.CollisionField2)), error(nil)
@@ -2239,11 +2235,6 @@ func (fl *_fieldList_UnionCollision2) ForEach(writeField func(wire.Field) error)
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("UnionCollision2 should have exactly one field: got %v fields", i)
 	}
 
 	return nil

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -44,40 +44,54 @@ type AccessorConflict struct {
 //     return err
 //   }
 func (v *AccessorConflict) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_AccessorConflict)(v)), nil
+}
+
+type _fieldList_AccessorConflict AccessorConflict
+
+func (fl *_fieldList_AccessorConflict) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [3]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*AccessorConflict)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Name != nil {
 		w, err = wire.NewValueString(*(v.Name)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.GetName2 != nil {
 		w, err = wire.NewValueString(*(v.GetName2)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.IsSetName2 != nil {
 		w, err = wire.NewValueBool(*(v.IsSetName2)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_AccessorConflict) Close() {}
 
 // FromWire deserializes a AccessorConflict struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -294,32 +308,44 @@ type AccessorNoConflict struct {
 //     return err
 //   }
 func (v *AccessorNoConflict) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_AccessorNoConflict)(v)), nil
+}
+
+type _fieldList_AccessorNoConflict AccessorNoConflict
+
+func (fl *_fieldList_AccessorNoConflict) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*AccessorNoConflict)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Getname != nil {
 		w, err = wire.NewValueString(*(v.Getname)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.GetName != nil {
 		w, err = wire.NewValueString(*(v.GetName)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_AccessorNoConflict) Close() {}
 
 // FromWire deserializes a AccessorNoConflict struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -815,40 +841,54 @@ func (_Map_String_String_MapItemList) Close() {}
 //     return err
 //   }
 func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_PrimitiveContainers)(v)), nil
+}
+
+type _fieldList_PrimitiveContainers PrimitiveContainers
+
+func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [3]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*PrimitiveContainers)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.A != nil {
 		w, err = wire.NewValueList(_List_String_ValueList(v.A)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.B != nil {
 		w, err = wire.NewValueSet(_Set_String_mapType_ValueList(v.B)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.C != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.C)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_PrimitiveContainers) Close() {}
 
 func _List_String_Read(l wire.ValueList) ([]string, error) {
 	if l.ValueType() != wire.TBinary {
@@ -1183,29 +1223,41 @@ type StructCollision struct {
 //     return err
 //   }
 func (v *StructCollision) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_StructCollision)(v)), nil
+}
+
+type _fieldList_StructCollision StructCollision
+
+func (fl *_fieldList_StructCollision) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*StructCollision)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueBool(v.CollisionField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.CollisionField2), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_StructCollision) Close() {}
 
 // FromWire deserializes a StructCollision struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -1354,36 +1406,48 @@ type UnionCollision struct {
 //     return err
 //   }
 func (v *UnionCollision) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_UnionCollision)(v)), nil
+}
+
+type _fieldList_UnionCollision UnionCollision
+
+func (fl *_fieldList_UnionCollision) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*UnionCollision)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.CollisionField != nil {
 		w, err = wire.NewValueBool(*(v.CollisionField)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.CollisionField2 != nil {
 		w, err = wire.NewValueString(*(v.CollisionField2)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("UnionCollision should have exactly one field: got %v fields", i)
+		return fmt.Errorf("UnionCollision should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_UnionCollision) Close() {}
 
 // FromWire deserializes a UnionCollision struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -1566,11 +1630,17 @@ func Default_WithDefault() *WithDefault {
 //     return err
 //   }
 func (v *WithDefault) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_WithDefault)(v)), nil
+}
+
+type _fieldList_WithDefault WithDefault
+
+func (fl *_fieldList_WithDefault) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*WithDefault)(fl)
+		w   wire.Value
+		err error
 	)
 
 	vPouet := v.Pouet
@@ -1583,14 +1653,18 @@ func (v *WithDefault) ToWire() (wire.Value, error) {
 	{
 		w, err = vPouet.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_WithDefault) Close() {}
 
 func _StructCollision_Read(w wire.Value) (*StructCollision2, error) {
 	var v StructCollision2
@@ -1951,29 +2025,41 @@ type StructCollision2 struct {
 //     return err
 //   }
 func (v *StructCollision2) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_StructCollision2)(v)), nil
+}
+
+type _fieldList_StructCollision2 StructCollision2
+
+func (fl *_fieldList_StructCollision2) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*StructCollision2)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueBool(v.CollisionField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.CollisionField2), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_StructCollision2) Close() {}
 
 // FromWire deserializes a StructCollision2 struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -2122,36 +2208,48 @@ type UnionCollision2 struct {
 //     return err
 //   }
 func (v *UnionCollision2) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_UnionCollision2)(v)), nil
+}
+
+type _fieldList_UnionCollision2 UnionCollision2
+
+func (fl *_fieldList_UnionCollision2) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*UnionCollision2)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.CollisionField != nil {
 		w, err = wire.NewValueBool(*(v.CollisionField)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.CollisionField2 != nil {
 		w, err = wire.NewValueString(*(v.CollisionField2)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("UnionCollision2 should have exactly one field: got %v fields", i)
+		return fmt.Errorf("UnionCollision2 should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_UnionCollision2) Close() {}
 
 // FromWire deserializes a UnionCollision2 struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -97,9 +97,9 @@ func (v *AccessorConflict) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *AccessorConflict) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -132,7 +132,12 @@ func (v *AccessorConflict) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -334,9 +339,9 @@ func (v *AccessorNoConflict) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *AccessorNoConflict) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -359,7 +364,12 @@ func (v *AccessorNoConflict) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -923,9 +933,9 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveContainers) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -952,7 +962,12 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -1210,12 +1225,12 @@ func (v *StructCollision) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *StructCollision) FromWire(w wire.Value) error {
-	var err error
 
 	collisionFieldIsSet := false
 	collision_fieldIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
@@ -1234,7 +1249,12 @@ func (v *StructCollision) FromWire(w wire.Value) error {
 				collision_fieldIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !collisionFieldIsSet {
 		return errors.New("field CollisionField of StructCollision is required")
@@ -1383,9 +1403,9 @@ func (v *UnionCollision) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *UnionCollision) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
@@ -1408,7 +1428,12 @@ func (v *UnionCollision) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.CollisionField != nil {
@@ -1591,9 +1616,9 @@ func _StructCollision_Read(w wire.Value) (*StructCollision2, error) {
 //   }
 //   return &v, nil
 func (v *WithDefault) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -1604,7 +1629,12 @@ func (v *WithDefault) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if v.Pouet == nil {
 		v.Pouet = &StructCollision2{
@@ -1963,12 +1993,12 @@ func (v *StructCollision2) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *StructCollision2) FromWire(w wire.Value) error {
-	var err error
 
 	collisionFieldIsSet := false
 	collision_fieldIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
@@ -1987,7 +2017,12 @@ func (v *StructCollision2) FromWire(w wire.Value) error {
 				collision_fieldIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !collisionFieldIsSet {
 		return errors.New("field CollisionField of StructCollision2 is required")
@@ -2136,9 +2171,9 @@ func (v *UnionCollision2) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *UnionCollision2) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
@@ -2161,7 +2196,12 @@ func (v *UnionCollision2) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.CollisionField != nil {

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -626,88 +626,114 @@ func (_Map_Set_I32_mapType_List_Double_MapItemList) Close() {}
 //     return err
 //   }
 func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ContainersOfContainers)(v)), nil
+}
+
+type _fieldList_ContainersOfContainers ContainersOfContainers
+
+func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [9]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ContainersOfContainers)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.ListOfLists != nil {
 		w, err = wire.NewValueList(_List_List_I32_ValueList(v.ListOfLists)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.ListOfSets != nil {
 		w, err = wire.NewValueList(_List_Set_I32_mapType_ValueList(v.ListOfSets)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.ListOfMaps != nil {
 		w, err = wire.NewValueList(_List_Map_I32_I32_ValueList(v.ListOfMaps)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.SetOfSets != nil {
 		w, err = wire.NewValueSet(_Set_Set_String_mapType_sliceType_ValueList(v.SetOfSets)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.SetOfLists != nil {
 		w, err = wire.NewValueSet(_Set_List_String_sliceType_ValueList(v.SetOfLists)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.SetOfMaps != nil {
 		w, err = wire.NewValueSet(_Set_Map_String_String_sliceType_ValueList(v.SetOfMaps)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 6, Value: w}
+		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.MapOfMapToInt != nil {
 		w, err = wire.NewValueMap(_Map_Map_String_I32_I64_MapItemList(v.MapOfMapToInt)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 7, Value: w}
+		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.MapOfListToSet != nil {
 		w, err = wire.NewValueMap(_Map_List_I32_Set_I64_mapType_MapItemList(v.MapOfListToSet)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 8, Value: w}
+		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.MapOfSetToListOfDouble != nil {
 		w, err = wire.NewValueMap(_Map_Set_I32_mapType_List_Double_MapItemList(v.MapOfSetToListOfDouble)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 9, Value: w}
+		if err := writeField(wire.Field{ID: 9, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ContainersOfContainers) Close() {}
 
 func _List_I32_Read(l wire.ValueList) ([]int32, error) {
 	if l.ValueType() != wire.TI32 {
@@ -2220,40 +2246,54 @@ func (_Map_EnumWithDuplicateValues_I32_MapItemList) Close() {}
 //     return err
 //   }
 func (v *EnumContainers) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_EnumContainers)(v)), nil
+}
+
+type _fieldList_EnumContainers EnumContainers
+
+func (fl *_fieldList_EnumContainers) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [3]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*EnumContainers)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.ListOfEnums != nil {
 		w, err = wire.NewValueList(_List_EnumDefault_ValueList(v.ListOfEnums)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.SetOfEnums != nil {
 		w, err = wire.NewValueSet(_Set_EnumWithValues_mapType_ValueList(v.SetOfEnums)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.MapOfEnums != nil {
 		w, err = wire.NewValueMap(_Map_EnumWithDuplicateValues_I32_MapItemList(v.MapOfEnums)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_EnumContainers) Close() {}
 
 func _EnumDefault_Read(w wire.Value) (enums.EnumDefault, error) {
 	var v enums.EnumDefault
@@ -2671,29 +2711,41 @@ func (_List_RecordType_1_ValueList) Close() {}
 //     return err
 //   }
 func (v *ListOfConflictingEnums) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ListOfConflictingEnums)(v)), nil
+}
+
+type _fieldList_ListOfConflictingEnums ListOfConflictingEnums
+
+func (fl *_fieldList_ListOfConflictingEnums) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ListOfConflictingEnums)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueList(_List_RecordType_ValueList(v.Records)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueList(_List_RecordType_1_ValueList(v.OtherRecords)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ListOfConflictingEnums) Close() {}
 
 func _RecordType_Read(w wire.Value) (enum_conflict.RecordType, error) {
 	var v enum_conflict.RecordType
@@ -3007,29 +3059,41 @@ func (_List_UUID_1_ValueList) Close() {}
 //     return err
 //   }
 func (v *ListOfConflictingUUIDs) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ListOfConflictingUUIDs)(v)), nil
+}
+
+type _fieldList_ListOfConflictingUUIDs ListOfConflictingUUIDs
+
+func (fl *_fieldList_ListOfConflictingUUIDs) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ListOfConflictingUUIDs)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueList(_List_UUID_ValueList(v.Uuids)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueList(_List_UUID_1_ValueList(v.OtherUUIDs)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ListOfConflictingUUIDs) Close() {}
 
 func _UUID_Read(w wire.Value) (*typedefs.UUID, error) {
 	var x typedefs.UUID
@@ -3287,24 +3351,34 @@ type ListOfOptionalPrimitives struct {
 //     return err
 //   }
 func (v *ListOfOptionalPrimitives) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ListOfOptionalPrimitives)(v)), nil
+}
+
+type _fieldList_ListOfOptionalPrimitives ListOfOptionalPrimitives
+
+func (fl *_fieldList_ListOfOptionalPrimitives) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ListOfOptionalPrimitives)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.ListOfStrings != nil {
 		w, err = wire.NewValueList(_List_String_ValueList(v.ListOfStrings)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ListOfOptionalPrimitives) Close() {}
 
 // FromWire deserializes a ListOfOptionalPrimitives struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3428,22 +3502,32 @@ type ListOfRequiredPrimitives struct {
 //     return err
 //   }
 func (v *ListOfRequiredPrimitives) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ListOfRequiredPrimitives)(v)), nil
+}
+
+type _fieldList_ListOfRequiredPrimitives ListOfRequiredPrimitives
+
+func (fl *_fieldList_ListOfRequiredPrimitives) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ListOfRequiredPrimitives)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueList(_List_String_ValueList(v.ListOfStrings)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ListOfRequiredPrimitives) Close() {}
 
 // FromWire deserializes a ListOfRequiredPrimitives struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3653,32 +3737,44 @@ func (_Map_String_Binary_MapItemList) Close() {}
 //     return err
 //   }
 func (v *MapOfBinaryAndString) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_MapOfBinaryAndString)(v)), nil
+}
+
+type _fieldList_MapOfBinaryAndString MapOfBinaryAndString
+
+func (fl *_fieldList_MapOfBinaryAndString) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*MapOfBinaryAndString)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.BinaryToString != nil {
 		w, err = wire.NewValueMap(_Map_Binary_String_MapItemList(v.BinaryToString)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.StringToBinary != nil {
 		w, err = wire.NewValueMap(_Map_String_Binary_MapItemList(v.StringToBinary)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_MapOfBinaryAndString) Close() {}
 
 func _Map_Binary_String_Read(m wire.MapItemList) ([]struct {
 	Key   []byte
@@ -4149,64 +4245,84 @@ func (_Map_String_Bool_MapItemList) Close() {}
 //     return err
 //   }
 func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_PrimitiveContainers)(v)), nil
+}
+
+type _fieldList_PrimitiveContainers PrimitiveContainers
+
+func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [6]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*PrimitiveContainers)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.ListOfBinary != nil {
 		w, err = wire.NewValueList(_List_Binary_ValueList(v.ListOfBinary)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.ListOfInts != nil {
 		w, err = wire.NewValueList(_List_I64_ValueList(v.ListOfInts)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.SetOfStrings != nil {
 		w, err = wire.NewValueSet(_Set_String_mapType_ValueList(v.SetOfStrings)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.SetOfBytes != nil {
 		w, err = wire.NewValueSet(_Set_Byte_mapType_ValueList(v.SetOfBytes)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.MapOfIntToString != nil {
 		w, err = wire.NewValueMap(_Map_I32_String_MapItemList(v.MapOfIntToString)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.MapOfStringToBool != nil {
 		w, err = wire.NewValueMap(_Map_String_Bool_MapItemList(v.MapOfStringToBool)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 6, Value: w}
+		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_PrimitiveContainers) Close() {}
 
 func _List_Binary_Read(l wire.ValueList) ([][]byte, error) {
 	if l.ValueType() != wire.TBinary {
@@ -4789,40 +4905,54 @@ func (_Map_I64_Double_MapItemList) Close() {}
 //     return err
 //   }
 func (v *PrimitiveContainersRequired) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_PrimitiveContainersRequired)(v)), nil
+}
+
+type _fieldList_PrimitiveContainersRequired PrimitiveContainersRequired
+
+func (fl *_fieldList_PrimitiveContainersRequired) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [3]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*PrimitiveContainersRequired)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueList(_List_String_ValueList(v.ListOfStrings)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.SetOfInts == nil {
-		return w, errors.New("field SetOfInts of PrimitiveContainersRequired is required")
+		return errors.New("field SetOfInts of PrimitiveContainersRequired is required")
 	}
 	w, err = wire.NewValueSet(_Set_I32_mapType_ValueList(v.SetOfInts)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.MapOfIntsToDoubles == nil {
-		return w, errors.New("field MapOfIntsToDoubles of PrimitiveContainersRequired is required")
+		return errors.New("field MapOfIntsToDoubles of PrimitiveContainersRequired is required")
 	}
 	w, err = wire.NewValueMap(_Map_I64_Double_MapItemList(v.MapOfIntsToDoubles)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 3, Value: w}
+	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_PrimitiveContainersRequired) Close() {}
 
 func _Map_I64_Double_Read(m wire.MapItemList) (map[int64]float64, error) {
 	if m.KeyType() != wire.TI64 {

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -633,8 +633,7 @@ type _fieldList_ContainersOfContainers ContainersOfContainers
 
 func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ContainersOfContainers)(fl)
+		v   = (*ContainersOfContainers)(fl)
 		w   wire.Value
 		err error
 	)
@@ -647,7 +646,6 @@ func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.ListOfSets != nil {
 		w, err = wire.NewValueList(_List_Set_I32_mapType_ValueList(v.ListOfSets)), error(nil)
@@ -657,7 +655,6 @@ func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.ListOfMaps != nil {
 		w, err = wire.NewValueList(_List_Map_I32_I32_ValueList(v.ListOfMaps)), error(nil)
@@ -667,7 +664,6 @@ func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.SetOfSets != nil {
 		w, err = wire.NewValueSet(_Set_Set_String_mapType_sliceType_ValueList(v.SetOfSets)), error(nil)
@@ -677,7 +673,6 @@ func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.SetOfLists != nil {
 		w, err = wire.NewValueSet(_Set_List_String_sliceType_ValueList(v.SetOfLists)), error(nil)
@@ -687,7 +682,6 @@ func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.SetOfMaps != nil {
 		w, err = wire.NewValueSet(_Set_Map_String_String_sliceType_ValueList(v.SetOfMaps)), error(nil)
@@ -697,7 +691,6 @@ func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.MapOfMapToInt != nil {
 		w, err = wire.NewValueMap(_Map_Map_String_I32_I64_MapItemList(v.MapOfMapToInt)), error(nil)
@@ -707,7 +700,6 @@ func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.MapOfListToSet != nil {
 		w, err = wire.NewValueMap(_Map_List_I32_Set_I64_mapType_MapItemList(v.MapOfListToSet)), error(nil)
@@ -717,7 +709,6 @@ func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.MapOfSetToListOfDouble != nil {
 		w, err = wire.NewValueMap(_Map_Set_I32_mapType_List_Double_MapItemList(v.MapOfSetToListOfDouble)), error(nil)
@@ -727,7 +718,6 @@ func (fl *_fieldList_ContainersOfContainers) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 9, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -2253,8 +2243,7 @@ type _fieldList_EnumContainers EnumContainers
 
 func (fl *_fieldList_EnumContainers) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*EnumContainers)(fl)
+		v   = (*EnumContainers)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2267,7 +2256,6 @@ func (fl *_fieldList_EnumContainers) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.SetOfEnums != nil {
 		w, err = wire.NewValueSet(_Set_EnumWithValues_mapType_ValueList(v.SetOfEnums)), error(nil)
@@ -2277,7 +2265,6 @@ func (fl *_fieldList_EnumContainers) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.MapOfEnums != nil {
 		w, err = wire.NewValueMap(_Map_EnumWithDuplicateValues_I32_MapItemList(v.MapOfEnums)), error(nil)
@@ -2287,7 +2274,6 @@ func (fl *_fieldList_EnumContainers) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -2718,8 +2704,7 @@ type _fieldList_ListOfConflictingEnums ListOfConflictingEnums
 
 func (fl *_fieldList_ListOfConflictingEnums) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ListOfConflictingEnums)(fl)
+		v   = (*ListOfConflictingEnums)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2731,7 +2716,6 @@ func (fl *_fieldList_ListOfConflictingEnums) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueList(_List_RecordType_1_ValueList(v.OtherRecords)), error(nil)
 	if err != nil {
@@ -2740,7 +2724,6 @@ func (fl *_fieldList_ListOfConflictingEnums) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -3066,8 +3049,7 @@ type _fieldList_ListOfConflictingUUIDs ListOfConflictingUUIDs
 
 func (fl *_fieldList_ListOfConflictingUUIDs) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ListOfConflictingUUIDs)(fl)
+		v   = (*ListOfConflictingUUIDs)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3079,7 +3061,6 @@ func (fl *_fieldList_ListOfConflictingUUIDs) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueList(_List_UUID_1_ValueList(v.OtherUUIDs)), error(nil)
 	if err != nil {
@@ -3088,7 +3069,6 @@ func (fl *_fieldList_ListOfConflictingUUIDs) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -3358,8 +3338,7 @@ type _fieldList_ListOfOptionalPrimitives ListOfOptionalPrimitives
 
 func (fl *_fieldList_ListOfOptionalPrimitives) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ListOfOptionalPrimitives)(fl)
+		v   = (*ListOfOptionalPrimitives)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3372,7 +3351,6 @@ func (fl *_fieldList_ListOfOptionalPrimitives) ForEach(writeField func(wire.Fiel
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -3509,8 +3487,7 @@ type _fieldList_ListOfRequiredPrimitives ListOfRequiredPrimitives
 
 func (fl *_fieldList_ListOfRequiredPrimitives) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ListOfRequiredPrimitives)(fl)
+		v   = (*ListOfRequiredPrimitives)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3522,7 +3499,6 @@ func (fl *_fieldList_ListOfRequiredPrimitives) ForEach(writeField func(wire.Fiel
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -3744,8 +3720,7 @@ type _fieldList_MapOfBinaryAndString MapOfBinaryAndString
 
 func (fl *_fieldList_MapOfBinaryAndString) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*MapOfBinaryAndString)(fl)
+		v   = (*MapOfBinaryAndString)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3758,7 +3733,6 @@ func (fl *_fieldList_MapOfBinaryAndString) ForEach(writeField func(wire.Field) e
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.StringToBinary != nil {
 		w, err = wire.NewValueMap(_Map_String_Binary_MapItemList(v.StringToBinary)), error(nil)
@@ -3768,7 +3742,6 @@ func (fl *_fieldList_MapOfBinaryAndString) ForEach(writeField func(wire.Field) e
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -4252,8 +4225,7 @@ type _fieldList_PrimitiveContainers PrimitiveContainers
 
 func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*PrimitiveContainers)(fl)
+		v   = (*PrimitiveContainers)(fl)
 		w   wire.Value
 		err error
 	)
@@ -4266,7 +4238,6 @@ func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) er
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.ListOfInts != nil {
 		w, err = wire.NewValueList(_List_I64_ValueList(v.ListOfInts)), error(nil)
@@ -4276,7 +4247,6 @@ func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) er
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.SetOfStrings != nil {
 		w, err = wire.NewValueSet(_Set_String_mapType_ValueList(v.SetOfStrings)), error(nil)
@@ -4286,7 +4256,6 @@ func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) er
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.SetOfBytes != nil {
 		w, err = wire.NewValueSet(_Set_Byte_mapType_ValueList(v.SetOfBytes)), error(nil)
@@ -4296,7 +4265,6 @@ func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) er
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.MapOfIntToString != nil {
 		w, err = wire.NewValueMap(_Map_I32_String_MapItemList(v.MapOfIntToString)), error(nil)
@@ -4306,7 +4274,6 @@ func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) er
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.MapOfStringToBool != nil {
 		w, err = wire.NewValueMap(_Map_String_Bool_MapItemList(v.MapOfStringToBool)), error(nil)
@@ -4316,7 +4283,6 @@ func (fl *_fieldList_PrimitiveContainers) ForEach(writeField func(wire.Field) er
 		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -4912,8 +4878,7 @@ type _fieldList_PrimitiveContainersRequired PrimitiveContainersRequired
 
 func (fl *_fieldList_PrimitiveContainersRequired) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*PrimitiveContainersRequired)(fl)
+		v   = (*PrimitiveContainersRequired)(fl)
 		w   wire.Value
 		err error
 	)
@@ -4925,7 +4890,6 @@ func (fl *_fieldList_PrimitiveContainersRequired) ForEach(writeField func(wire.F
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.SetOfInts == nil {
 		return errors.New("field SetOfInts of PrimitiveContainersRequired is required")
 	}
@@ -4936,7 +4900,6 @@ func (fl *_fieldList_PrimitiveContainersRequired) ForEach(writeField func(wire.F
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.MapOfIntsToDoubles == nil {
 		return errors.New("field MapOfIntsToDoubles of PrimitiveContainersRequired is required")
 	}
@@ -4947,7 +4910,6 @@ func (fl *_fieldList_PrimitiveContainersRequired) ForEach(writeField func(wire.F
 	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -1144,9 +1144,9 @@ func _Map_Set_I32_mapType_List_Double_Read(m wire.MapItemList) ([]struct {
 //   }
 //   return &v, nil
 func (v *ContainersOfContainers) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -1221,7 +1221,12 @@ func (v *ContainersOfContainers) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -2351,9 +2356,9 @@ func _Map_EnumWithDuplicateValues_I32_Read(m wire.MapItemList) (map[enums.EnumWi
 //   }
 //   return &v, nil
 func (v *EnumContainers) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -2380,7 +2385,12 @@ func (v *EnumContainers) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -2751,12 +2761,12 @@ func _List_RecordType_1_Read(l wire.ValueList) ([]enums.RecordType, error) {
 //   }
 //   return &v, nil
 func (v *ListOfConflictingEnums) FromWire(w wire.Value) error {
-	var err error
 
 	recordsIsSet := false
 	otherRecordsIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -2775,7 +2785,12 @@ func (v *ListOfConflictingEnums) FromWire(w wire.Value) error {
 				otherRecordsIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !recordsIsSet {
 		return errors.New("field Records of ListOfConflictingEnums is required")
@@ -3082,12 +3097,12 @@ func _List_UUID_1_Read(l wire.ValueList) ([]uuid_conflict.UUID, error) {
 //   }
 //   return &v, nil
 func (v *ListOfConflictingUUIDs) FromWire(w wire.Value) error {
-	var err error
 
 	uuidsIsSet := false
 	otherUUIDsIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -3106,7 +3121,12 @@ func (v *ListOfConflictingUUIDs) FromWire(w wire.Value) error {
 				otherUUIDsIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !uuidsIsSet {
 		return errors.New("field Uuids of ListOfConflictingUUIDs is required")
@@ -3304,9 +3324,9 @@ func (v *ListOfOptionalPrimitives) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ListOfOptionalPrimitives) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -3317,7 +3337,12 @@ func (v *ListOfOptionalPrimitives) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -3438,11 +3463,11 @@ func (v *ListOfRequiredPrimitives) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ListOfRequiredPrimitives) FromWire(w wire.Value) error {
-	var err error
 
 	listOfStringsIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -3453,7 +3478,12 @@ func (v *ListOfRequiredPrimitives) FromWire(w wire.Value) error {
 				listOfStringsIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !listOfStringsIsSet {
 		return errors.New("field ListOfStrings of ListOfRequiredPrimitives is required")
@@ -3733,9 +3763,9 @@ func _Map_String_Binary_Read(m wire.MapItemList) (map[string][]byte, error) {
 //   }
 //   return &v, nil
 func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TMap {
@@ -3754,7 +3784,12 @@ func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -4302,9 +4337,9 @@ func _Map_String_Bool_Read(m wire.MapItemList) (map[string]bool, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveContainers) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -4355,7 +4390,12 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -4830,13 +4870,13 @@ func _Map_I64_Double_Read(m wire.MapItemList) (map[int64]float64, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveContainersRequired) FromWire(w wire.Value) error {
-	var err error
 
 	listOfStringsIsSet := false
 	setOfIntsIsSet := false
 	mapOfIntsToDoublesIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -4863,7 +4903,12 @@ func (v *PrimitiveContainersRequired) FromWire(w wire.Value) error {
 				mapOfIntsToDoublesIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !listOfStringsIsSet {
 		return errors.New("field ListOfStrings of PrimitiveContainersRequired is required")

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -230,11 +230,17 @@ func Default_Records() *Records {
 //     return err
 //   }
 func (v *Records) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Records)(v)), nil
+}
+
+type _fieldList_Records Records
+
+func (fl *_fieldList_Records) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Records)(fl)
+		w   wire.Value
+		err error
 	)
 
 	vRecordType := v.RecordType
@@ -244,9 +250,11 @@ func (v *Records) ToWire() (wire.Value, error) {
 	{
 		w, err = vRecordType.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vOtherRecordType := v.OtherRecordType
@@ -256,14 +264,18 @@ func (v *Records) ToWire() (wire.Value, error) {
 	{
 		w, err = vOtherRecordType.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Records) Close() {}
 
 func _RecordType_Read(w wire.Value) (RecordType, error) {
 	var v RecordType

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -237,8 +237,7 @@ type _fieldList_Records Records
 
 func (fl *_fieldList_Records) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Records)(fl)
+		v   = (*Records)(fl)
 		w   wire.Value
 		err error
 	)
@@ -255,7 +254,6 @@ func (fl *_fieldList_Records) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vOtherRecordType := v.OtherRecordType
 	if vOtherRecordType == nil {
@@ -269,7 +267,6 @@ func (fl *_fieldList_Records) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -295,9 +295,9 @@ func _RecordType_1_Read(w wire.Value) (enums.RecordType, error) {
 //   }
 //   return &v, nil
 func (v *Records) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
@@ -320,7 +320,12 @@ func (v *Records) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if v.RecordType == nil {
 		v.RecordType = _RecordType_ptr(DefaultRecordType)

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -1565,8 +1565,7 @@ type _fieldList_StructWithOptionalEnum StructWithOptionalEnum
 
 func (fl *_fieldList_StructWithOptionalEnum) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*StructWithOptionalEnum)(fl)
+		v   = (*StructWithOptionalEnum)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1579,7 +1578,6 @@ func (fl *_fieldList_StructWithOptionalEnum) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -1601,9 +1601,9 @@ func _EnumDefault_Read(w wire.Value) (EnumDefault, error) {
 //   }
 //   return &v, nil
 func (v *StructWithOptionalEnum) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
@@ -1616,7 +1616,12 @@ func (v *StructWithOptionalEnum) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -1558,24 +1558,34 @@ type StructWithOptionalEnum struct {
 //     return err
 //   }
 func (v *StructWithOptionalEnum) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_StructWithOptionalEnum)(v)), nil
+}
+
+type _fieldList_StructWithOptionalEnum StructWithOptionalEnum
+
+func (fl *_fieldList_StructWithOptionalEnum) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*StructWithOptionalEnum)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.E != nil {
 		w, err = v.E.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_StructWithOptionalEnum) Close() {}
 
 func _EnumDefault_Read(w wire.Value) (EnumDefault, error) {
 	var v EnumDefault

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -78,11 +78,11 @@ func (v *DoesNotExistException) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *DoesNotExistException) FromWire(w wire.Value) error {
-	var err error
 
 	keyIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -103,7 +103,12 @@ func (v *DoesNotExistException) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !keyIsSet {
 		return errors.New("field Key of DoesNotExistException is required")
@@ -273,11 +278,11 @@ func (v *DoesNotExistException2) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *DoesNotExistException2) FromWire(w wire.Value) error {
-	var err error
 
 	keyIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -298,7 +303,12 @@ func (v *DoesNotExistException2) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !keyIsSet {
 		return errors.New("field Key of DoesNotExistException2 is required")
@@ -439,10 +449,16 @@ func (v *EmptyException) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *EmptyException) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -35,30 +35,42 @@ type DoesNotExistException struct {
 //     return err
 //   }
 func (v *DoesNotExistException) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_DoesNotExistException)(v)), nil
+}
+
+type _fieldList_DoesNotExistException DoesNotExistException
+
+func (fl *_fieldList_DoesNotExistException) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*DoesNotExistException)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Key), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Error2 != nil {
 		w, err = wire.NewValueString(*(v.Error2)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_DoesNotExistException) Close() {}
 
 // FromWire deserializes a DoesNotExistException struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -235,30 +247,42 @@ type DoesNotExistException2 struct {
 //     return err
 //   }
 func (v *DoesNotExistException2) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_DoesNotExistException2)(v)), nil
+}
+
+type _fieldList_DoesNotExistException2 DoesNotExistException2
+
+func (fl *_fieldList_DoesNotExistException2) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*DoesNotExistException2)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Key), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Error2 != nil {
 		w, err = wire.NewValueString(*(v.Error2)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_DoesNotExistException2) Close() {}
 
 // FromWire deserializes a DoesNotExistException2 struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -422,13 +446,17 @@ type EmptyException struct {
 //     return err
 //   }
 func (v *EmptyException) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_EmptyException)(v)), nil
 }
+
+type _fieldList_EmptyException EmptyException
+
+func (fl *_fieldList_EmptyException) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_EmptyException) Close() {}
 
 // FromWire deserializes a EmptyException struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -42,8 +42,7 @@ type _fieldList_DoesNotExistException DoesNotExistException
 
 func (fl *_fieldList_DoesNotExistException) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*DoesNotExistException)(fl)
+		v   = (*DoesNotExistException)(fl)
 		w   wire.Value
 		err error
 	)
@@ -55,7 +54,6 @@ func (fl *_fieldList_DoesNotExistException) ForEach(writeField func(wire.Field) 
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Error2 != nil {
 		w, err = wire.NewValueString(*(v.Error2)), error(nil)
 		if err != nil {
@@ -64,7 +62,6 @@ func (fl *_fieldList_DoesNotExistException) ForEach(writeField func(wire.Field) 
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -254,8 +251,7 @@ type _fieldList_DoesNotExistException2 DoesNotExistException2
 
 func (fl *_fieldList_DoesNotExistException2) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*DoesNotExistException2)(fl)
+		v   = (*DoesNotExistException2)(fl)
 		w   wire.Value
 		err error
 	)
@@ -267,7 +263,6 @@ func (fl *_fieldList_DoesNotExistException2) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Error2 != nil {
 		w, err = wire.NewValueString(*(v.Error2)), error(nil)
 		if err != nil {
@@ -276,7 +271,6 @@ func (fl *_fieldList_DoesNotExistException2) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -78,11 +78,11 @@ func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
 //   }
 //   return &v, nil
 func (v *DocumentStruct) FromWire(w wire.Value) error {
-	var err error
 
 	secondIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -93,7 +93,12 @@ func (v *DocumentStruct) FromWire(w wire.Value) error {
 				secondIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !secondIsSet {
 		return errors.New("field Second of DocumentStruct is required")

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -34,25 +34,35 @@ type DocumentStruct struct {
 //     return err
 //   }
 func (v *DocumentStruct) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_DocumentStruct)(v)), nil
+}
+
+type _fieldList_DocumentStruct DocumentStruct
+
+func (fl *_fieldList_DocumentStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*DocumentStruct)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Second == nil {
-		return w, errors.New("field Second of DocumentStruct is required")
+		return errors.New("field Second of DocumentStruct is required")
 	}
 	w, err = v.Second.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_DocumentStruct) Close() {}
 
 func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
 	var v non_hyphenated.Second

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -41,8 +41,7 @@ type _fieldList_DocumentStruct DocumentStruct
 
 func (fl *_fieldList_DocumentStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*DocumentStruct)(fl)
+		v   = (*DocumentStruct)(fl)
 		w   wire.Value
 		err error
 	)
@@ -57,7 +56,6 @@ func (fl *_fieldList_DocumentStruct) ForEach(writeField func(wire.Field) error) 
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -78,11 +78,11 @@ func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
 //   }
 //   return &v, nil
 func (v *DocumentStructure) FromWire(w wire.Value) error {
-	var err error
 
 	r2IsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -93,7 +93,12 @@ func (v *DocumentStructure) FromWire(w wire.Value) error {
 				r2IsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !r2IsSet {
 		return errors.New("field R2 of DocumentStructure is required")

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -41,8 +41,7 @@ type _fieldList_DocumentStructure DocumentStructure
 
 func (fl *_fieldList_DocumentStructure) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*DocumentStructure)(fl)
+		v   = (*DocumentStructure)(fl)
 		w   wire.Value
 		err error
 	)
@@ -57,7 +56,6 @@ func (fl *_fieldList_DocumentStructure) ForEach(writeField func(wire.Field) erro
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -34,25 +34,35 @@ type DocumentStructure struct {
 //     return err
 //   }
 func (v *DocumentStructure) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_DocumentStructure)(v)), nil
+}
+
+type _fieldList_DocumentStructure DocumentStructure
+
+func (fl *_fieldList_DocumentStructure) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*DocumentStructure)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.R2 == nil {
-		return w, errors.New("field R2 of DocumentStructure is required")
+		return errors.New("field R2 of DocumentStructure is required")
 	}
 	w, err = v.R2.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_DocumentStructure) Close() {}
 
 func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
 	var v non_hyphenated.Second

--- a/gen/internal/tests/non_hyphenated/non_hyphenated.go
+++ b/gen/internal/tests/non_hyphenated/non_hyphenated.go
@@ -57,10 +57,16 @@ func (v *First) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *First) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -147,10 +153,16 @@ func (v *Second) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *Second) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }

--- a/gen/internal/tests/non_hyphenated/non_hyphenated.go
+++ b/gen/internal/tests/non_hyphenated/non_hyphenated.go
@@ -30,13 +30,17 @@ type First struct {
 //     return err
 //   }
 func (v *First) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_First)(v)), nil
 }
+
+type _fieldList_First First
+
+func (fl *_fieldList_First) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_First) Close() {}
 
 // FromWire deserializes a First struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -126,13 +130,17 @@ type Second struct {
 //     return err
 //   }
 func (v *Second) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_Second)(v)), nil
 }
+
+type _fieldList_Second Second
+
+func (fl *_fieldList_Second) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_Second) Close() {}
 
 // FromWire deserializes a Second struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -299,98 +299,128 @@ func (_Map_I64_Double_MapItemList) Close() {}
 //     return err
 //   }
 func (v *PrimitiveRequiredStruct) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_PrimitiveRequiredStruct)(v)), nil
+}
+
+type _fieldList_PrimitiveRequiredStruct PrimitiveRequiredStruct
+
+func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [11]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*PrimitiveRequiredStruct)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueBool(v.BoolField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI8(v.ByteField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI16(v.Int16Field), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 3, Value: w}
+	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI32(v.Int32Field), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 4, Value: w}
+	if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI64(v.Int64Field), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 5, Value: w}
+	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueDouble(v.DoubleField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 6, Value: w}
+	if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.StringField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 7, Value: w}
+	if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.BinaryField == nil {
-		return w, errors.New("field BinaryField of PrimitiveRequiredStruct is required")
+		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
 	}
 	w, err = wire.NewValueBinary(v.BinaryField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 8, Value: w}
+	if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueList(_List_String_ValueList(v.ListOfStrings)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 9, Value: w}
+	if err := writeField(wire.Field{ID: 9, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.SetOfInts == nil {
-		return w, errors.New("field SetOfInts of PrimitiveRequiredStruct is required")
+		return errors.New("field SetOfInts of PrimitiveRequiredStruct is required")
 	}
 	w, err = wire.NewValueSet(_Set_I32_mapType_ValueList(v.SetOfInts)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 10, Value: w}
+	if err := writeField(wire.Field{ID: 10, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.MapOfIntsToDoubles == nil {
-		return w, errors.New("field MapOfIntsToDoubles of PrimitiveRequiredStruct is required")
+		return errors.New("field MapOfIntsToDoubles of PrimitiveRequiredStruct is required")
 	}
 	w, err = wire.NewValueMap(_Map_I64_Double_MapItemList(v.MapOfIntsToDoubles)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 11, Value: w}
+	if err := writeField(wire.Field{ID: 11, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_PrimitiveRequiredStruct) Close() {}
 
 func _List_String_Read(l wire.ValueList) ([]string, error) {
 	if l.ValueType() != wire.TBinary {

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -306,8 +306,7 @@ type _fieldList_PrimitiveRequiredStruct PrimitiveRequiredStruct
 
 func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*PrimitiveRequiredStruct)(fl)
+		v   = (*PrimitiveRequiredStruct)(fl)
 		w   wire.Value
 		err error
 	)
@@ -319,7 +318,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI8(v.ByteField), error(nil)
 	if err != nil {
@@ -328,7 +326,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI16(v.Int16Field), error(nil)
 	if err != nil {
@@ -337,7 +334,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI32(v.Int32Field), error(nil)
 	if err != nil {
@@ -346,7 +342,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI64(v.Int64Field), error(nil)
 	if err != nil {
@@ -355,7 +350,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueDouble(v.DoubleField), error(nil)
 	if err != nil {
@@ -364,7 +358,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.StringField), error(nil)
 	if err != nil {
@@ -373,7 +366,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.BinaryField == nil {
 		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
 	}
@@ -384,7 +376,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueList(_List_String_ValueList(v.ListOfStrings)), error(nil)
 	if err != nil {
@@ -393,7 +384,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 9, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.SetOfInts == nil {
 		return errors.New("field SetOfInts of PrimitiveRequiredStruct is required")
 	}
@@ -404,7 +394,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 10, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.MapOfIntsToDoubles == nil {
 		return errors.New("field MapOfIntsToDoubles of PrimitiveRequiredStruct is required")
 	}
@@ -415,7 +404,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 11, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -475,7 +475,6 @@ func _Map_I64_Double_Read(m wire.MapItemList) (map[int64]float64, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
-	var err error
 
 	boolFieldIsSet := false
 	byteFieldIsSet := false
@@ -489,7 +488,8 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	setOfIntsIsSet := false
 	mapOfIntsToDoublesIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
@@ -580,7 +580,12 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 				mapOfIntsToDoublesIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !boolFieldIsSet {
 		return errors.New("field BoolField of PrimitiveRequiredStruct is required")

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -82,12 +82,12 @@ func (v *ConflictingNamesSetValueArgs) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ConflictingNamesSetValueArgs) FromWire(w wire.Value) error {
-	var err error
 
 	keyIsSet := false
 	valueIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -106,7 +106,12 @@ func (v *ConflictingNamesSetValueArgs) FromWire(w wire.Value) error {
 				valueIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !keyIsSet {
 		return errors.New("field Key of ConflictingNamesSetValueArgs is required")
@@ -247,9 +252,9 @@ func (v *InternalError) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *InternalError) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -262,7 +267,12 @@ func (v *InternalError) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -448,10 +458,16 @@ func (v *Cache_Clear_Args) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *Cache_Clear_Args) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -583,9 +599,9 @@ func (v *Cache_ClearAfter_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Cache_ClearAfter_Args) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI64 {
@@ -598,7 +614,12 @@ func (v *Cache_ClearAfter_Args) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -777,9 +798,9 @@ func _ConflictingNamesSetValueArgs_Read(w wire.Value) (*ConflictingNamesSetValue
 //   }
 //   return &v, nil
 func (v *ConflictingNames_SetValue_Args) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -790,7 +811,12 @@ func (v *ConflictingNames_SetValue_Args) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -995,10 +1021,16 @@ func (v *ConflictingNames_SetValue_Result) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *ConflictingNames_SetValue_Result) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -1120,9 +1152,9 @@ func _Key_Read(w wire.Value) (Key, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_DeleteValue_Args) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -1135,7 +1167,12 @@ func (v *KeyValue_DeleteValue_Args) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -1412,9 +1449,9 @@ func _InternalError_Read(w wire.Value) (*InternalError, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -1433,7 +1470,12 @@ func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.DoesNotExist != nil {
@@ -1654,9 +1696,9 @@ func _List_Key_Read(l wire.ValueList) ([]Key, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_GetManyValues_Args) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -1667,7 +1709,12 @@ func (v *KeyValue_GetManyValues_Args) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -1998,9 +2045,9 @@ func _List_ArbitraryValue_Read(l wire.ValueList) ([]*unions.ArbitraryValue, erro
 //   }
 //   return &v, nil
 func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 0:
 			if field.Value.Type() == wire.TList {
@@ -2019,7 +2066,12 @@ func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.Success != nil {
@@ -2222,9 +2274,9 @@ func (v *KeyValue_GetValue_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_GetValue_Args) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -2237,7 +2289,12 @@ func (v *KeyValue_GetValue_Args) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -2489,9 +2546,9 @@ func (v *KeyValue_GetValue_Result) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 0:
 			if field.Value.Type() == wire.TStruct {
@@ -2510,7 +2567,12 @@ func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.Success != nil {
@@ -2696,9 +2758,9 @@ func (v *KeyValue_SetValue_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -2719,7 +2781,12 @@ func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -2952,10 +3019,16 @@ func (v *KeyValue_SetValue_Result) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *KeyValue_SetValue_Result) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -3083,12 +3156,12 @@ func (v *KeyValue_SetValueV2_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
-	var err error
 
 	keyIsSet := false
 	valueIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -3107,7 +3180,12 @@ func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
 				valueIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !keyIsSet {
 		return errors.New("field Key of KeyValue_SetValueV2_Args is required")
@@ -3333,10 +3411,16 @@ func (v *KeyValue_SetValueV2_Result) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *KeyValue_SetValueV2_Result) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -3441,10 +3525,16 @@ func (v *KeyValue_Size_Args) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *KeyValue_Size_Args) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -3642,9 +3732,9 @@ func (v *KeyValue_Size_Result) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_Size_Result) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 0:
 			if field.Value.Type() == wire.TI64 {
@@ -3657,7 +3747,12 @@ func (v *KeyValue_Size_Result) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.Success != nil {
@@ -3795,10 +3890,16 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) ToWire() (wire.Val
 //   return &v, nil
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -3972,10 +4073,16 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) ToWire() (wire.V
 //   return &v, nil
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -45,8 +45,7 @@ type _fieldList_ConflictingNamesSetValueArgs ConflictingNamesSetValueArgs
 
 func (fl *_fieldList_ConflictingNamesSetValueArgs) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ConflictingNamesSetValueArgs)(fl)
+		v   = (*ConflictingNamesSetValueArgs)(fl)
 		w   wire.Value
 		err error
 	)
@@ -58,7 +57,6 @@ func (fl *_fieldList_ConflictingNamesSetValueArgs) ForEach(writeField func(wire.
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Value == nil {
 		return errors.New("field Value of ConflictingNamesSetValueArgs is required")
 	}
@@ -69,7 +67,6 @@ func (fl *_fieldList_ConflictingNamesSetValueArgs) ForEach(writeField func(wire.
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -234,8 +231,7 @@ type _fieldList_InternalError InternalError
 
 func (fl *_fieldList_InternalError) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*InternalError)(fl)
+		v   = (*InternalError)(fl)
 		w   wire.Value
 		err error
 	)
@@ -248,7 +244,6 @@ func (fl *_fieldList_InternalError) ForEach(writeField func(wire.Field) error) e
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -595,8 +590,7 @@ type _fieldList_Cache_ClearAfter_Args Cache_ClearAfter_Args
 
 func (fl *_fieldList_Cache_ClearAfter_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Cache_ClearAfter_Args)(fl)
+		v   = (*Cache_ClearAfter_Args)(fl)
 		w   wire.Value
 		err error
 	)
@@ -609,7 +603,6 @@ func (fl *_fieldList_Cache_ClearAfter_Args) ForEach(writeField func(wire.Field) 
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -798,8 +791,7 @@ type _fieldList_ConflictingNames_SetValue_Args ConflictingNames_SetValue_Args
 
 func (fl *_fieldList_ConflictingNames_SetValue_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ConflictingNames_SetValue_Args)(fl)
+		v   = (*ConflictingNames_SetValue_Args)(fl)
 		w   wire.Value
 		err error
 	)
@@ -812,7 +804,6 @@ func (fl *_fieldList_ConflictingNames_SetValue_Args) ForEach(writeField func(wir
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -1166,8 +1157,7 @@ type _fieldList_KeyValue_DeleteValue_Args KeyValue_DeleteValue_Args
 
 func (fl *_fieldList_KeyValue_DeleteValue_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*KeyValue_DeleteValue_Args)(fl)
+		v   = (*KeyValue_DeleteValue_Args)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1180,7 +1170,6 @@ func (fl *_fieldList_KeyValue_DeleteValue_Args) ForEach(writeField func(wire.Fie
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -1448,6 +1437,18 @@ type KeyValue_DeleteValue_Result struct {
 //     return err
 //   }
 func (v *KeyValue_DeleteValue_Result) ToWire() (wire.Value, error) {
+	var i int
+	if v.DoesNotExist != nil {
+		i++
+	}
+	if v.InternalError != nil {
+		i++
+	}
+
+	if i > 1 {
+		return wire.Value{}, fmt.Errorf("KeyValue_DeleteValue_Result should have at most one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_KeyValue_DeleteValue_Result)(v)), nil
 }
 
@@ -1455,8 +1456,7 @@ type _fieldList_KeyValue_DeleteValue_Result KeyValue_DeleteValue_Result
 
 func (fl *_fieldList_KeyValue_DeleteValue_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*KeyValue_DeleteValue_Result)(fl)
+		v   = (*KeyValue_DeleteValue_Result)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1469,7 +1469,6 @@ func (fl *_fieldList_KeyValue_DeleteValue_Result) ForEach(writeField func(wire.F
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.InternalError != nil {
 		w, err = v.InternalError.ToWire()
@@ -1479,11 +1478,6 @@ func (fl *_fieldList_KeyValue_DeleteValue_Result) ForEach(writeField func(wire.F
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i > 1 {
-		return fmt.Errorf("KeyValue_DeleteValue_Result should have at most one field: got %v fields", i)
 	}
 
 	return nil
@@ -1720,8 +1714,7 @@ type _fieldList_KeyValue_GetManyValues_Args KeyValue_GetManyValues_Args
 
 func (fl *_fieldList_KeyValue_GetManyValues_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*KeyValue_GetManyValues_Args)(fl)
+		v   = (*KeyValue_GetManyValues_Args)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1734,7 +1727,6 @@ func (fl *_fieldList_KeyValue_GetManyValues_Args) ForEach(writeField func(wire.F
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -2054,6 +2046,18 @@ func (_List_ArbitraryValue_ValueList) Close() {}
 //     return err
 //   }
 func (v *KeyValue_GetManyValues_Result) ToWire() (wire.Value, error) {
+	var i int
+	if v.Success != nil {
+		i++
+	}
+	if v.DoesNotExist != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("KeyValue_GetManyValues_Result should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_KeyValue_GetManyValues_Result)(v)), nil
 }
 
@@ -2061,8 +2065,7 @@ type _fieldList_KeyValue_GetManyValues_Result KeyValue_GetManyValues_Result
 
 func (fl *_fieldList_KeyValue_GetManyValues_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*KeyValue_GetManyValues_Result)(fl)
+		v   = (*KeyValue_GetManyValues_Result)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2075,7 +2078,6 @@ func (fl *_fieldList_KeyValue_GetManyValues_Result) ForEach(writeField func(wire
 		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.DoesNotExist != nil {
 		w, err = v.DoesNotExist.ToWire()
@@ -2085,11 +2087,6 @@ func (fl *_fieldList_KeyValue_GetManyValues_Result) ForEach(writeField func(wire
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("KeyValue_GetManyValues_Result should have exactly one field: got %v fields", i)
 	}
 
 	return nil
@@ -2338,8 +2335,7 @@ type _fieldList_KeyValue_GetValue_Args KeyValue_GetValue_Args
 
 func (fl *_fieldList_KeyValue_GetValue_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*KeyValue_GetValue_Args)(fl)
+		v   = (*KeyValue_GetValue_Args)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2352,7 +2348,6 @@ func (fl *_fieldList_KeyValue_GetValue_Args) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -2601,6 +2596,18 @@ type KeyValue_GetValue_Result struct {
 //     return err
 //   }
 func (v *KeyValue_GetValue_Result) ToWire() (wire.Value, error) {
+	var i int
+	if v.Success != nil {
+		i++
+	}
+	if v.DoesNotExist != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("KeyValue_GetValue_Result should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_KeyValue_GetValue_Result)(v)), nil
 }
 
@@ -2608,8 +2615,7 @@ type _fieldList_KeyValue_GetValue_Result KeyValue_GetValue_Result
 
 func (fl *_fieldList_KeyValue_GetValue_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*KeyValue_GetValue_Result)(fl)
+		v   = (*KeyValue_GetValue_Result)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2622,7 +2628,6 @@ func (fl *_fieldList_KeyValue_GetValue_Result) ForEach(writeField func(wire.Fiel
 		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.DoesNotExist != nil {
 		w, err = v.DoesNotExist.ToWire()
@@ -2632,11 +2637,6 @@ func (fl *_fieldList_KeyValue_GetValue_Result) ForEach(writeField func(wire.Fiel
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("KeyValue_GetValue_Result should have exactly one field: got %v fields", i)
 	}
 
 	return nil
@@ -2836,8 +2836,7 @@ type _fieldList_KeyValue_SetValue_Args KeyValue_SetValue_Args
 
 func (fl *_fieldList_KeyValue_SetValue_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*KeyValue_SetValue_Args)(fl)
+		v   = (*KeyValue_SetValue_Args)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2850,7 +2849,6 @@ func (fl *_fieldList_KeyValue_SetValue_Args) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Value != nil {
 		w, err = v.Value.ToWire()
@@ -2860,7 +2858,6 @@ func (fl *_fieldList_KeyValue_SetValue_Args) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -3251,8 +3248,7 @@ type _fieldList_KeyValue_SetValueV2_Args KeyValue_SetValueV2_Args
 
 func (fl *_fieldList_KeyValue_SetValueV2_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*KeyValue_SetValueV2_Args)(fl)
+		v   = (*KeyValue_SetValueV2_Args)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3264,7 +3260,6 @@ func (fl *_fieldList_KeyValue_SetValueV2_Args) ForEach(writeField func(wire.Fiel
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Value == nil {
 		return errors.New("field Value of KeyValue_SetValueV2_Args is required")
 	}
@@ -3275,7 +3270,6 @@ func (fl *_fieldList_KeyValue_SetValueV2_Args) ForEach(writeField func(wire.Fiel
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -3843,6 +3837,15 @@ type KeyValue_Size_Result struct {
 //     return err
 //   }
 func (v *KeyValue_Size_Result) ToWire() (wire.Value, error) {
+	var i int
+	if v.Success != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("KeyValue_Size_Result should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_KeyValue_Size_Result)(v)), nil
 }
 
@@ -3850,8 +3853,7 @@ type _fieldList_KeyValue_Size_Result KeyValue_Size_Result
 
 func (fl *_fieldList_KeyValue_Size_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*KeyValue_Size_Result)(fl)
+		v   = (*KeyValue_Size_Result)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3864,11 +3866,6 @@ func (fl *_fieldList_KeyValue_Size_Result) ForEach(writeField func(wire.Field) e
 		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("KeyValue_Size_Result should have exactly one field: got %v fields", i)
 	}
 
 	return nil

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -38,31 +38,43 @@ type ConflictingNamesSetValueArgs struct {
 //     return err
 //   }
 func (v *ConflictingNamesSetValueArgs) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ConflictingNamesSetValueArgs)(v)), nil
+}
+
+type _fieldList_ConflictingNamesSetValueArgs ConflictingNamesSetValueArgs
+
+func (fl *_fieldList_ConflictingNamesSetValueArgs) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ConflictingNamesSetValueArgs)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Key), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Value == nil {
-		return w, errors.New("field Value of ConflictingNamesSetValueArgs is required")
+		return errors.New("field Value of ConflictingNamesSetValueArgs is required")
 	}
 	w, err = wire.NewValueBinary(v.Value), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ConflictingNamesSetValueArgs) Close() {}
 
 // FromWire deserializes a ConflictingNamesSetValueArgs struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -215,24 +227,34 @@ type InternalError struct {
 //     return err
 //   }
 func (v *InternalError) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_InternalError)(v)), nil
+}
+
+type _fieldList_InternalError InternalError
+
+func (fl *_fieldList_InternalError) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*InternalError)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Message != nil {
 		w, err = wire.NewValueString(*(v.Message)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_InternalError) Close() {}
 
 // FromWire deserializes a InternalError struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -431,13 +453,17 @@ type Cache_Clear_Args struct {
 //     return err
 //   }
 func (v *Cache_Clear_Args) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_Cache_Clear_Args)(v)), nil
 }
+
+type _fieldList_Cache_Clear_Args Cache_Clear_Args
+
+func (fl *_fieldList_Cache_Clear_Args) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_Cache_Clear_Args) Close() {}
 
 // FromWire deserializes a Cache_Clear_Args struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -562,24 +588,34 @@ type Cache_ClearAfter_Args struct {
 //     return err
 //   }
 func (v *Cache_ClearAfter_Args) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Cache_ClearAfter_Args)(v)), nil
+}
+
+type _fieldList_Cache_ClearAfter_Args Cache_ClearAfter_Args
+
+func (fl *_fieldList_Cache_ClearAfter_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Cache_ClearAfter_Args)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.DurationMS != nil {
 		w, err = wire.NewValueI64(*(v.DurationMS)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Cache_ClearAfter_Args) Close() {}
 
 // FromWire deserializes a Cache_ClearAfter_Args struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -755,24 +791,34 @@ type ConflictingNames_SetValue_Args struct {
 //     return err
 //   }
 func (v *ConflictingNames_SetValue_Args) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ConflictingNames_SetValue_Args)(v)), nil
+}
+
+type _fieldList_ConflictingNames_SetValue_Args ConflictingNames_SetValue_Args
+
+func (fl *_fieldList_ConflictingNames_SetValue_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ConflictingNames_SetValue_Args)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Request != nil {
 		w, err = v.Request.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ConflictingNames_SetValue_Args) Close() {}
 
 func _ConflictingNamesSetValueArgs_Read(w wire.Value) (*ConflictingNamesSetValueArgs, error) {
 	var v ConflictingNamesSetValueArgs
@@ -994,13 +1040,17 @@ type ConflictingNames_SetValue_Result struct {
 //     return err
 //   }
 func (v *ConflictingNames_SetValue_Result) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_ConflictingNames_SetValue_Result)(v)), nil
 }
+
+type _fieldList_ConflictingNames_SetValue_Result ConflictingNames_SetValue_Result
+
+func (fl *_fieldList_ConflictingNames_SetValue_Result) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_ConflictingNames_SetValue_Result) Close() {}
 
 // FromWire deserializes a ConflictingNames_SetValue_Result struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -1109,24 +1159,34 @@ type KeyValue_DeleteValue_Args struct {
 //     return err
 //   }
 func (v *KeyValue_DeleteValue_Args) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_KeyValue_DeleteValue_Args)(v)), nil
+}
+
+type _fieldList_KeyValue_DeleteValue_Args KeyValue_DeleteValue_Args
+
+func (fl *_fieldList_KeyValue_DeleteValue_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*KeyValue_DeleteValue_Args)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Key != nil {
 		w, err = v.Key.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_KeyValue_DeleteValue_Args) Close() {}
 
 func _Key_Read(w wire.Value) (Key, error) {
 	var x Key
@@ -1388,36 +1448,48 @@ type KeyValue_DeleteValue_Result struct {
 //     return err
 //   }
 func (v *KeyValue_DeleteValue_Result) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_KeyValue_DeleteValue_Result)(v)), nil
+}
+
+type _fieldList_KeyValue_DeleteValue_Result KeyValue_DeleteValue_Result
+
+func (fl *_fieldList_KeyValue_DeleteValue_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*KeyValue_DeleteValue_Result)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.DoesNotExist != nil {
 		w, err = v.DoesNotExist.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.InternalError != nil {
 		w, err = v.InternalError.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i > 1 {
-		return wire.Value{}, fmt.Errorf("KeyValue_DeleteValue_Result should have at most one field: got %v fields", i)
+		return fmt.Errorf("KeyValue_DeleteValue_Result should have at most one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_KeyValue_DeleteValue_Result) Close() {}
 
 func _DoesNotExistException_Read(w wire.Value) (*exceptions.DoesNotExistException, error) {
 	var v exceptions.DoesNotExistException
@@ -1641,24 +1713,34 @@ func (_List_Key_ValueList) Close() {}
 //     return err
 //   }
 func (v *KeyValue_GetManyValues_Args) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_KeyValue_GetManyValues_Args)(v)), nil
+}
+
+type _fieldList_KeyValue_GetManyValues_Args KeyValue_GetManyValues_Args
+
+func (fl *_fieldList_KeyValue_GetManyValues_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*KeyValue_GetManyValues_Args)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Range != nil {
 		w, err = wire.NewValueList(_List_Key_ValueList(v.Range)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_KeyValue_GetManyValues_Args) Close() {}
 
 func _List_Key_Read(l wire.ValueList) ([]Key, error) {
 	if l.ValueType() != wire.TBinary {
@@ -1972,36 +2054,48 @@ func (_List_ArbitraryValue_ValueList) Close() {}
 //     return err
 //   }
 func (v *KeyValue_GetManyValues_Result) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_KeyValue_GetManyValues_Result)(v)), nil
+}
+
+type _fieldList_KeyValue_GetManyValues_Result KeyValue_GetManyValues_Result
+
+func (fl *_fieldList_KeyValue_GetManyValues_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*KeyValue_GetManyValues_Result)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Success != nil {
 		w, err = wire.NewValueList(_List_ArbitraryValue_ValueList(v.Success)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 0, Value: w}
+		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.DoesNotExist != nil {
 		w, err = v.DoesNotExist.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("KeyValue_GetManyValues_Result should have exactly one field: got %v fields", i)
+		return fmt.Errorf("KeyValue_GetManyValues_Result should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_KeyValue_GetManyValues_Result) Close() {}
 
 func _ArbitraryValue_Read(w wire.Value) (*unions.ArbitraryValue, error) {
 	var v unions.ArbitraryValue
@@ -2237,24 +2331,34 @@ type KeyValue_GetValue_Args struct {
 //     return err
 //   }
 func (v *KeyValue_GetValue_Args) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_KeyValue_GetValue_Args)(v)), nil
+}
+
+type _fieldList_KeyValue_GetValue_Args KeyValue_GetValue_Args
+
+func (fl *_fieldList_KeyValue_GetValue_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*KeyValue_GetValue_Args)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Key != nil {
 		w, err = v.Key.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_KeyValue_GetValue_Args) Close() {}
 
 // FromWire deserializes a KeyValue_GetValue_Args struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -2497,36 +2601,48 @@ type KeyValue_GetValue_Result struct {
 //     return err
 //   }
 func (v *KeyValue_GetValue_Result) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_KeyValue_GetValue_Result)(v)), nil
+}
+
+type _fieldList_KeyValue_GetValue_Result KeyValue_GetValue_Result
+
+func (fl *_fieldList_KeyValue_GetValue_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*KeyValue_GetValue_Result)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Success != nil {
 		w, err = v.Success.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 0, Value: w}
+		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.DoesNotExist != nil {
 		w, err = v.DoesNotExist.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("KeyValue_GetValue_Result should have exactly one field: got %v fields", i)
+		return fmt.Errorf("KeyValue_GetValue_Result should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_KeyValue_GetValue_Result) Close() {}
 
 // FromWire deserializes a KeyValue_GetValue_Result struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -2713,32 +2829,44 @@ type KeyValue_SetValue_Args struct {
 //     return err
 //   }
 func (v *KeyValue_SetValue_Args) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_KeyValue_SetValue_Args)(v)), nil
+}
+
+type _fieldList_KeyValue_SetValue_Args KeyValue_SetValue_Args
+
+func (fl *_fieldList_KeyValue_SetValue_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*KeyValue_SetValue_Args)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Key != nil {
 		w, err = v.Key.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Value != nil {
 		w, err = v.Value.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_KeyValue_SetValue_Args) Close() {}
 
 // FromWire deserializes a KeyValue_SetValue_Args struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -2992,13 +3120,17 @@ type KeyValue_SetValue_Result struct {
 //     return err
 //   }
 func (v *KeyValue_SetValue_Result) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_KeyValue_SetValue_Result)(v)), nil
 }
+
+type _fieldList_KeyValue_SetValue_Result KeyValue_SetValue_Result
+
+func (fl *_fieldList_KeyValue_SetValue_Result) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_KeyValue_SetValue_Result) Close() {}
 
 // FromWire deserializes a KeyValue_SetValue_Result struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3112,31 +3244,43 @@ type KeyValue_SetValueV2_Args struct {
 //     return err
 //   }
 func (v *KeyValue_SetValueV2_Args) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_KeyValue_SetValueV2_Args)(v)), nil
+}
+
+type _fieldList_KeyValue_SetValueV2_Args KeyValue_SetValueV2_Args
+
+func (fl *_fieldList_KeyValue_SetValueV2_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*KeyValue_SetValueV2_Args)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = v.Key.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Value == nil {
-		return w, errors.New("field Value of KeyValue_SetValueV2_Args is required")
+		return errors.New("field Value of KeyValue_SetValueV2_Args is required")
 	}
 	w, err = v.Value.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_KeyValue_SetValueV2_Args) Close() {}
 
 // FromWire deserializes a KeyValue_SetValueV2_Args struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3384,13 +3528,17 @@ type KeyValue_SetValueV2_Result struct {
 //     return err
 //   }
 func (v *KeyValue_SetValueV2_Result) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_KeyValue_SetValueV2_Result)(v)), nil
 }
+
+type _fieldList_KeyValue_SetValueV2_Result KeyValue_SetValueV2_Result
+
+func (fl *_fieldList_KeyValue_SetValueV2_Result) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_KeyValue_SetValueV2_Result) Close() {}
 
 // FromWire deserializes a KeyValue_SetValueV2_Result struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3498,13 +3646,17 @@ type KeyValue_Size_Args struct {
 //     return err
 //   }
 func (v *KeyValue_Size_Args) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_KeyValue_Size_Args)(v)), nil
 }
+
+type _fieldList_KeyValue_Size_Args KeyValue_Size_Args
+
+func (fl *_fieldList_KeyValue_Size_Args) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_KeyValue_Size_Args) Close() {}
 
 // FromWire deserializes a KeyValue_Size_Args struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3691,28 +3843,38 @@ type KeyValue_Size_Result struct {
 //     return err
 //   }
 func (v *KeyValue_Size_Result) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_KeyValue_Size_Result)(v)), nil
+}
+
+type _fieldList_KeyValue_Size_Result KeyValue_Size_Result
+
+func (fl *_fieldList_KeyValue_Size_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*KeyValue_Size_Result)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Success != nil {
 		w, err = wire.NewValueI64(*(v.Success)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 0, Value: w}
+		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("KeyValue_Size_Result should have exactly one field: got %v fields", i)
+		return fmt.Errorf("KeyValue_Size_Result should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_KeyValue_Size_Result) Close() {}
 
 // FromWire deserializes a KeyValue_Size_Result struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3863,13 +4025,17 @@ type NonStandardServiceName_NonStandardFunctionName_Args struct {
 //     return err
 //   }
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_NonStandardServiceName_NonStandardFunctionName_Args)(v)), nil
 }
+
+type _fieldList_NonStandardServiceName_NonStandardFunctionName_Args NonStandardServiceName_NonStandardFunctionName_Args
+
+func (fl *_fieldList_NonStandardServiceName_NonStandardFunctionName_Args) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_NonStandardServiceName_NonStandardFunctionName_Args) Close() {}
 
 // FromWire deserializes a NonStandardServiceName_NonStandardFunctionName_Args struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -4046,13 +4212,17 @@ type NonStandardServiceName_NonStandardFunctionName_Result struct {
 //     return err
 //   }
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_NonStandardServiceName_NonStandardFunctionName_Result)(v)), nil
 }
+
+type _fieldList_NonStandardServiceName_NonStandardFunctionName_Result NonStandardServiceName_NonStandardFunctionName_Result
+
+func (fl *_fieldList_NonStandardServiceName_NonStandardFunctionName_Result) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_NonStandardServiceName_NonStandardFunctionName_Result) Close() {}
 
 // FromWire deserializes a NonStandardServiceName_NonStandardFunctionName_Result struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -217,102 +217,130 @@ func (_Set_Set_String_sliceType_sliceType_ValueList) Close() {}
 //     return err
 //   }
 func (v *Bar) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Bar)(v)), nil
+}
+
+type _fieldList_Bar Bar
+
+func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [10]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Bar)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.RequiredInt32ListField == nil {
-		return w, errors.New("field RequiredInt32ListField of Bar is required")
+		return errors.New("field RequiredInt32ListField of Bar is required")
 	}
 	w, err = wire.NewValueSet(_Set_I32_sliceType_ValueList(v.RequiredInt32ListField)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.OptionalStringListField != nil {
 		w, err = wire.NewValueSet(_Set_String_sliceType_ValueList(v.OptionalStringListField)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.RequiredTypedefStringListField == nil {
-		return w, errors.New("field RequiredTypedefStringListField of Bar is required")
+		return errors.New("field RequiredTypedefStringListField of Bar is required")
 	}
 	w, err = v.RequiredTypedefStringListField.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 3, Value: w}
+	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.OptionalTypedefStringListField != nil {
 		w, err = v.OptionalTypedefStringListField.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.RequiredFooListField == nil {
-		return w, errors.New("field RequiredFooListField of Bar is required")
+		return errors.New("field RequiredFooListField of Bar is required")
 	}
 	w, err = wire.NewValueSet(_Set_Foo_sliceType_ValueList(v.RequiredFooListField)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 5, Value: w}
+	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.OptionalFooListField != nil {
 		w, err = wire.NewValueSet(_Set_Foo_sliceType_ValueList(v.OptionalFooListField)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 6, Value: w}
+		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.RequiredTypedefFooListField == nil {
-		return w, errors.New("field RequiredTypedefFooListField of Bar is required")
+		return errors.New("field RequiredTypedefFooListField of Bar is required")
 	}
 	w, err = v.RequiredTypedefFooListField.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 7, Value: w}
+	if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.OptionalTypedefFooListField != nil {
 		w, err = v.OptionalTypedefFooListField.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 8, Value: w}
+		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.RequiredStringListListField == nil {
-		return w, errors.New("field RequiredStringListListField of Bar is required")
+		return errors.New("field RequiredStringListListField of Bar is required")
 	}
 	w, err = wire.NewValueSet(_Set_Set_String_sliceType_sliceType_ValueList(v.RequiredStringListListField)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 9, Value: w}
+	if err := writeField(wire.Field{ID: 9, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.RequiredTypedefStringListListField == nil {
-		return w, errors.New("field RequiredTypedefStringListListField of Bar is required")
+		return errors.New("field RequiredTypedefStringListListField of Bar is required")
 	}
 	w, err = v.RequiredTypedefStringListListField.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 10, Value: w}
+	if err := writeField(wire.Field{ID: 10, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Bar) Close() {}
 
 func _Set_I32_sliceType_Read(s wire.ValueList) ([]int32, error) {
 	if s.ValueType() != wire.TI32 {
@@ -955,22 +983,32 @@ type Foo struct {
 //     return err
 //   }
 func (v *Foo) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Foo)(v)), nil
+}
+
+type _fieldList_Foo Foo
+
+func (fl *_fieldList_Foo) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Foo)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.StringField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Foo) Close() {}
 
 // FromWire deserializes a Foo struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -224,8 +224,7 @@ type _fieldList_Bar Bar
 
 func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Bar)(fl)
+		v   = (*Bar)(fl)
 		w   wire.Value
 		err error
 	)
@@ -240,7 +239,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.OptionalStringListField != nil {
 		w, err = wire.NewValueSet(_Set_String_sliceType_ValueList(v.OptionalStringListField)), error(nil)
 		if err != nil {
@@ -249,7 +247,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.RequiredTypedefStringListField == nil {
 		return errors.New("field RequiredTypedefStringListField of Bar is required")
@@ -261,7 +258,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.OptionalTypedefStringListField != nil {
 		w, err = v.OptionalTypedefStringListField.ToWire()
 		if err != nil {
@@ -270,7 +266,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.RequiredFooListField == nil {
 		return errors.New("field RequiredFooListField of Bar is required")
@@ -282,7 +277,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.OptionalFooListField != nil {
 		w, err = wire.NewValueSet(_Set_Foo_sliceType_ValueList(v.OptionalFooListField)), error(nil)
 		if err != nil {
@@ -291,7 +285,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.RequiredTypedefFooListField == nil {
 		return errors.New("field RequiredTypedefFooListField of Bar is required")
@@ -303,7 +296,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.OptionalTypedefFooListField != nil {
 		w, err = v.OptionalTypedefFooListField.ToWire()
 		if err != nil {
@@ -312,7 +304,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.RequiredStringListListField == nil {
 		return errors.New("field RequiredStringListListField of Bar is required")
@@ -324,7 +315,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 9, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.RequiredTypedefStringListListField == nil {
 		return errors.New("field RequiredTypedefStringListListField of Bar is required")
 	}
@@ -335,7 +325,6 @@ func (fl *_fieldList_Bar) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 10, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -990,8 +979,7 @@ type _fieldList_Foo Foo
 
 func (fl *_fieldList_Foo) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Foo)(fl)
+		v   = (*Foo)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1003,7 +991,6 @@ func (fl *_fieldList_Foo) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -432,7 +432,6 @@ func _StringListList_Read(w wire.Value) (StringListList, error) {
 //   }
 //   return &v, nil
 func (v *Bar) FromWire(w wire.Value) error {
-	var err error
 
 	requiredInt32ListFieldIsSet := false
 
@@ -445,7 +444,8 @@ func (v *Bar) FromWire(w wire.Value) error {
 	requiredStringListListFieldIsSet := false
 	requiredTypedefStringListListFieldIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TSet {
@@ -528,7 +528,12 @@ func (v *Bar) FromWire(w wire.Value) error {
 				requiredTypedefStringListListFieldIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !requiredInt32ListFieldIsSet {
 		return errors.New("field RequiredInt32ListField of Bar is required")
@@ -985,11 +990,11 @@ func (v *Foo) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Foo) FromWire(w wire.Value) error {
-	var err error
 
 	stringFieldIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -1000,7 +1005,12 @@ func (v *Foo) FromWire(w wire.Value) error {
 				stringFieldIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !stringFieldIsSet {
 		return errors.New("field StringField of Foo is required")

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -44,8 +44,7 @@ type _fieldList_ContactInfo ContactInfo
 
 func (fl *_fieldList_ContactInfo) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ContactInfo)(fl)
+		v   = (*ContactInfo)(fl)
 		w   wire.Value
 		err error
 	)
@@ -57,7 +56,6 @@ func (fl *_fieldList_ContactInfo) ForEach(writeField func(wire.Field) error) err
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -300,8 +298,7 @@ type _fieldList_DefaultsStruct DefaultsStruct
 
 func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*DefaultsStruct)(fl)
+		v   = (*DefaultsStruct)(fl)
 		w   wire.Value
 		err error
 	)
@@ -318,7 +315,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vOptionalPrimitive := v.OptionalPrimitive
 	if vOptionalPrimitive == nil {
@@ -332,7 +328,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vRequiredEnum := v.RequiredEnum
 	if vRequiredEnum == nil {
@@ -346,7 +341,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vOptionalEnum := v.OptionalEnum
 	if vOptionalEnum == nil {
@@ -360,7 +354,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vRequiredList := v.RequiredList
 	if vRequiredList == nil {
@@ -377,7 +370,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vOptionalList := v.OptionalList
 	if vOptionalList == nil {
@@ -395,7 +387,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vRequiredStruct := v.RequiredStruct
 	if vRequiredStruct == nil {
@@ -418,7 +409,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vOptionalStruct := v.OptionalStruct
 	if vOptionalStruct == nil {
@@ -441,7 +431,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vRequiredBoolDefaultTrue := v.RequiredBoolDefaultTrue
 	if vRequiredBoolDefaultTrue == nil {
@@ -455,7 +444,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 9, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vOptionalBoolDefaultTrue := v.OptionalBoolDefaultTrue
 	if vOptionalBoolDefaultTrue == nil {
@@ -469,7 +457,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 10, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vRequiredBoolDefaultFalse := v.RequiredBoolDefaultFalse
 	if vRequiredBoolDefaultFalse == nil {
@@ -483,7 +470,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 11, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	vOptionalBoolDefaultFalse := v.OptionalBoolDefaultFalse
 	if vOptionalBoolDefaultFalse == nil {
@@ -497,7 +483,6 @@ func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 12, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -1248,8 +1233,7 @@ type _fieldList_Edge Edge
 
 func (fl *_fieldList_Edge) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Edge)(fl)
+		v   = (*Edge)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1264,7 +1248,6 @@ func (fl *_fieldList_Edge) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.EndPoint == nil {
 		return errors.New("field EndPoint of Edge is required")
 	}
@@ -1275,7 +1258,6 @@ func (fl *_fieldList_Edge) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -1552,8 +1534,7 @@ type _fieldList_Frame Frame
 
 func (fl *_fieldList_Frame) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Frame)(fl)
+		v   = (*Frame)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1568,7 +1549,6 @@ func (fl *_fieldList_Frame) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Size == nil {
 		return errors.New("field Size of Frame is required")
 	}
@@ -1579,7 +1559,6 @@ func (fl *_fieldList_Frame) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -1760,8 +1739,7 @@ type _fieldList_GoTags GoTags
 
 func (fl *_fieldList_GoTags) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*GoTags)(fl)
+		v   = (*GoTags)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1773,7 +1751,6 @@ func (fl *_fieldList_GoTags) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Bar != nil {
 		w, err = wire.NewValueString(*(v.Bar)), error(nil)
 		if err != nil {
@@ -1782,7 +1759,6 @@ func (fl *_fieldList_GoTags) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	w, err = wire.NewValueString(v.FooBar), error(nil)
@@ -1792,7 +1768,6 @@ func (fl *_fieldList_GoTags) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.FooBarWithSpace), error(nil)
 	if err != nil {
@@ -1801,7 +1776,6 @@ func (fl *_fieldList_GoTags) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.FooBarWithOmitEmpty != nil {
 		w, err = wire.NewValueString(*(v.FooBarWithOmitEmpty)), error(nil)
 		if err != nil {
@@ -1810,7 +1784,6 @@ func (fl *_fieldList_GoTags) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	w, err = wire.NewValueString(v.FooBarWithRequired), error(nil)
@@ -1820,7 +1793,6 @@ func (fl *_fieldList_GoTags) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -2151,8 +2123,7 @@ type _fieldList_Graph Graph
 
 func (fl *_fieldList_Graph) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Graph)(fl)
+		v   = (*Graph)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2164,7 +2135,6 @@ func (fl *_fieldList_Graph) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -2381,8 +2351,7 @@ type _fieldList_Node Node
 
 func (fl *_fieldList_Node) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Node)(fl)
+		v   = (*Node)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2394,7 +2363,6 @@ func (fl *_fieldList_Node) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Tail != nil {
 		w, err = v.Tail.ToWire()
 		if err != nil {
@@ -2403,7 +2371,6 @@ func (fl *_fieldList_Node) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -2617,8 +2584,7 @@ type _fieldList_NotOmitEmpty NotOmitEmpty
 
 func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*NotOmitEmpty)(fl)
+		v   = (*NotOmitEmpty)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2631,7 +2597,6 @@ func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.NotOmitEmptyInt != nil {
 		w, err = wire.NewValueString(*(v.NotOmitEmptyInt)), error(nil)
@@ -2641,7 +2606,6 @@ func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.NotOmitEmptyBool != nil {
 		w, err = wire.NewValueString(*(v.NotOmitEmptyBool)), error(nil)
@@ -2651,7 +2615,6 @@ func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.NotOmitEmptyList != nil {
 		w, err = wire.NewValueList(_List_String_ValueList(v.NotOmitEmptyList)), error(nil)
@@ -2661,7 +2624,6 @@ func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.NotOmitEmptyMap != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.NotOmitEmptyMap)), error(nil)
@@ -2671,7 +2633,6 @@ func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.NotOmitEmptyListMixedWithOmitEmpty != nil {
 		w, err = wire.NewValueList(_List_String_ValueList(v.NotOmitEmptyListMixedWithOmitEmpty)), error(nil)
@@ -2681,7 +2642,6 @@ func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
 		w, err = wire.NewValueList(_List_String_ValueList(v.NotOmitEmptyListMixedWithOmitEmptyV2)), error(nil)
@@ -2691,7 +2651,6 @@ func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.OmitEmptyString != nil {
 		w, err = wire.NewValueString(*(v.OmitEmptyString)), error(nil)
@@ -2701,7 +2660,6 @@ func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -3134,8 +3092,7 @@ type _fieldList_Omit Omit
 
 func (fl *_fieldList_Omit) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Omit)(fl)
+		v   = (*Omit)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3147,7 +3104,6 @@ func (fl *_fieldList_Omit) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.Hidden), error(nil)
 	if err != nil {
@@ -3156,7 +3112,6 @@ func (fl *_fieldList_Omit) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -3316,8 +3271,7 @@ type _fieldList_PersonalInfo PersonalInfo
 
 func (fl *_fieldList_PersonalInfo) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*PersonalInfo)(fl)
+		v   = (*PersonalInfo)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3330,7 +3284,6 @@ func (fl *_fieldList_PersonalInfo) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -3471,8 +3424,7 @@ type _fieldList_Point Point
 
 func (fl *_fieldList_Point) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Point)(fl)
+		v   = (*Point)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3484,7 +3436,6 @@ func (fl *_fieldList_Point) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueDouble(v.Y), error(nil)
 	if err != nil {
@@ -3493,7 +3444,6 @@ func (fl *_fieldList_Point) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -3663,8 +3613,7 @@ type _fieldList_PrimitiveOptionalStruct PrimitiveOptionalStruct
 
 func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*PrimitiveOptionalStruct)(fl)
+		v   = (*PrimitiveOptionalStruct)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3677,7 +3626,6 @@ func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.ByteField != nil {
 		w, err = wire.NewValueI8(*(v.ByteField)), error(nil)
@@ -3687,7 +3635,6 @@ func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Int16Field != nil {
 		w, err = wire.NewValueI16(*(v.Int16Field)), error(nil)
@@ -3697,7 +3644,6 @@ func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Int32Field != nil {
 		w, err = wire.NewValueI32(*(v.Int32Field)), error(nil)
@@ -3707,7 +3653,6 @@ func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Int64Field != nil {
 		w, err = wire.NewValueI64(*(v.Int64Field)), error(nil)
@@ -3717,7 +3662,6 @@ func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.DoubleField != nil {
 		w, err = wire.NewValueDouble(*(v.DoubleField)), error(nil)
@@ -3727,7 +3671,6 @@ func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.StringField != nil {
 		w, err = wire.NewValueString(*(v.StringField)), error(nil)
@@ -3737,7 +3680,6 @@ func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.BinaryField != nil {
 		w, err = wire.NewValueBinary(v.BinaryField), error(nil)
@@ -3747,7 +3689,6 @@ func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -4179,8 +4120,7 @@ type _fieldList_PrimitiveRequiredStruct PrimitiveRequiredStruct
 
 func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*PrimitiveRequiredStruct)(fl)
+		v   = (*PrimitiveRequiredStruct)(fl)
 		w   wire.Value
 		err error
 	)
@@ -4192,7 +4132,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI8(v.ByteField), error(nil)
 	if err != nil {
@@ -4201,7 +4140,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI16(v.Int16Field), error(nil)
 	if err != nil {
@@ -4210,7 +4148,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI32(v.Int32Field), error(nil)
 	if err != nil {
@@ -4219,7 +4156,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI64(v.Int64Field), error(nil)
 	if err != nil {
@@ -4228,7 +4164,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueDouble(v.DoubleField), error(nil)
 	if err != nil {
@@ -4237,7 +4172,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.StringField), error(nil)
 	if err != nil {
@@ -4246,7 +4180,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.BinaryField == nil {
 		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
 	}
@@ -4257,7 +4190,6 @@ func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field
 	if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -4591,8 +4523,7 @@ type _fieldList_Rename Rename
 
 func (fl *_fieldList_Rename) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Rename)(fl)
+		v   = (*Rename)(fl)
 		w   wire.Value
 		err error
 	)
@@ -4604,7 +4535,6 @@ func (fl *_fieldList_Rename) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.CamelCase), error(nil)
 	if err != nil {
@@ -4613,7 +4543,6 @@ func (fl *_fieldList_Rename) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -4777,8 +4706,7 @@ type _fieldList_Size Size
 
 func (fl *_fieldList_Size) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Size)(fl)
+		v   = (*Size)(fl)
 		w   wire.Value
 		err error
 	)
@@ -4790,7 +4718,6 @@ func (fl *_fieldList_Size) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueDouble(v.Height), error(nil)
 	if err != nil {
@@ -4799,7 +4726,6 @@ func (fl *_fieldList_Size) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -4962,8 +4888,7 @@ type _fieldList_StructLabels StructLabels
 
 func (fl *_fieldList_StructLabels) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*StructLabels)(fl)
+		v   = (*StructLabels)(fl)
 		w   wire.Value
 		err error
 	)
@@ -4976,7 +4901,6 @@ func (fl *_fieldList_StructLabels) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Foo != nil {
 		w, err = wire.NewValueString(*(v.Foo)), error(nil)
@@ -4986,7 +4910,6 @@ func (fl *_fieldList_StructLabels) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Qux != nil {
 		w, err = wire.NewValueString(*(v.Qux)), error(nil)
@@ -4996,7 +4919,6 @@ func (fl *_fieldList_StructLabels) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Quux != nil {
 		w, err = wire.NewValueString(*(v.Quux)), error(nil)
@@ -5006,7 +4928,6 @@ func (fl *_fieldList_StructLabels) ForEach(writeField func(wire.Field) error) er
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -5252,8 +5173,7 @@ type _fieldList_User User
 
 func (fl *_fieldList_User) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*User)(fl)
+		v   = (*User)(fl)
 		w   wire.Value
 		err error
 	)
@@ -5265,7 +5185,6 @@ func (fl *_fieldList_User) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Contact != nil {
 		w, err = v.Contact.ToWire()
 		if err != nil {
@@ -5274,7 +5193,6 @@ func (fl *_fieldList_User) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Personal != nil {
 		w, err = v.Personal.ToWire()
@@ -5284,7 +5202,6 @@ func (fl *_fieldList_User) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -5631,8 +5548,7 @@ type _fieldList_ZapOptOutStruct ZapOptOutStruct
 
 func (fl *_fieldList_ZapOptOutStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ZapOptOutStruct)(fl)
+		v   = (*ZapOptOutStruct)(fl)
 		w   wire.Value
 		err error
 	)
@@ -5644,7 +5560,6 @@ func (fl *_fieldList_ZapOptOutStruct) ForEach(writeField func(wire.Field) error)
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.Optout), error(nil)
 	if err != nil {
@@ -5653,7 +5568,6 @@ func (fl *_fieldList_ZapOptOutStruct) ForEach(writeField func(wire.Field) error)
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -72,11 +72,11 @@ func (v *ContactInfo) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ContactInfo) FromWire(w wire.Value) error {
-	var err error
 
 	emailAddressIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -87,7 +87,12 @@ func (v *ContactInfo) FromWire(w wire.Value) error {
 				emailAddressIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !emailAddressIsSet {
 		return errors.New("field EmailAddress of ContactInfo is required")
@@ -530,9 +535,9 @@ func _Edge_Read(w wire.Value) (*Edge, error) {
 //   }
 //   return &v, nil
 func (v *DefaultsStruct) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
@@ -647,7 +652,12 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if v.RequiredPrimitive == nil {
 		v.RequiredPrimitive = ptr.Int32(100)
@@ -1242,12 +1252,12 @@ func _Point_Read(w wire.Value) (*Point, error) {
 //   }
 //   return &v, nil
 func (v *Edge) FromWire(w wire.Value) error {
-	var err error
 
 	startPointIsSet := false
 	endPointIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -1266,7 +1276,12 @@ func (v *Edge) FromWire(w wire.Value) error {
 				endPointIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !startPointIsSet {
 		return errors.New("field StartPoint of Edge is required")
@@ -1401,10 +1416,16 @@ func (v *EmptyStruct) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *EmptyStruct) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -1519,12 +1540,12 @@ func _Size_Read(w wire.Value) (*Size, error) {
 //   }
 //   return &v, nil
 func (v *Frame) FromWire(w wire.Value) error {
-	var err error
 
 	topLeftIsSet := false
 	sizeIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -1543,7 +1564,12 @@ func (v *Frame) FromWire(w wire.Value) error {
 				sizeIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !topLeftIsSet {
 		return errors.New("field TopLeft of Frame is required")
@@ -1729,7 +1755,6 @@ func (v *GoTags) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *GoTags) FromWire(w wire.Value) error {
-	var err error
 
 	FooIsSet := false
 
@@ -1738,7 +1763,8 @@ func (v *GoTags) FromWire(w wire.Value) error {
 
 	FooBarWithRequiredIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -1793,7 +1819,12 @@ func (v *GoTags) FromWire(w wire.Value) error {
 				FooBarWithRequiredIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !FooIsSet {
 		return errors.New("field Foo of GoTags is required")
@@ -2076,11 +2107,11 @@ func _List_Edge_Read(l wire.ValueList) ([]*Edge, error) {
 //   }
 //   return &v, nil
 func (v *Graph) FromWire(w wire.Value) error {
-	var err error
 
 	edgesIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -2091,7 +2122,12 @@ func (v *Graph) FromWire(w wire.Value) error {
 				edgesIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !edgesIsSet {
 		return errors.New("field Edges of Graph is required")
@@ -2287,11 +2323,11 @@ func _List_Read(w wire.Value) (*List, error) {
 //   }
 //   return &v, nil
 func (v *Node) FromWire(w wire.Value) error {
-	var err error
 
 	valueIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
@@ -2310,7 +2346,12 @@ func (v *Node) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !valueIsSet {
 		return errors.New("field Value of Node is required")
@@ -2578,9 +2619,9 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 //   }
 //   return &v, nil
 func (v *NotOmitEmpty) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -2655,7 +2696,12 @@ func (v *NotOmitEmpty) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -2987,12 +3033,12 @@ func (v *Omit) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Omit) FromWire(w wire.Value) error {
-	var err error
 
 	serializedIsSet := false
 	hiddenIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -3011,7 +3057,12 @@ func (v *Omit) FromWire(w wire.Value) error {
 				hiddenIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !serializedIsSet {
 		return errors.New("field Serialized of Omit is required")
@@ -3147,9 +3198,9 @@ func (v *PersonalInfo) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *PersonalInfo) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
@@ -3162,7 +3213,12 @@ func (v *PersonalInfo) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -3292,12 +3348,12 @@ func (v *Point) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Point) FromWire(w wire.Value) error {
-	var err error
 
 	xIsSet := false
 	yIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TDouble {
@@ -3316,7 +3372,12 @@ func (v *Point) FromWire(w wire.Value) error {
 				yIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !xIsSet {
 		return errors.New("field X of Point is required")
@@ -3518,9 +3579,9 @@ func (v *PrimitiveOptionalStruct) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
@@ -3601,7 +3662,12 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -3998,7 +4064,6 @@ func (v *PrimitiveRequiredStruct) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
-	var err error
 
 	boolFieldIsSet := false
 	byteFieldIsSet := false
@@ -4009,7 +4074,8 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	stringFieldIsSet := false
 	binaryFieldIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
@@ -4076,7 +4142,12 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 				binaryFieldIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !boolFieldIsSet {
 		return errors.New("field BoolField of PrimitiveRequiredStruct is required")
@@ -4337,12 +4408,12 @@ func (v *Rename) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Rename) FromWire(w wire.Value) error {
-	var err error
 
 	DefaultIsSet := false
 	camelCaseIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -4361,7 +4432,12 @@ func (v *Rename) FromWire(w wire.Value) error {
 				camelCaseIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !DefaultIsSet {
 		return errors.New("field Default of Rename is required")
@@ -4506,12 +4582,12 @@ func (v *Size) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Size) FromWire(w wire.Value) error {
-	var err error
 
 	widthIsSet := false
 	heightIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TDouble {
@@ -4530,7 +4606,12 @@ func (v *Size) FromWire(w wire.Value) error {
 				heightIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !widthIsSet {
 		return errors.New("field Width of Size is required")
@@ -4693,9 +4774,9 @@ func (v *StructLabels) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *StructLabels) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
@@ -4738,7 +4819,12 @@ func (v *StructLabels) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -4964,11 +5050,11 @@ func _PersonalInfo_Read(w wire.Value) (*PersonalInfo, error) {
 //   }
 //   return &v, nil
 func (v *User) FromWire(w wire.Value) error {
-	var err error
 
 	nameIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -4995,7 +5081,12 @@ func (v *User) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !nameIsSet {
 		return errors.New("field Name of User is required")
@@ -5303,12 +5394,12 @@ func (v *ZapOptOutStruct) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ZapOptOutStruct) FromWire(w wire.Value) error {
-	var err error
 
 	nameIsSet := false
 	optoutIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -5327,7 +5418,12 @@ func (v *ZapOptOutStruct) FromWire(w wire.Value) error {
 				optoutIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !nameIsSet {
 		return errors.New("field Name of ZapOptOutStruct is required")

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -37,22 +37,32 @@ type ContactInfo struct {
 //     return err
 //   }
 func (v *ContactInfo) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ContactInfo)(v)), nil
+}
+
+type _fieldList_ContactInfo ContactInfo
+
+func (fl *_fieldList_ContactInfo) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ContactInfo)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.EmailAddress), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ContactInfo) Close() {}
 
 // FromWire deserializes a ContactInfo struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -283,11 +293,17 @@ func (_List_Double_ValueList) Close() {}
 //     return err
 //   }
 func (v *DefaultsStruct) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_DefaultsStruct)(v)), nil
+}
+
+type _fieldList_DefaultsStruct DefaultsStruct
+
+func (fl *_fieldList_DefaultsStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [12]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*DefaultsStruct)(fl)
+		w   wire.Value
+		err error
 	)
 
 	vRequiredPrimitive := v.RequiredPrimitive
@@ -297,9 +313,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = wire.NewValueI32(*(vRequiredPrimitive)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vOptionalPrimitive := v.OptionalPrimitive
@@ -309,9 +327,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = wire.NewValueI32(*(vOptionalPrimitive)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vRequiredEnum := v.RequiredEnum
@@ -321,9 +341,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = vRequiredEnum.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vOptionalEnum := v.OptionalEnum
@@ -333,9 +355,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = vOptionalEnum.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vRequiredList := v.RequiredList
@@ -348,9 +372,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = wire.NewValueList(_List_String_ValueList(vRequiredList)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vOptionalList := v.OptionalList
@@ -364,9 +390,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = wire.NewValueList(_List_Double_ValueList(vOptionalList)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 6, Value: w}
+		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vRequiredStruct := v.RequiredStruct
@@ -385,9 +413,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = vRequiredStruct.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 7, Value: w}
+		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vOptionalStruct := v.OptionalStruct
@@ -406,9 +436,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = vOptionalStruct.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 8, Value: w}
+		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vRequiredBoolDefaultTrue := v.RequiredBoolDefaultTrue
@@ -418,9 +450,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = wire.NewValueBool(*(vRequiredBoolDefaultTrue)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 9, Value: w}
+		if err := writeField(wire.Field{ID: 9, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vOptionalBoolDefaultTrue := v.OptionalBoolDefaultTrue
@@ -430,9 +464,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = wire.NewValueBool(*(vOptionalBoolDefaultTrue)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 10, Value: w}
+		if err := writeField(wire.Field{ID: 10, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vRequiredBoolDefaultFalse := v.RequiredBoolDefaultFalse
@@ -442,9 +478,11 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = wire.NewValueBool(*(vRequiredBoolDefaultFalse)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 11, Value: w}
+		if err := writeField(wire.Field{ID: 11, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	vOptionalBoolDefaultFalse := v.OptionalBoolDefaultFalse
@@ -454,14 +492,18 @@ func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	{
 		w, err = wire.NewValueBool(*(vOptionalBoolDefaultFalse)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 12, Value: w}
+		if err := writeField(wire.Field{ID: 12, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_DefaultsStruct) Close() {}
 
 func _EnumDefault_Read(w wire.Value) (enums.EnumDefault, error) {
 	var v enums.EnumDefault
@@ -1199,34 +1241,46 @@ type Edge struct {
 //     return err
 //   }
 func (v *Edge) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Edge)(v)), nil
+}
+
+type _fieldList_Edge Edge
+
+func (fl *_fieldList_Edge) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Edge)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.StartPoint == nil {
-		return w, errors.New("field StartPoint of Edge is required")
+		return errors.New("field StartPoint of Edge is required")
 	}
 	w, err = v.StartPoint.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.EndPoint == nil {
-		return w, errors.New("field EndPoint of Edge is required")
+		return errors.New("field EndPoint of Edge is required")
 	}
 	w, err = v.EndPoint.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Edge) Close() {}
 
 func _Point_Read(w wire.Value) (*Point, error) {
 	var v Point
@@ -1389,13 +1443,17 @@ type EmptyStruct struct {
 //     return err
 //   }
 func (v *EmptyStruct) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_EmptyStruct)(v)), nil
 }
+
+type _fieldList_EmptyStruct EmptyStruct
+
+func (fl *_fieldList_EmptyStruct) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_EmptyStruct) Close() {}
 
 // FromWire deserializes a EmptyStruct struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -1487,34 +1545,46 @@ type Frame struct {
 //     return err
 //   }
 func (v *Frame) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Frame)(v)), nil
+}
+
+type _fieldList_Frame Frame
+
+func (fl *_fieldList_Frame) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Frame)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.TopLeft == nil {
-		return w, errors.New("field TopLeft of Frame is required")
+		return errors.New("field TopLeft of Frame is required")
 	}
 	w, err = v.TopLeft.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Size == nil {
-		return w, errors.New("field Size of Frame is required")
+		return errors.New("field Size of Frame is required")
 	}
 	w, err = v.Size.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Frame) Close() {}
 
 func _Size_Read(w wire.Value) (*Size, error) {
 	var v Size
@@ -1683,59 +1753,79 @@ type GoTags struct {
 //     return err
 //   }
 func (v *GoTags) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_GoTags)(v)), nil
+}
+
+type _fieldList_GoTags GoTags
+
+func (fl *_fieldList_GoTags) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [6]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*GoTags)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Foo), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Bar != nil {
 		w, err = wire.NewValueString(*(v.Bar)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	w, err = wire.NewValueString(v.FooBar), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 3, Value: w}
+	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.FooBarWithSpace), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 4, Value: w}
+	if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.FooBarWithOmitEmpty != nil {
 		w, err = wire.NewValueString(*(v.FooBarWithOmitEmpty)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	w, err = wire.NewValueString(v.FooBarWithRequired), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 6, Value: w}
+	if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_GoTags) Close() {}
 
 // FromWire deserializes a GoTags struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -2054,22 +2144,32 @@ func (_List_Edge_ValueList) Close() {}
 //     return err
 //   }
 func (v *Graph) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Graph)(v)), nil
+}
+
+type _fieldList_Graph Graph
+
+func (fl *_fieldList_Graph) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Graph)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueList(_List_Edge_ValueList(v.Edges)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Graph) Close() {}
 
 func _List_Edge_Read(l wire.ValueList) ([]*Edge, error) {
 	if l.ValueType() != wire.TStruct {
@@ -2274,30 +2374,42 @@ type Node struct {
 //     return err
 //   }
 func (v *Node) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Node)(v)), nil
+}
+
+type _fieldList_Node Node
+
+func (fl *_fieldList_Node) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Node)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueI32(v.Value), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Tail != nil {
 		w, err = v.Tail.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Node) Close() {}
 
 func _List_Read(w wire.Value) (*List, error) {
 	var x List
@@ -2498,80 +2610,104 @@ func (_Map_String_String_MapItemList) Close() {}
 //     return err
 //   }
 func (v *NotOmitEmpty) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_NotOmitEmpty)(v)), nil
+}
+
+type _fieldList_NotOmitEmpty NotOmitEmpty
+
+func (fl *_fieldList_NotOmitEmpty) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [8]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*NotOmitEmpty)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.NotOmitEmptyString != nil {
 		w, err = wire.NewValueString(*(v.NotOmitEmptyString)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.NotOmitEmptyInt != nil {
 		w, err = wire.NewValueString(*(v.NotOmitEmptyInt)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.NotOmitEmptyBool != nil {
 		w, err = wire.NewValueString(*(v.NotOmitEmptyBool)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.NotOmitEmptyList != nil {
 		w, err = wire.NewValueList(_List_String_ValueList(v.NotOmitEmptyList)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.NotOmitEmptyMap != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.NotOmitEmptyMap)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.NotOmitEmptyListMixedWithOmitEmpty != nil {
 		w, err = wire.NewValueList(_List_String_ValueList(v.NotOmitEmptyListMixedWithOmitEmpty)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 6, Value: w}
+		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
 		w, err = wire.NewValueList(_List_String_ValueList(v.NotOmitEmptyListMixedWithOmitEmptyV2)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 7, Value: w}
+		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.OmitEmptyString != nil {
 		w, err = wire.NewValueString(*(v.OmitEmptyString)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 8, Value: w}
+		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_NotOmitEmpty) Close() {}
 
 func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 	if m.KeyType() != wire.TBinary {
@@ -2991,29 +3127,41 @@ type Omit struct {
 //     return err
 //   }
 func (v *Omit) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Omit)(v)), nil
+}
+
+type _fieldList_Omit Omit
+
+func (fl *_fieldList_Omit) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Omit)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Serialized), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.Hidden), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Omit) Close() {}
 
 // FromWire deserializes a Omit struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3161,24 +3309,34 @@ type PersonalInfo struct {
 //     return err
 //   }
 func (v *PersonalInfo) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_PersonalInfo)(v)), nil
+}
+
+type _fieldList_PersonalInfo PersonalInfo
+
+func (fl *_fieldList_PersonalInfo) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*PersonalInfo)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Age != nil {
 		w, err = wire.NewValueI32(*(v.Age)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_PersonalInfo) Close() {}
 
 // FromWire deserializes a PersonalInfo struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3306,29 +3464,41 @@ type Point struct {
 //     return err
 //   }
 func (v *Point) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Point)(v)), nil
+}
+
+type _fieldList_Point Point
+
+func (fl *_fieldList_Point) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Point)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueDouble(v.X), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueDouble(v.Y), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Point) Close() {}
 
 // FromWire deserializes a Point struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3486,80 +3656,104 @@ type PrimitiveOptionalStruct struct {
 //     return err
 //   }
 func (v *PrimitiveOptionalStruct) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_PrimitiveOptionalStruct)(v)), nil
+}
+
+type _fieldList_PrimitiveOptionalStruct PrimitiveOptionalStruct
+
+func (fl *_fieldList_PrimitiveOptionalStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [8]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*PrimitiveOptionalStruct)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.BoolField != nil {
 		w, err = wire.NewValueBool(*(v.BoolField)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.ByteField != nil {
 		w, err = wire.NewValueI8(*(v.ByteField)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Int16Field != nil {
 		w, err = wire.NewValueI16(*(v.Int16Field)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Int32Field != nil {
 		w, err = wire.NewValueI32(*(v.Int32Field)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Int64Field != nil {
 		w, err = wire.NewValueI64(*(v.Int64Field)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.DoubleField != nil {
 		w, err = wire.NewValueDouble(*(v.DoubleField)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 6, Value: w}
+		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.StringField != nil {
 		w, err = wire.NewValueString(*(v.StringField)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 7, Value: w}
+		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.BinaryField != nil {
 		w, err = wire.NewValueBinary(v.BinaryField), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 8, Value: w}
+		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_PrimitiveOptionalStruct) Close() {}
 
 // FromWire deserializes a PrimitiveOptionalStruct struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -3978,73 +4172,97 @@ type PrimitiveRequiredStruct struct {
 //     return err
 //   }
 func (v *PrimitiveRequiredStruct) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_PrimitiveRequiredStruct)(v)), nil
+}
+
+type _fieldList_PrimitiveRequiredStruct PrimitiveRequiredStruct
+
+func (fl *_fieldList_PrimitiveRequiredStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [8]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*PrimitiveRequiredStruct)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueBool(v.BoolField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI8(v.ByteField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI16(v.Int16Field), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 3, Value: w}
+	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI32(v.Int32Field), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 4, Value: w}
+	if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI64(v.Int64Field), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 5, Value: w}
+	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueDouble(v.DoubleField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 6, Value: w}
+	if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.StringField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 7, Value: w}
+	if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.BinaryField == nil {
-		return w, errors.New("field BinaryField of PrimitiveRequiredStruct is required")
+		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
 	}
 	w, err = wire.NewValueBinary(v.BinaryField), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 8, Value: w}
+	if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_PrimitiveRequiredStruct) Close() {}
 
 // FromWire deserializes a PrimitiveRequiredStruct struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -4366,29 +4584,41 @@ type Rename struct {
 //     return err
 //   }
 func (v *Rename) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Rename)(v)), nil
+}
+
+type _fieldList_Rename Rename
+
+func (fl *_fieldList_Rename) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Rename)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Default), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.CamelCase), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Rename) Close() {}
 
 // FromWire deserializes a Rename struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -4540,29 +4770,41 @@ type Size struct {
 //     return err
 //   }
 func (v *Size) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Size)(v)), nil
+}
+
+type _fieldList_Size Size
+
+func (fl *_fieldList_Size) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Size)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueDouble(v.Width), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueDouble(v.Height), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Size) Close() {}
 
 // FromWire deserializes a Size struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -4713,48 +4955,64 @@ type StructLabels struct {
 //     return err
 //   }
 func (v *StructLabels) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_StructLabels)(v)), nil
+}
+
+type _fieldList_StructLabels StructLabels
+
+func (fl *_fieldList_StructLabels) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [4]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*StructLabels)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.IsRequired != nil {
 		w, err = wire.NewValueBool(*(v.IsRequired)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Foo != nil {
 		w, err = wire.NewValueString(*(v.Foo)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Qux != nil {
 		w, err = wire.NewValueString(*(v.Qux)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Quux != nil {
 		w, err = wire.NewValueString(*(v.Quux)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_StructLabels) Close() {}
 
 // FromWire deserializes a StructLabels struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -4987,38 +5245,52 @@ type User struct {
 //     return err
 //   }
 func (v *User) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_User)(v)), nil
+}
+
+type _fieldList_User User
+
+func (fl *_fieldList_User) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [3]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*User)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Name), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Contact != nil {
 		w, err = v.Contact.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Personal != nil {
 		w, err = v.Personal.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_User) Close() {}
 
 func _ContactInfo_Read(w wire.Value) (*ContactInfo, error) {
 	var v ContactInfo
@@ -5352,29 +5624,41 @@ type ZapOptOutStruct struct {
 //     return err
 //   }
 func (v *ZapOptOutStruct) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ZapOptOutStruct)(v)), nil
+}
+
+type _fieldList_ZapOptOutStruct ZapOptOutStruct
+
+func (fl *_fieldList_ZapOptOutStruct) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ZapOptOutStruct)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Name), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.Optout), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ZapOptOutStruct) Close() {}
 
 // FromWire deserializes a ZapOptOutStruct struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -171,8 +171,7 @@ type _fieldList_DefaultPrimitiveTypedef DefaultPrimitiveTypedef
 
 func (fl *_fieldList_DefaultPrimitiveTypedef) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*DefaultPrimitiveTypedef)(fl)
+		v   = (*DefaultPrimitiveTypedef)(fl)
 		w   wire.Value
 		err error
 	)
@@ -189,7 +188,6 @@ func (fl *_fieldList_DefaultPrimitiveTypedef) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -553,8 +551,7 @@ type _fieldList_Event Event
 
 func (fl *_fieldList_Event) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Event)(fl)
+		v   = (*Event)(fl)
 		w   wire.Value
 		err error
 	)
@@ -569,7 +566,6 @@ func (fl *_fieldList_Event) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Time != nil {
 		w, err = v.Time.ToWire()
 		if err != nil {
@@ -578,7 +574,6 @@ func (fl *_fieldList_Event) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -1525,8 +1520,7 @@ type _fieldList_Transition Transition
 
 func (fl *_fieldList_Transition) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Transition)(fl)
+		v   = (*Transition)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1538,7 +1532,6 @@ func (fl *_fieldList_Transition) ForEach(writeField func(wire.Field) error) erro
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = v.ToState.ToWire()
 	if err != nil {
@@ -1547,7 +1540,6 @@ func (fl *_fieldList_Transition) ForEach(writeField func(wire.Field) error) erro
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Events != nil {
 		w, err = v.Events.ToWire()
 		if err != nil {
@@ -1556,7 +1548,6 @@ func (fl *_fieldList_Transition) ForEach(writeField func(wire.Field) error) erro
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -1756,8 +1747,7 @@ type _fieldList_TransitiveTypedefField TransitiveTypedefField
 
 func (fl *_fieldList_TransitiveTypedefField) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*TransitiveTypedefField)(fl)
+		v   = (*TransitiveTypedefField)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1772,7 +1762,6 @@ func (fl *_fieldList_TransitiveTypedefField) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -1949,8 +1938,7 @@ type _fieldList_I128 I128
 
 func (fl *_fieldList_I128) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*I128)(fl)
+		v   = (*I128)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1962,7 +1950,6 @@ func (fl *_fieldList_I128) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI64(v.Low), error(nil)
 	if err != nil {
@@ -1971,7 +1958,6 @@ func (fl *_fieldList_I128) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -164,11 +164,17 @@ func Default_DefaultPrimitiveTypedef() *DefaultPrimitiveTypedef {
 //     return err
 //   }
 func (v *DefaultPrimitiveTypedef) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_DefaultPrimitiveTypedef)(v)), nil
+}
+
+type _fieldList_DefaultPrimitiveTypedef DefaultPrimitiveTypedef
+
+func (fl *_fieldList_DefaultPrimitiveTypedef) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*DefaultPrimitiveTypedef)(fl)
+		w   wire.Value
+		err error
 	)
 
 	vState := v.State
@@ -178,14 +184,18 @@ func (v *DefaultPrimitiveTypedef) ToWire() (wire.Value, error) {
 	{
 		w, err = vState.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_DefaultPrimitiveTypedef) Close() {}
 
 func _State_Read(w wire.Value) (State, error) {
 	var x State
@@ -536,33 +546,45 @@ type Event struct {
 //     return err
 //   }
 func (v *Event) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Event)(v)), nil
+}
+
+type _fieldList_Event Event
+
+func (fl *_fieldList_Event) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Event)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.UUID == nil {
-		return w, errors.New("field UUID of Event is required")
+		return errors.New("field UUID of Event is required")
 	}
 	w, err = v.UUID.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Time != nil {
 		w, err = v.Time.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Event) Close() {}
 
 func _UUID_Read(w wire.Value) (*UUID, error) {
 	var x UUID
@@ -1496,37 +1518,51 @@ type Transition struct {
 //     return err
 //   }
 func (v *Transition) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Transition)(v)), nil
+}
+
+type _fieldList_Transition Transition
+
+func (fl *_fieldList_Transition) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [3]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Transition)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = v.FromState.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = v.ToState.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Events != nil {
 		w, err = v.Events.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Transition) Close() {}
 
 func _EventGroup_Read(w wire.Value) (EventGroup, error) {
 	var x EventGroup
@@ -1713,25 +1749,35 @@ type TransitiveTypedefField struct {
 //     return err
 //   }
 func (v *TransitiveTypedefField) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_TransitiveTypedefField)(v)), nil
+}
+
+type _fieldList_TransitiveTypedefField TransitiveTypedefField
+
+func (fl *_fieldList_TransitiveTypedefField) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*TransitiveTypedefField)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.DefUUID == nil {
-		return w, errors.New("field DefUUID of TransitiveTypedefField is required")
+		return errors.New("field DefUUID of TransitiveTypedefField is required")
 	}
 	w, err = v.DefUUID.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_TransitiveTypedefField) Close() {}
 
 func _MyUUID_Read(w wire.Value) (*MyUUID, error) {
 	var x MyUUID
@@ -1896,29 +1942,41 @@ type I128 struct {
 //     return err
 //   }
 func (v *I128) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_I128)(v)), nil
+}
+
+type _fieldList_I128 I128
+
+func (fl *_fieldList_I128) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*I128)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueI64(v.High), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI64(v.Low), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_I128) Close() {}
 
 // FromWire deserializes a I128 struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -211,9 +211,9 @@ func _State_Read(w wire.Value) (State, error) {
 //   }
 //   return &v, nil
 func (v *DefaultPrimitiveTypedef) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -226,7 +226,12 @@ func (v *DefaultPrimitiveTypedef) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if v.State == nil {
 		v.State = _State_ptr("hello")
@@ -589,11 +594,11 @@ func _Timestamp_Read(w wire.Value) (Timestamp, error) {
 //   }
 //   return &v, nil
 func (v *Event) FromWire(w wire.Value) error {
-	var err error
 
 	uuidIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -614,7 +619,12 @@ func (v *Event) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !uuidIsSet {
 		return errors.New("field UUID of Event is required")
@@ -1542,12 +1552,12 @@ func _EventGroup_Read(w wire.Value) (EventGroup, error) {
 //   }
 //   return &v, nil
 func (v *Transition) FromWire(w wire.Value) error {
-	var err error
 
 	fromStateIsSet := false
 	toStateIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -1574,7 +1584,12 @@ func (v *Transition) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !fromStateIsSet {
 		return errors.New("field FromState of Transition is required")
@@ -1742,11 +1757,11 @@ func _MyUUID_Read(w wire.Value) (*MyUUID, error) {
 //   }
 //   return &v, nil
 func (v *TransitiveTypedefField) FromWire(w wire.Value) error {
-	var err error
 
 	defUUIDIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -1757,7 +1772,12 @@ func (v *TransitiveTypedefField) FromWire(w wire.Value) error {
 				defUUIDIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !defUUIDIsSet {
 		return errors.New("field DefUUID of TransitiveTypedefField is required")
@@ -1918,12 +1938,12 @@ func (v *I128) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *I128) FromWire(w wire.Value) error {
-	var err error
 
 	highIsSet := false
 	lowIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI64 {
@@ -1942,7 +1962,12 @@ func (v *I128) FromWire(w wire.Value) error {
 				lowIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !highIsSet {
 		return errors.New("field High of I128 is required")

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -114,6 +114,27 @@ func (_Map_String_ArbitraryValue_MapItemList) Close() {}
 //     return err
 //   }
 func (v *ArbitraryValue) ToWire() (wire.Value, error) {
+	var i int
+	if v.BoolValue != nil {
+		i++
+	}
+	if v.Int64Value != nil {
+		i++
+	}
+	if v.StringValue != nil {
+		i++
+	}
+	if v.ListValue != nil {
+		i++
+	}
+	if v.MapValue != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("ArbitraryValue should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_ArbitraryValue)(v)), nil
 }
 
@@ -121,8 +142,7 @@ type _fieldList_ArbitraryValue ArbitraryValue
 
 func (fl *_fieldList_ArbitraryValue) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ArbitraryValue)(fl)
+		v   = (*ArbitraryValue)(fl)
 		w   wire.Value
 		err error
 	)
@@ -135,7 +155,6 @@ func (fl *_fieldList_ArbitraryValue) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Int64Value != nil {
 		w, err = wire.NewValueI64(*(v.Int64Value)), error(nil)
@@ -145,7 +164,6 @@ func (fl *_fieldList_ArbitraryValue) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.StringValue != nil {
 		w, err = wire.NewValueString(*(v.StringValue)), error(nil)
@@ -155,7 +173,6 @@ func (fl *_fieldList_ArbitraryValue) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.ListValue != nil {
 		w, err = wire.NewValueList(_List_ArbitraryValue_ValueList(v.ListValue)), error(nil)
@@ -165,7 +182,6 @@ func (fl *_fieldList_ArbitraryValue) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.MapValue != nil {
 		w, err = wire.NewValueMap(_Map_String_ArbitraryValue_MapItemList(v.MapValue)), error(nil)
@@ -175,11 +191,6 @@ func (fl *_fieldList_ArbitraryValue) ForEach(writeField func(wire.Field) error) 
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("ArbitraryValue should have exactly one field: got %v fields", i)
 	}
 
 	return nil
@@ -604,6 +615,18 @@ type Document struct {
 //     return err
 //   }
 func (v *Document) ToWire() (wire.Value, error) {
+	var i int
+	if v.Pdf != nil {
+		i++
+	}
+	if v.PlainText != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("Document should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_Document)(v)), nil
 }
 
@@ -611,8 +634,7 @@ type _fieldList_Document Document
 
 func (fl *_fieldList_Document) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Document)(fl)
+		v   = (*Document)(fl)
 		w   wire.Value
 		err error
 	)
@@ -625,7 +647,6 @@ func (fl *_fieldList_Document) ForEach(writeField func(wire.Field) error) error 
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.PlainText != nil {
 		w, err = wire.NewValueString(*(v.PlainText)), error(nil)
@@ -635,11 +656,6 @@ func (fl *_fieldList_Document) ForEach(writeField func(wire.Field) error) error 
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("Document should have exactly one field: got %v fields", i)
 	}
 
 	return nil

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -114,60 +114,78 @@ func (_Map_String_ArbitraryValue_MapItemList) Close() {}
 //     return err
 //   }
 func (v *ArbitraryValue) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ArbitraryValue)(v)), nil
+}
+
+type _fieldList_ArbitraryValue ArbitraryValue
+
+func (fl *_fieldList_ArbitraryValue) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [5]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ArbitraryValue)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.BoolValue != nil {
 		w, err = wire.NewValueBool(*(v.BoolValue)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Int64Value != nil {
 		w, err = wire.NewValueI64(*(v.Int64Value)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.StringValue != nil {
 		w, err = wire.NewValueString(*(v.StringValue)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.ListValue != nil {
 		w, err = wire.NewValueList(_List_ArbitraryValue_ValueList(v.ListValue)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.MapValue != nil {
 		w, err = wire.NewValueMap(_Map_String_ArbitraryValue_MapItemList(v.MapValue)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("ArbitraryValue should have exactly one field: got %v fields", i)
+		return fmt.Errorf("ArbitraryValue should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ArbitraryValue) Close() {}
 
 func _ArbitraryValue_Read(w wire.Value) (*ArbitraryValue, error) {
 	var v ArbitraryValue
@@ -586,36 +604,48 @@ type Document struct {
 //     return err
 //   }
 func (v *Document) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Document)(v)), nil
+}
+
+type _fieldList_Document Document
+
+func (fl *_fieldList_Document) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Document)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Pdf != nil {
 		w, err = v.Pdf.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.PlainText != nil {
 		w, err = wire.NewValueString(*(v.PlainText)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("Document should have exactly one field: got %v fields", i)
+		return fmt.Errorf("Document should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Document) Close() {}
 
 func _PDF_Read(w wire.Value) (typedefs.PDF, error) {
 	var x typedefs.PDF
@@ -790,13 +820,17 @@ type EmptyUnion struct {
 //     return err
 //   }
 func (v *EmptyUnion) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_EmptyUnion)(v)), nil
 }
+
+type _fieldList_EmptyUnion EmptyUnion
+
+func (fl *_fieldList_EmptyUnion) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_EmptyUnion) Close() {}
 
 // FromWire deserializes a EmptyUnion struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -239,9 +239,9 @@ func _Map_String_ArbitraryValue_Read(m wire.MapItemList) (map[string]*ArbitraryV
 //   }
 //   return &v, nil
 func (v *ArbitraryValue) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
@@ -290,7 +290,12 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.BoolValue != nil {
@@ -636,9 +641,9 @@ func _PDF_Read(w wire.Value) (typedefs.PDF, error) {
 //   }
 //   return &v, nil
 func (v *Document) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -659,7 +664,12 @@ func (v *Document) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.Pdf != nil {
@@ -807,10 +817,16 @@ func (v *EmptyUnion) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *EmptyUnion) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -71,31 +71,43 @@ type UUIDConflict struct {
 //     return err
 //   }
 func (v *UUIDConflict) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_UUIDConflict)(v)), nil
+}
+
+type _fieldList_UUIDConflict UUIDConflict
+
+func (fl *_fieldList_UUIDConflict) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*UUIDConflict)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = v.LocalUUID.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.ImportedUUID == nil {
-		return w, errors.New("field ImportedUUID of UUIDConflict is required")
+		return errors.New("field ImportedUUID of UUIDConflict is required")
 	}
 	w, err = v.ImportedUUID.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_UUIDConflict) Close() {}
 
 func _UUID_Read(w wire.Value) (UUID, error) {
 	var x UUID

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -127,12 +127,12 @@ func _UUID_1_Read(w wire.Value) (*typedefs.UUID, error) {
 //   }
 //   return &v, nil
 func (v *UUIDConflict) FromWire(w wire.Value) error {
-	var err error
 
 	localUUIDIsSet := false
 	importedUUIDIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -151,7 +151,12 @@ func (v *UUIDConflict) FromWire(w wire.Value) error {
 				importedUUIDIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !localUUIDIsSet {
 		return errors.New("field LocalUUID of UUIDConflict is required")

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -78,8 +78,7 @@ type _fieldList_UUIDConflict UUIDConflict
 
 func (fl *_fieldList_UUIDConflict) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*UUIDConflict)(fl)
+		v   = (*UUIDConflict)(fl)
 		w   wire.Value
 		err error
 	)
@@ -91,7 +90,6 @@ func (fl *_fieldList_UUIDConflict) ForEach(writeField func(wire.Field) error) er
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.ImportedUUID == nil {
 		return errors.New("field ImportedUUID of UUIDConflict is required")
 	}
@@ -102,7 +100,6 @@ func (fl *_fieldList_UUIDConflict) ForEach(writeField func(wire.Field) error) er
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }

--- a/gen/roundtrip_test.go
+++ b/gen/roundtrip_test.go
@@ -35,6 +35,8 @@ import (
 // assertRoundTrip checks if x.ToWire() results in the given Value and whether
 // x.FromWire() with the given value results in the original x.
 func assertRoundTrip(t *testing.T, x thriftType, v wire.Value, msg string, args ...interface{}) bool {
+	t.Helper()
+
 	message := fmt.Sprintf(msg, args...)
 
 	if w, err := x.ToWire(); assert.NoError(t, err, "failed to serialize: %v", x) {
@@ -65,6 +67,8 @@ func assertRoundTrip(t *testing.T, x thriftType, v wire.Value, msg string, args 
 
 // assertBinaryRoundTrip checks that De/Encode returns the same value.
 func assertBinaryRoundTrip(t *testing.T, w wire.Value, message string) (wire.Value, bool) {
+	t.Helper()
+
 	var buff bytes.Buffer
 	if !assert.NoError(t, protocol.Binary.Encode(w, &buff), "%v: failed to serialize", message) {
 		return w, false

--- a/gen/service_test.go
+++ b/gen/service_test.go
@@ -31,6 +31,7 @@ import (
 	tx "go.uber.org/thriftrw/gen/internal/tests/exceptions"
 	tv "go.uber.org/thriftrw/gen/internal/tests/services"
 	tu "go.uber.org/thriftrw/gen/internal/tests/unions"
+	"go.uber.org/thriftrw/internal/envelope/envelopetest"
 	"go.uber.org/thriftrw/protocol"
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/wire"
@@ -550,7 +551,7 @@ func TestServiceTypesEnveloper(t *testing.T) {
 		expected.SeqID = 1234
 		expected.Value, err = tt.s.ToWire()
 		if assert.NoError(t, err, "Error serializing %v", tt.s) {
-			assert.Equal(t, expected, envelope, "Envelope mismatch for %v", tt)
+			envelopetest.AssertEqual(t, expected, envelope, "envelope mismatch for %v", tt)
 		}
 	}
 }

--- a/internal/envelope/envelopetest/equal.go
+++ b/internal/envelope/envelopetest/equal.go
@@ -1,0 +1,19 @@
+package envelopetest
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/thriftrw/wire"
+)
+
+// AssertEqual asserts that the provided envelopes are equivalent.
+func AssertEqual(t assert.TestingT, want, got wire.Envelope, msgAndArgs ...interface{}) (ok bool) {
+	ok = true
+
+	// Perform all checks and return false if any of them fails.
+	ok = assert.Equal(t, want.Name, got.Name, msgAndArgs...) && ok
+	ok = assert.Equal(t, want.Type, got.Type, msgAndArgs...) && ok
+	ok = assert.Equal(t, want.SeqID, got.SeqID, msgAndArgs...) && ok
+	ok = assert.True(t, wire.ValuesAreEqual(want.Value, got.Value), msgAndArgs...) && ok
+
+	return ok
+}

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -396,9 +396,9 @@ func _ExceptionType_Read(w wire.Value) (ExceptionType, error) {
 //   }
 //   return &v, nil
 func (v *TApplicationException) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -421,7 +421,12 @@ func (v *TApplicationException) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -352,8 +352,7 @@ type _fieldList_TApplicationException TApplicationException
 
 func (fl *_fieldList_TApplicationException) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*TApplicationException)(fl)
+		v   = (*TApplicationException)(fl)
 		w   wire.Value
 		err error
 	)
@@ -366,7 +365,6 @@ func (fl *_fieldList_TApplicationException) ForEach(writeField func(wire.Field) 
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Type != nil {
 		w, err = v.Type.ToWire()
@@ -376,7 +374,6 @@ func (fl *_fieldList_TApplicationException) ForEach(writeField func(wire.Field) 
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -345,32 +345,44 @@ type TApplicationException struct {
 //     return err
 //   }
 func (v *TApplicationException) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_TApplicationException)(v)), nil
+}
+
+type _fieldList_TApplicationException TApplicationException
+
+func (fl *_fieldList_TApplicationException) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*TApplicationException)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Message != nil {
 		w, err = wire.NewValueString(*(v.Message)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Type != nil {
 		w, err = v.Type.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_TApplicationException) Close() {}
 
 func _ExceptionType_Read(w wire.Value) (ExceptionType, error) {
 	var v ExceptionType

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -128,39 +128,53 @@ func (_Map_String_String_MapItemList) Close() {}
 //     return err
 //   }
 func (v *Argument) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Argument)(v)), nil
+}
+
+type _fieldList_Argument Argument
+
+func (fl *_fieldList_Argument) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [3]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Argument)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Name), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Type == nil {
-		return w, errors.New("field Type of Argument is required")
+		return errors.New("field Type of Argument is required")
 	}
 	w, err = v.Type.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Annotations != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.Annotations)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Argument) Close() {}
 
 func _Type_Read(w wire.Value) (*Type, error) {
 	var v Type
@@ -632,68 +646,90 @@ func (_List_Argument_ValueList) Close() {}
 //     return err
 //   }
 func (v *Function) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Function)(v)), nil
+}
+
+type _fieldList_Function Function
+
+func (fl *_fieldList_Function) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [7]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Function)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Name), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.ThriftName), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueList(_List_Argument_ValueList(v.Arguments)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 3, Value: w}
+	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.ReturnType != nil {
 		w, err = v.ReturnType.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Exceptions != nil {
 		w, err = wire.NewValueList(_List_Argument_ValueList(v.Exceptions)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.OneWay != nil {
 		w, err = wire.NewValueBool(*(v.OneWay)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 6, Value: w}
+		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.Annotations != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.Annotations)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 7, Value: w}
+		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Function) Close() {}
 
 func _Argument_Read(w wire.Value) (*Argument, error) {
 	var v Argument
@@ -1228,62 +1264,82 @@ func (_List_ModuleID_ValueList) Close() {}
 //     return err
 //   }
 func (v *GenerateServiceRequest) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_GenerateServiceRequest)(v)), nil
+}
+
+type _fieldList_GenerateServiceRequest GenerateServiceRequest
+
+func (fl *_fieldList_GenerateServiceRequest) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [6]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*GenerateServiceRequest)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueList(_List_ServiceID_ValueList(v.RootServices)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Services == nil {
-		return w, errors.New("field Services of GenerateServiceRequest is required")
+		return errors.New("field Services of GenerateServiceRequest is required")
 	}
 	w, err = wire.NewValueMap(_Map_ServiceID_Service_MapItemList(v.Services)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Modules == nil {
-		return w, errors.New("field Modules of GenerateServiceRequest is required")
+		return errors.New("field Modules of GenerateServiceRequest is required")
 	}
 	w, err = wire.NewValueMap(_Map_ModuleID_Module_MapItemList(v.Modules)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 3, Value: w}
+	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.PackagePrefix), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 4, Value: w}
+	if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.ThriftRoot), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 5, Value: w}
+	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.RootModules != nil {
 		w, err = wire.NewValueList(_List_ModuleID_ValueList(v.RootModules)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 6, Value: w}
+		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_GenerateServiceRequest) Close() {}
 
 func _ServiceID_Read(w wire.Value) (ServiceID, error) {
 	var x ServiceID
@@ -1859,24 +1915,34 @@ func (_Map_String_Binary_MapItemList) Close() {}
 //     return err
 //   }
 func (v *GenerateServiceResponse) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_GenerateServiceResponse)(v)), nil
+}
+
+type _fieldList_GenerateServiceResponse GenerateServiceResponse
+
+func (fl *_fieldList_GenerateServiceResponse) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*GenerateServiceResponse)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Files != nil {
 		w, err = wire.NewValueMap(_Map_String_Binary_MapItemList(v.Files)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_GenerateServiceResponse) Close() {}
 
 func _Map_String_Binary_Read(m wire.MapItemList) (map[string][]byte, error) {
 	if m.KeyType() != wire.TBinary {
@@ -2057,13 +2123,17 @@ type HandshakeRequest struct {
 //     return err
 //   }
 func (v *HandshakeRequest) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_HandshakeRequest)(v)), nil
 }
+
+type _fieldList_HandshakeRequest HandshakeRequest
+
+func (fl *_fieldList_HandshakeRequest) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_HandshakeRequest) Close() {}
 
 // FromWire deserializes a HandshakeRequest struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -2194,44 +2264,60 @@ func (_List_Feature_ValueList) Close() {}
 //     return err
 //   }
 func (v *HandshakeResponse) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_HandshakeResponse)(v)), nil
+}
+
+type _fieldList_HandshakeResponse HandshakeResponse
+
+func (fl *_fieldList_HandshakeResponse) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [4]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*HandshakeResponse)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Name), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueI32(v.APIVersion), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueList(_List_Feature_ValueList(v.Features)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 3, Value: w}
+	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.LibraryVersion != nil {
 		w, err = wire.NewValueString(*(v.LibraryVersion)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_HandshakeResponse) Close() {}
 
 func _Feature_Read(w wire.Value) (Feature, error) {
 	var v Feature
@@ -2519,36 +2605,50 @@ type Module struct {
 //     return err
 //   }
 func (v *Module) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Module)(v)), nil
+}
+
+type _fieldList_Module Module
+
+func (fl *_fieldList_Module) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [3]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Module)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.ImportPath), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.Directory), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.ThriftFilePath), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 3, Value: w}
+	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Module) Close() {}
 
 // FromWire deserializes a Module struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -2814,59 +2914,79 @@ func (_List_Function_ValueList) Close() {}
 //     return err
 //   }
 func (v *Service) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Service)(v)), nil
+}
+
+type _fieldList_Service Service
+
+func (fl *_fieldList_Service) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [6]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Service)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Name), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 7, Value: w}
+	if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.ThriftName), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.ParentID != nil {
 		w, err = v.ParentID.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	w, err = wire.NewValueList(_List_Function_ValueList(v.Functions)), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 5, Value: w}
+	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = v.ModuleID.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 6, Value: w}
+	if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Annotations != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.Annotations)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 8, Value: w}
+		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Service) Close() {}
 
 func _Function_Read(w wire.Value) (*Function, error) {
 	var v Function
@@ -3522,68 +3642,88 @@ type Type struct {
 //     return err
 //   }
 func (v *Type) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Type)(v)), nil
+}
+
+type _fieldList_Type Type
+
+func (fl *_fieldList_Type) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [6]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Type)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.SimpleType != nil {
 		w, err = v.SimpleType.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.SliceType != nil {
 		w, err = v.SliceType.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 2, Value: w}
+		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.KeyValueSliceType != nil {
 		w, err = v.KeyValueSliceType.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.MapType != nil {
 		w, err = v.MapType.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 4, Value: w}
+		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.ReferenceType != nil {
 		w, err = v.ReferenceType.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 5, Value: w}
+		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 	if v.PointerType != nil {
 		w, err = v.PointerType.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 6, Value: w}
+		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("Type should have exactly one field: got %v fields", i)
+		return fmt.Errorf("Type should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Type) Close() {}
 
 func _SimpleType_Read(w wire.Value) (SimpleType, error) {
 	var v SimpleType
@@ -3927,34 +4067,46 @@ type TypePair struct {
 //     return err
 //   }
 func (v *TypePair) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_TypePair)(v)), nil
+}
+
+type _fieldList_TypePair TypePair
+
+func (fl *_fieldList_TypePair) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [2]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*TypePair)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Left == nil {
-		return w, errors.New("field Left of TypePair is required")
+		return errors.New("field Left of TypePair is required")
 	}
 	w, err = v.Left.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Right == nil {
-		return w, errors.New("field Right of TypePair is required")
+		return errors.New("field Right of TypePair is required")
 	}
 	w, err = v.Right.ToWire()
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_TypePair) Close() {}
 
 // FromWire deserializes a TypePair struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -4134,37 +4286,51 @@ type TypeReference struct {
 //     return err
 //   }
 func (v *TypeReference) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_TypeReference)(v)), nil
+}
+
+type _fieldList_TypeReference TypeReference
+
+func (fl *_fieldList_TypeReference) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [3]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*TypeReference)(fl)
+		w   wire.Value
+		err error
 	)
 
 	w, err = wire.NewValueString(v.Name), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 1, Value: w}
+	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+		return err
+	}
 	i++
 
 	w, err = wire.NewValueString(v.ImportPath), error(nil)
 	if err != nil {
-		return w, err
+		return err
 	}
-	fields[i] = wire.Field{ID: 2, Value: w}
+	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
+		return err
+	}
 	i++
 	if v.Annotations != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.Annotations)), error(nil)
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 3, Value: w}
+		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_TypeReference) Close() {}
 
 // FromWire deserializes a TypeReference struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -4358,13 +4524,17 @@ type Plugin_Goodbye_Args struct {
 //     return err
 //   }
 func (v *Plugin_Goodbye_Args) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_Plugin_Goodbye_Args)(v)), nil
 }
+
+type _fieldList_Plugin_Goodbye_Args Plugin_Goodbye_Args
+
+func (fl *_fieldList_Plugin_Goodbye_Args) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_Plugin_Goodbye_Args) Close() {}
 
 // FromWire deserializes a Plugin_Goodbye_Args struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -4541,13 +4711,17 @@ type Plugin_Goodbye_Result struct {
 //     return err
 //   }
 func (v *Plugin_Goodbye_Result) ToWire() (wire.Value, error) {
-	var (
-		fields [0]wire.Field
-		i      int = 0
-	)
-
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return wire.NewValueFieldList((*_fieldList_Plugin_Goodbye_Result)(v)), nil
 }
+
+type _fieldList_Plugin_Goodbye_Result Plugin_Goodbye_Result
+
+func (fl *_fieldList_Plugin_Goodbye_Result) ForEach(writeField func(wire.Field) error) error {
+
+	return nil
+}
+
+func (fl *_fieldList_Plugin_Goodbye_Result) Close() {}
 
 // FromWire deserializes a Plugin_Goodbye_Result struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
@@ -4656,24 +4830,34 @@ type Plugin_Handshake_Args struct {
 //     return err
 //   }
 func (v *Plugin_Handshake_Args) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Plugin_Handshake_Args)(v)), nil
+}
+
+type _fieldList_Plugin_Handshake_Args Plugin_Handshake_Args
+
+func (fl *_fieldList_Plugin_Handshake_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Plugin_Handshake_Args)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Request != nil {
 		w, err = v.Request.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Plugin_Handshake_Args) Close() {}
 
 func _HandshakeRequest_Read(w wire.Value) (*HandshakeRequest, error) {
 	var v HandshakeRequest
@@ -4905,28 +5089,38 @@ type Plugin_Handshake_Result struct {
 //     return err
 //   }
 func (v *Plugin_Handshake_Result) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_Plugin_Handshake_Result)(v)), nil
+}
+
+type _fieldList_Plugin_Handshake_Result Plugin_Handshake_Result
+
+func (fl *_fieldList_Plugin_Handshake_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*Plugin_Handshake_Result)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Success != nil {
 		w, err = v.Success.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 0, Value: w}
+		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("Plugin_Handshake_Result should have exactly one field: got %v fields", i)
+		return fmt.Errorf("Plugin_Handshake_Result should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_Plugin_Handshake_Result) Close() {}
 
 func _HandshakeResponse_Read(w wire.Value) (*HandshakeResponse, error) {
 	var v HandshakeResponse
@@ -5082,24 +5276,34 @@ type ServiceGenerator_Generate_Args struct {
 //     return err
 //   }
 func (v *ServiceGenerator_Generate_Args) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ServiceGenerator_Generate_Args)(v)), nil
+}
+
+type _fieldList_ServiceGenerator_Generate_Args ServiceGenerator_Generate_Args
+
+func (fl *_fieldList_ServiceGenerator_Generate_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ServiceGenerator_Generate_Args)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Request != nil {
 		w, err = v.Request.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 1, Value: w}
+		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ServiceGenerator_Generate_Args) Close() {}
 
 func _GenerateServiceRequest_Read(w wire.Value) (*GenerateServiceRequest, error) {
 	var v GenerateServiceRequest
@@ -5331,28 +5535,38 @@ type ServiceGenerator_Generate_Result struct {
 //     return err
 //   }
 func (v *ServiceGenerator_Generate_Result) ToWire() (wire.Value, error) {
+	return wire.NewValueFieldList((*_fieldList_ServiceGenerator_Generate_Result)(v)), nil
+}
+
+type _fieldList_ServiceGenerator_Generate_Result ServiceGenerator_Generate_Result
+
+func (fl *_fieldList_ServiceGenerator_Generate_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		fields [1]wire.Field
-		i      int = 0
-		w      wire.Value
-		err    error
+		i   int = 0
+		v       = (*ServiceGenerator_Generate_Result)(fl)
+		w   wire.Value
+		err error
 	)
 
 	if v.Success != nil {
 		w, err = v.Success.ToWire()
 		if err != nil {
-			return w, err
+			return err
 		}
-		fields[i] = wire.Field{ID: 0, Value: w}
+		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
+			return err
+		}
 		i++
 	}
 
 	if i != 1 {
-		return wire.Value{}, fmt.Errorf("ServiceGenerator_Generate_Result should have exactly one field: got %v fields", i)
+		return fmt.Errorf("ServiceGenerator_Generate_Result should have exactly one field: got %v fields", i)
 	}
 
-	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+	return nil
 }
+
+func (fl *_fieldList_ServiceGenerator_Generate_Result) Close() {}
 
 func _GenerateServiceResponse_Read(w wire.Value) (*GenerateServiceResponse, error) {
 	var v GenerateServiceResponse

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -135,8 +135,7 @@ type _fieldList_Argument Argument
 
 func (fl *_fieldList_Argument) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Argument)(fl)
+		v   = (*Argument)(fl)
 		w   wire.Value
 		err error
 	)
@@ -148,7 +147,6 @@ func (fl *_fieldList_Argument) ForEach(writeField func(wire.Field) error) error 
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Type == nil {
 		return errors.New("field Type of Argument is required")
 	}
@@ -159,7 +157,6 @@ func (fl *_fieldList_Argument) ForEach(writeField func(wire.Field) error) error 
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Annotations != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.Annotations)), error(nil)
 		if err != nil {
@@ -168,7 +165,6 @@ func (fl *_fieldList_Argument) ForEach(writeField func(wire.Field) error) error 
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -653,8 +649,7 @@ type _fieldList_Function Function
 
 func (fl *_fieldList_Function) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Function)(fl)
+		v   = (*Function)(fl)
 		w   wire.Value
 		err error
 	)
@@ -666,7 +661,6 @@ func (fl *_fieldList_Function) ForEach(writeField func(wire.Field) error) error 
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.ThriftName), error(nil)
 	if err != nil {
@@ -675,7 +669,6 @@ func (fl *_fieldList_Function) ForEach(writeField func(wire.Field) error) error 
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueList(_List_Argument_ValueList(v.Arguments)), error(nil)
 	if err != nil {
@@ -684,7 +677,6 @@ func (fl *_fieldList_Function) ForEach(writeField func(wire.Field) error) error 
 	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.ReturnType != nil {
 		w, err = v.ReturnType.ToWire()
 		if err != nil {
@@ -693,7 +685,6 @@ func (fl *_fieldList_Function) ForEach(writeField func(wire.Field) error) error 
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Exceptions != nil {
 		w, err = wire.NewValueList(_List_Argument_ValueList(v.Exceptions)), error(nil)
@@ -703,7 +694,6 @@ func (fl *_fieldList_Function) ForEach(writeField func(wire.Field) error) error 
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.OneWay != nil {
 		w, err = wire.NewValueBool(*(v.OneWay)), error(nil)
@@ -713,7 +703,6 @@ func (fl *_fieldList_Function) ForEach(writeField func(wire.Field) error) error 
 		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.Annotations != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.Annotations)), error(nil)
@@ -723,7 +712,6 @@ func (fl *_fieldList_Function) ForEach(writeField func(wire.Field) error) error 
 		if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -1271,8 +1259,7 @@ type _fieldList_GenerateServiceRequest GenerateServiceRequest
 
 func (fl *_fieldList_GenerateServiceRequest) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*GenerateServiceRequest)(fl)
+		v   = (*GenerateServiceRequest)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1284,7 +1271,6 @@ func (fl *_fieldList_GenerateServiceRequest) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Services == nil {
 		return errors.New("field Services of GenerateServiceRequest is required")
 	}
@@ -1295,7 +1281,6 @@ func (fl *_fieldList_GenerateServiceRequest) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Modules == nil {
 		return errors.New("field Modules of GenerateServiceRequest is required")
 	}
@@ -1306,7 +1291,6 @@ func (fl *_fieldList_GenerateServiceRequest) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.PackagePrefix), error(nil)
 	if err != nil {
@@ -1315,7 +1299,6 @@ func (fl *_fieldList_GenerateServiceRequest) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.ThriftRoot), error(nil)
 	if err != nil {
@@ -1324,7 +1307,6 @@ func (fl *_fieldList_GenerateServiceRequest) ForEach(writeField func(wire.Field)
 	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.RootModules != nil {
 		w, err = wire.NewValueList(_List_ModuleID_ValueList(v.RootModules)), error(nil)
 		if err != nil {
@@ -1333,7 +1315,6 @@ func (fl *_fieldList_GenerateServiceRequest) ForEach(writeField func(wire.Field)
 		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -1922,8 +1903,7 @@ type _fieldList_GenerateServiceResponse GenerateServiceResponse
 
 func (fl *_fieldList_GenerateServiceResponse) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*GenerateServiceResponse)(fl)
+		v   = (*GenerateServiceResponse)(fl)
 		w   wire.Value
 		err error
 	)
@@ -1936,7 +1916,6 @@ func (fl *_fieldList_GenerateServiceResponse) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -2271,8 +2250,7 @@ type _fieldList_HandshakeResponse HandshakeResponse
 
 func (fl *_fieldList_HandshakeResponse) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*HandshakeResponse)(fl)
+		v   = (*HandshakeResponse)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2284,7 +2262,6 @@ func (fl *_fieldList_HandshakeResponse) ForEach(writeField func(wire.Field) erro
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueI32(v.APIVersion), error(nil)
 	if err != nil {
@@ -2293,7 +2270,6 @@ func (fl *_fieldList_HandshakeResponse) ForEach(writeField func(wire.Field) erro
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueList(_List_Feature_ValueList(v.Features)), error(nil)
 	if err != nil {
@@ -2302,7 +2278,6 @@ func (fl *_fieldList_HandshakeResponse) ForEach(writeField func(wire.Field) erro
 	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.LibraryVersion != nil {
 		w, err = wire.NewValueString(*(v.LibraryVersion)), error(nil)
 		if err != nil {
@@ -2311,7 +2286,6 @@ func (fl *_fieldList_HandshakeResponse) ForEach(writeField func(wire.Field) erro
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -2612,8 +2586,7 @@ type _fieldList_Module Module
 
 func (fl *_fieldList_Module) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Module)(fl)
+		v   = (*Module)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2625,7 +2598,6 @@ func (fl *_fieldList_Module) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.Directory), error(nil)
 	if err != nil {
@@ -2634,7 +2606,6 @@ func (fl *_fieldList_Module) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.ThriftFilePath), error(nil)
 	if err != nil {
@@ -2643,7 +2614,6 @@ func (fl *_fieldList_Module) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -2921,8 +2891,7 @@ type _fieldList_Service Service
 
 func (fl *_fieldList_Service) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Service)(fl)
+		v   = (*Service)(fl)
 		w   wire.Value
 		err error
 	)
@@ -2934,7 +2903,6 @@ func (fl *_fieldList_Service) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 7, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.ThriftName), error(nil)
 	if err != nil {
@@ -2943,7 +2911,6 @@ func (fl *_fieldList_Service) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.ParentID != nil {
 		w, err = v.ParentID.ToWire()
 		if err != nil {
@@ -2952,7 +2919,6 @@ func (fl *_fieldList_Service) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	w, err = wire.NewValueList(_List_Function_ValueList(v.Functions)), error(nil)
@@ -2962,7 +2928,6 @@ func (fl *_fieldList_Service) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = v.ModuleID.ToWire()
 	if err != nil {
@@ -2971,7 +2936,6 @@ func (fl *_fieldList_Service) ForEach(writeField func(wire.Field) error) error {
 	if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Annotations != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.Annotations)), error(nil)
 		if err != nil {
@@ -2980,7 +2944,6 @@ func (fl *_fieldList_Service) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 8, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -3642,6 +3605,30 @@ type Type struct {
 //     return err
 //   }
 func (v *Type) ToWire() (wire.Value, error) {
+	i := 0
+	if v.SimpleType != nil {
+		i++
+	}
+	if v.SliceType != nil {
+		i++
+	}
+	if v.KeyValueSliceType != nil {
+		i++
+	}
+	if v.MapType != nil {
+		i++
+	}
+	if v.ReferenceType != nil {
+		i++
+	}
+	if v.PointerType != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("Type should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_Type)(v)), nil
 }
 
@@ -3649,8 +3636,7 @@ type _fieldList_Type Type
 
 func (fl *_fieldList_Type) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Type)(fl)
+		v   = (*Type)(fl)
 		w   wire.Value
 		err error
 	)
@@ -3663,7 +3649,6 @@ func (fl *_fieldList_Type) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.SliceType != nil {
 		w, err = v.SliceType.ToWire()
@@ -3673,7 +3658,6 @@ func (fl *_fieldList_Type) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.KeyValueSliceType != nil {
 		w, err = v.KeyValueSliceType.ToWire()
@@ -3683,7 +3667,6 @@ func (fl *_fieldList_Type) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.MapType != nil {
 		w, err = v.MapType.ToWire()
@@ -3693,7 +3676,6 @@ func (fl *_fieldList_Type) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 4, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.ReferenceType != nil {
 		w, err = v.ReferenceType.ToWire()
@@ -3703,7 +3685,6 @@ func (fl *_fieldList_Type) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 5, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 	if v.PointerType != nil {
 		w, err = v.PointerType.ToWire()
@@ -3713,11 +3694,6 @@ func (fl *_fieldList_Type) ForEach(writeField func(wire.Field) error) error {
 		if err := writeField(wire.Field{ID: 6, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("Type should have exactly one field: got %v fields", i)
 	}
 
 	return nil
@@ -4074,8 +4050,7 @@ type _fieldList_TypePair TypePair
 
 func (fl *_fieldList_TypePair) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*TypePair)(fl)
+		v   = (*TypePair)(fl)
 		w   wire.Value
 		err error
 	)
@@ -4090,7 +4065,6 @@ func (fl *_fieldList_TypePair) ForEach(writeField func(wire.Field) error) error 
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Right == nil {
 		return errors.New("field Right of TypePair is required")
 	}
@@ -4101,7 +4075,6 @@ func (fl *_fieldList_TypePair) ForEach(writeField func(wire.Field) error) error 
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	return nil
 }
@@ -4293,8 +4266,7 @@ type _fieldList_TypeReference TypeReference
 
 func (fl *_fieldList_TypeReference) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*TypeReference)(fl)
+		v   = (*TypeReference)(fl)
 		w   wire.Value
 		err error
 	)
@@ -4306,7 +4278,6 @@ func (fl *_fieldList_TypeReference) ForEach(writeField func(wire.Field) error) e
 	if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 		return err
 	}
-	i++
 
 	w, err = wire.NewValueString(v.ImportPath), error(nil)
 	if err != nil {
@@ -4315,7 +4286,6 @@ func (fl *_fieldList_TypeReference) ForEach(writeField func(wire.Field) error) e
 	if err := writeField(wire.Field{ID: 2, Value: w}); err != nil {
 		return err
 	}
-	i++
 	if v.Annotations != nil {
 		w, err = wire.NewValueMap(_Map_String_String_MapItemList(v.Annotations)), error(nil)
 		if err != nil {
@@ -4324,7 +4294,6 @@ func (fl *_fieldList_TypeReference) ForEach(writeField func(wire.Field) error) e
 		if err := writeField(wire.Field{ID: 3, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -4837,8 +4806,7 @@ type _fieldList_Plugin_Handshake_Args Plugin_Handshake_Args
 
 func (fl *_fieldList_Plugin_Handshake_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Plugin_Handshake_Args)(fl)
+		v   = (*Plugin_Handshake_Args)(fl)
 		w   wire.Value
 		err error
 	)
@@ -4851,7 +4819,6 @@ func (fl *_fieldList_Plugin_Handshake_Args) ForEach(writeField func(wire.Field) 
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -5089,6 +5056,15 @@ type Plugin_Handshake_Result struct {
 //     return err
 //   }
 func (v *Plugin_Handshake_Result) ToWire() (wire.Value, error) {
+	i := 0
+	if v.Success != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("Plugin_Handshake_Result should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_Plugin_Handshake_Result)(v)), nil
 }
 
@@ -5096,8 +5072,7 @@ type _fieldList_Plugin_Handshake_Result Plugin_Handshake_Result
 
 func (fl *_fieldList_Plugin_Handshake_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*Plugin_Handshake_Result)(fl)
+		v   = (*Plugin_Handshake_Result)(fl)
 		w   wire.Value
 		err error
 	)
@@ -5110,11 +5085,6 @@ func (fl *_fieldList_Plugin_Handshake_Result) ForEach(writeField func(wire.Field
 		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("Plugin_Handshake_Result should have exactly one field: got %v fields", i)
 	}
 
 	return nil
@@ -5283,8 +5253,7 @@ type _fieldList_ServiceGenerator_Generate_Args ServiceGenerator_Generate_Args
 
 func (fl *_fieldList_ServiceGenerator_Generate_Args) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ServiceGenerator_Generate_Args)(fl)
+		v   = (*ServiceGenerator_Generate_Args)(fl)
 		w   wire.Value
 		err error
 	)
@@ -5297,7 +5266,6 @@ func (fl *_fieldList_ServiceGenerator_Generate_Args) ForEach(writeField func(wir
 		if err := writeField(wire.Field{ID: 1, Value: w}); err != nil {
 			return err
 		}
-		i++
 	}
 
 	return nil
@@ -5535,6 +5503,15 @@ type ServiceGenerator_Generate_Result struct {
 //     return err
 //   }
 func (v *ServiceGenerator_Generate_Result) ToWire() (wire.Value, error) {
+	i := 0
+	if v.Success != nil {
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("ServiceGenerator_Generate_Result should have exactly one field: got %v fields", i)
+	}
+
 	return wire.NewValueFieldList((*_fieldList_ServiceGenerator_Generate_Result)(v)), nil
 }
 
@@ -5542,8 +5519,7 @@ type _fieldList_ServiceGenerator_Generate_Result ServiceGenerator_Generate_Resul
 
 func (fl *_fieldList_ServiceGenerator_Generate_Result) ForEach(writeField func(wire.Field) error) error {
 	var (
-		i   int = 0
-		v       = (*ServiceGenerator_Generate_Result)(fl)
+		v   = (*ServiceGenerator_Generate_Result)(fl)
 		w   wire.Value
 		err error
 	)
@@ -5556,11 +5532,6 @@ func (fl *_fieldList_ServiceGenerator_Generate_Result) ForEach(writeField func(w
 		if err := writeField(wire.Field{ID: 0, Value: w}); err != nil {
 			return err
 		}
-		i++
-	}
-
-	if i != 1 {
-		return fmt.Errorf("ServiceGenerator_Generate_Result should have exactly one field: got %v fields", i)
 	}
 
 	return nil

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -214,12 +214,12 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 //   }
 //   return &v, nil
 func (v *Argument) FromWire(w wire.Value) error {
-	var err error
 
 	nameIsSet := false
 	typeIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -246,7 +246,12 @@ func (v *Argument) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !nameIsSet {
 		return errors.New("field Name of Argument is required")
@@ -732,13 +737,13 @@ func _List_Argument_Read(l wire.ValueList) ([]*Argument, error) {
 //   }
 //   return &v, nil
 func (v *Function) FromWire(w wire.Value) error {
-	var err error
 
 	nameIsSet := false
 	thriftNameIsSet := false
 	argumentsIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -799,7 +804,12 @@ func (v *Function) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !nameIsSet {
 		return errors.New("field Name of Function is required")
@@ -1409,7 +1419,6 @@ func _List_ModuleID_Read(l wire.ValueList) ([]ModuleID, error) {
 //   }
 //   return &v, nil
 func (v *GenerateServiceRequest) FromWire(w wire.Value) error {
-	var err error
 
 	rootServicesIsSet := false
 	servicesIsSet := false
@@ -1417,7 +1426,8 @@ func (v *GenerateServiceRequest) FromWire(w wire.Value) error {
 	packagePrefixIsSet := false
 	thriftRootIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TList {
@@ -1468,7 +1478,12 @@ func (v *GenerateServiceRequest) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !rootServicesIsSet {
 		return errors.New("field RootServices of GenerateServiceRequest is required")
@@ -1909,9 +1924,9 @@ func _Map_String_Binary_Read(m wire.MapItemList) (map[string][]byte, error) {
 //   }
 //   return &v, nil
 func (v *GenerateServiceResponse) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TMap {
@@ -1922,7 +1937,12 @@ func (v *GenerateServiceResponse) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -2064,10 +2084,16 @@ func (v *HandshakeRequest) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *HandshakeRequest) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -2249,13 +2275,13 @@ func _List_Feature_Read(l wire.ValueList) ([]Feature, error) {
 //   }
 //   return &v, nil
 func (v *HandshakeResponse) FromWire(w wire.Value) error {
-	var err error
 
 	nameIsSet := false
 	apiVersionIsSet := false
 	featuresIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -2292,7 +2318,12 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !nameIsSet {
 		return errors.New("field Name of HandshakeResponse is required")
@@ -2537,13 +2568,13 @@ func (v *Module) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Module) FromWire(w wire.Value) error {
-	var err error
 
 	importPathIsSet := false
 	directoryIsSet := false
 	thriftFilePathIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -2570,7 +2601,12 @@ func (v *Module) FromWire(w wire.Value) error {
 				thriftFilePathIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !importPathIsSet {
 		return errors.New("field ImportPath of Module is required")
@@ -2874,7 +2910,6 @@ func _List_Function_Read(l wire.ValueList) ([]*Function, error) {
 //   }
 //   return &v, nil
 func (v *Service) FromWire(w wire.Value) error {
-	var err error
 
 	nameIsSet := false
 	thriftNameIsSet := false
@@ -2882,7 +2917,8 @@ func (v *Service) FromWire(w wire.Value) error {
 	functionsIsSet := false
 	moduleIDIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 7:
 			if field.Value.Type() == wire.TBinary {
@@ -2935,7 +2971,12 @@ func (v *Service) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !nameIsSet {
 		return errors.New("field Name of Service is required")
@@ -3580,9 +3621,9 @@ func _TypeReference_Read(w wire.Value) (*TypeReference, error) {
 //   }
 //   return &v, nil
 func (v *Type) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
@@ -3635,7 +3676,12 @@ func (v *Type) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.SimpleType != nil {
@@ -3928,12 +3974,12 @@ func (v *TypePair) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *TypePair) FromWire(w wire.Value) error {
-	var err error
 
 	leftIsSet := false
 	rightIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -3952,7 +3998,12 @@ func (v *TypePair) FromWire(w wire.Value) error {
 				rightIsSet = true
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !leftIsSet {
 		return errors.New("field Left of TypePair is required")
@@ -4133,12 +4184,12 @@ func (v *TypeReference) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *TypeReference) FromWire(w wire.Value) error {
-	var err error
 
 	nameIsSet := false
 	importPathIsSet := false
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
@@ -4165,7 +4216,12 @@ func (v *TypeReference) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	if !nameIsSet {
 		return errors.New("field Name of TypeReference is required")
@@ -4329,10 +4385,16 @@ func (v *Plugin_Goodbye_Args) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *Plugin_Goodbye_Args) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -4506,10 +4568,16 @@ func (v *Plugin_Goodbye_Result) ToWire() (wire.Value, error) {
 //   return &v, nil
 func (v *Plugin_Goodbye_Result) FromWire(w wire.Value) error {
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -4631,9 +4699,9 @@ func _HandshakeRequest_Read(w wire.Value) (*HandshakeRequest, error) {
 //   }
 //   return &v, nil
 func (v *Plugin_Handshake_Args) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -4644,7 +4712,12 @@ func (v *Plugin_Handshake_Args) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -4879,9 +4952,9 @@ func _HandshakeResponse_Read(w wire.Value) (*HandshakeResponse, error) {
 //   }
 //   return &v, nil
 func (v *Plugin_Handshake_Result) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 0:
 			if field.Value.Type() == wire.TStruct {
@@ -4892,7 +4965,12 @@ func (v *Plugin_Handshake_Result) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.Success != nil {
@@ -5047,9 +5125,9 @@ func _GenerateServiceRequest_Read(w wire.Value) (*GenerateServiceRequest, error)
 //   }
 //   return &v, nil
 func (v *ServiceGenerator_Generate_Args) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
@@ -5060,7 +5138,12 @@ func (v *ServiceGenerator_Generate_Args) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	return nil
 }
@@ -5295,9 +5378,9 @@ func _GenerateServiceResponse_Read(w wire.Value) (*GenerateServiceResponse, erro
 //   }
 //   return &v, nil
 func (v *ServiceGenerator_Generate_Result) FromWire(w wire.Value) error {
-	var err error
 
-	for _, field := range w.GetStruct().Fields {
+	fields := w.GetFieldList()
+	err := fields.ForEach(func(field wire.Field) (err error) {
 		switch field.ID {
 		case 0:
 			if field.Value.Type() == wire.TStruct {
@@ -5308,7 +5391,12 @@ func (v *ServiceGenerator_Generate_Result) FromWire(w wire.Value) error {
 
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	fields.Close()
 
 	count := 0
 	if v.Success != nil {

--- a/protocol/binary/lazy_field_list.go
+++ b/protocol/binary/lazy_field_list.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package binary
+
+import (
+	"sync"
+
+	"go.uber.org/thriftrw/wire"
+)
+
+var (
+	lazyFieldListPool = sync.Pool{New: func() interface{} {
+		return new(lazyFieldList)
+	}}
+)
+
+type lazyFieldList struct {
+	reader *Reader
+	offset int64
+}
+
+func borrowLazyFieldList(r *Reader) *lazyFieldList {
+	return lazyFieldListPool.Get().(*lazyFieldList)
+}
+
+func (ll *lazyFieldList) Close() {
+	ll.reader = nil
+	lazyFieldListPool.Put(ll)
+}
+
+func (ll *lazyFieldList) ForEach(f func(wire.Field) error) error {
+	off := ll.offset
+
+	br := ll.reader
+	typ, off, err := br.readByte(off)
+	if err != nil {
+		return err
+	}
+
+	for typ != 0 {
+		var fid int16
+		var val wire.Value
+
+		fid, off, err = br.readInt16(off)
+		if err != nil {
+			return err
+		}
+
+		val, off, err = br.ReadValue(wire.Type(typ), off)
+		if err != nil {
+			return err
+		}
+
+		if err := f(wire.Field{ID: fid, Value: val}); err != nil {
+			return err
+		}
+
+		typ, off, err = br.readByte(off)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/protocol/binary_test.go
+++ b/protocol/binary_test.go
@@ -28,6 +28,7 @@ import (
 	"reflect"
 	"testing"
 
+	"go.uber.org/thriftrw/internal/envelope/envelopetest"
 	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/wire"
 
@@ -787,7 +788,7 @@ func TestBinaryEnvelopeSuccessful(t *testing.T) {
 			continue
 		}
 
-		if !assert.Equal(t, tt.want, e, "%v: decoded envelope mismatch") {
+		if !envelopetest.AssertEqual(t, tt.want, e, "%v: decoded envelope mismatch", tt) {
 			continue
 		}
 
@@ -799,7 +800,7 @@ func TestBinaryEnvelopeSuccessful(t *testing.T) {
 			continue
 		}
 
-		if !assert.Equal(t, tt.want.Value, r, "%v: decoded request mismatch", tt.msg) {
+		if !assert.True(t, wire.ValuesAreEqual(tt.want.Value, r), "%v: decoded request mismatch", tt.msg) {
 			continue
 		}
 

--- a/wire/evaluate.go
+++ b/wire/evaluate.go
@@ -23,18 +23,17 @@ package wire
 import "fmt"
 
 // EvaluateValue ensures that the given Value is fully evaluated. Lazy lists
-// are spinned and any errors raised by them are returned.
+// are spun and any errors raised by them are returned.
 func EvaluateValue(v Value) error {
 	switch v.Type() {
 	case TBool, TI8, TDouble, TI16, TI32, TI64, TBinary:
 		return nil
 	case TStruct:
-		for _, f := range v.GetStruct().Fields {
-			if err := EvaluateValue(f.Value); err != nil {
-				return err
-			}
-		}
-		return nil
+		fs := v.GetFieldList()
+		defer fs.Close()
+		return fs.ForEach(func(f Field) error {
+			return EvaluateValue(f.Value)
+		})
 	case TMap:
 		m := v.GetMap()
 		defer m.Close()

--- a/wire/lazy_field_list.go
+++ b/wire/lazy_field_list.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package wire
+
+// FieldList is a list of fields of a struct.
+type FieldList interface {
+	// ForEach calls the provided function on all serializable fields in a
+	// struct.
+	//
+	// If the provided function returns a non-nil error, ForEach halts and
+	// returns the error.
+	ForEach(func(Field) error) error
+
+	// Close releases any resources associated with the FieldList. The
+	// FieldList MUST NOT be used again after this invocation.
+	Close()
+}
+
+// FieldListFromSlice builds a FieldList from the provided slice.
+func FieldListFromSlice(fields []Field) FieldList {
+	return fieldList(fields)
+}
+
+type fieldList []Field
+
+func (fl fieldList) ForEach(f func(Field) error) error {
+	for _, field := range fl {
+		if err := f(field); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (fl fieldList) Close() {}
+
+// FieldListToSlice converts a FieldList to a list of fields.
+func FieldListToSlice(fl FieldList) []Field {
+	if fields, ok := fl.(fieldList); ok {
+		// Optimize FieldListToSlice(FieldListFromSlice(...))
+		return fields
+	}
+
+	var fields []Field
+	// ignore the error; this cannot fail
+	_ = fl.ForEach(func(f Field) error {
+		fields = append(fields, f)
+		return nil
+	})
+	return fields
+}

--- a/wire/value.go
+++ b/wire/value.go
@@ -39,7 +39,7 @@ type Value struct {
 	tnumber uint64
 	tbinary []byte
 	tstruct Struct
-	tcoll   interface{} // set/map/list
+	tiface  interface{} // set/map/list
 }
 
 // Type retrieves the type of value inside a Value.
@@ -202,40 +202,40 @@ func (v *Value) GetStruct() Struct {
 // NewValueMap constructs a new Value that contains a map.
 func NewValueMap(v MapItemList) Value {
 	return Value{
-		typ:   TMap,
-		tcoll: v,
+		typ:    TMap,
+		tiface: v,
 	}
 }
 
 // GetMap gets the Map value from a Value.
 func (v *Value) GetMap() MapItemList {
-	return v.tcoll.(MapItemList)
+	return v.tiface.(MapItemList)
 }
 
 // NewValueSet constructs a new Value that contains a set.
 func NewValueSet(v ValueList) Value {
 	return Value{
-		typ:   TSet,
-		tcoll: v,
+		typ:    TSet,
+		tiface: v,
 	}
 }
 
 // GetSet gets the Set value from a Value.
 func (v *Value) GetSet() ValueList {
-	return v.tcoll.(ValueList)
+	return v.tiface.(ValueList)
 }
 
 // NewValueList constructs a new Value that contains a list.
 func NewValueList(v ValueList) Value {
 	return Value{
-		typ:   TList,
-		tcoll: v,
+		typ:    TList,
+		tiface: v,
 	}
 }
 
 // GetList gets the List value from a Value.
 func (v *Value) GetList() ValueList {
-	return v.tcoll.(ValueList)
+	return v.tiface.(ValueList)
 }
 
 func (v Value) String() string {
@@ -257,11 +257,11 @@ func (v Value) String() string {
 	case TStruct:
 		return fmt.Sprintf("TStruct(%v)", v.tstruct)
 	case TMap:
-		return fmt.Sprintf("TMap(%v)", v.tcoll)
+		return fmt.Sprintf("TMap(%v)", v.tiface)
 	case TSet:
-		return fmt.Sprintf("TSet(%v)", v.tcoll)
+		return fmt.Sprintf("TSet(%v)", v.tiface)
 	case TList:
-		return fmt.Sprintf("TList(%v)", v.tcoll)
+		return fmt.Sprintf("TList(%v)", v.tiface)
 	default:
 		panic(fmt.Sprintf("Unknown value type %v", v.typ))
 	}

--- a/wire/value_equals.go
+++ b/wire/value_equals.go
@@ -54,11 +54,11 @@ func ValuesAreEqual(left, right Value) bool {
 	case TStruct:
 		return StructsAreEqual(left.tstruct, right.tstruct)
 	case TMap:
-		return MapsAreEqual(left.tcoll.(MapItemList), right.tcoll.(MapItemList))
+		return MapsAreEqual(left.tiface.(MapItemList), right.tiface.(MapItemList))
 	case TSet:
-		return SetsAreEqual(left.tcoll.(ValueList), right.tcoll.(ValueList))
+		return SetsAreEqual(left.tiface.(ValueList), right.tiface.(ValueList))
 	case TList:
-		return ListsAreEqual(left.tcoll.(ValueList), right.tcoll.(ValueList))
+		return ListsAreEqual(left.tiface.(ValueList), right.tiface.(ValueList))
 	default:
 		return false
 	}

--- a/wire/value_equals.go
+++ b/wire/value_equals.go
@@ -52,7 +52,7 @@ func ValuesAreEqual(left, right Value) bool {
 	case TBinary:
 		return bytes.Equal(left.tbinary, right.tbinary)
 	case TStruct:
-		return StructsAreEqual(left.tstruct, right.tstruct)
+		return StructsAreEqual(left.GetFieldList(), right.GetFieldList())
 	case TMap:
 		return MapsAreEqual(left.tiface.(MapItemList), right.tiface.(MapItemList))
 	case TSet:
@@ -65,16 +65,25 @@ func ValuesAreEqual(left, right Value) bool {
 }
 
 // StructsAreEqual checks if two structs are equal.
-func StructsAreEqual(left, right Struct) bool {
-	if len(left.Fields) != len(right.Fields) {
-		return false
-	}
-
+func StructsAreEqual(left, right FieldList) bool {
 	// Fields are unordered so we need to build a map to actually compare
 	// them.
 
-	leftFields := left.fieldMap()
-	rightFields := right.fieldMap()
+	leftFields := make(map[int16]Value)
+	left.ForEach(func(f Field) error {
+		leftFields[f.ID] = f.Value
+		return nil
+	})
+
+	rightFields := make(map[int16]Value)
+	right.ForEach(func(f Field) error {
+		rightFields[f.ID] = f.Value
+		return nil
+	})
+
+	if len(leftFields) != len(rightFields) {
+		return false
+	}
 
 	for i, lvalue := range leftFields {
 		if rvalue, ok := rightFields[i]; !ok {


### PR DESCRIPTION
@kanads found out that some services were spending a lot of time
allocating and growing slices of `[]wire.Field` during deserialization.
Specifically, [on this line][1], where we append to the slice, we spend
a fair bit of CPU growing the slice.

    fields = append(fields, wire.Field{ID: fid, Value: val})

@kanads is experimenting with pre-allocating these slices to some sane
value in production. That's a good short-term fix, but the long-term
fix is likely to address this TODO in that function:

    // TODO(abg) add a lazy FieldList type instead of []Field.

[1]: https://github.com/thriftrw/thriftrw-go/blob/9c16419a8cced33850d40e7620e5dfe96e7b1a4f/protocol/binary/reader.go#L304

This change adds a lazy wire.FieldList type that behaves similarly to
the wire.ValueList and wire.MapItemList types.

    type FieldList interface {
        ForEach(func(Field) error) error
        Close()
    }

Using this, during deserialization we can return an implementation that
doesn't deserialize from the struct until ForEach is called.

---

I'm not completely sold on this yet because of nested structs: for
nested structs, we'll end up skipping over them several times. However,
this might still end up being more efficient than the many allocations
we make. Benchmarks pending.

```
name                                        old time/op    new time/op    delta
RoundTrip/PrimitiveOptionalStruct/Encode-4    3.14µs ±22%    2.21µs ±12%   -29.72%  (p=0.008 n=5+5)
RoundTrip/PrimitiveOptionalStruct/Decode-4    4.79µs ±17%    3.38µs ±19%   -29.49%  (p=0.016 n=5+5)
RoundTrip/Graph/Encode-4                      7.16µs ±23%    3.37µs ±28%   -52.92%  (p=0.008 n=5+5)
RoundTrip/Graph/Decode-4                      9.59µs ±16%    8.64µs ±11%      ~     (p=0.222 n=5+5)
RoundTrip/ContainersOfContainers/Encode-4     34.5µs ±11%    27.9µs ±10%   -19.11%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Decode-4     80.6µs ±16%    78.6µs ±33%      ~     (p=0.548 n=5+5)

name                                        old alloc/op   new alloc/op   delta
RoundTrip/PrimitiveOptionalStruct/Encode-4      704B ± 0%        0B       -100.00%  (p=0.008 n=5+5)
RoundTrip/PrimitiveOptionalStruct/Decode-4    1.40kB ± 0%    0.09kB ± 0%   -93.71%  (p=0.008 n=5+5)
RoundTrip/Graph/Encode-4                      1.70kB ± 0%    0.02kB ± 0%   -98.59%  (p=0.008 n=5+5)
RoundTrip/Graph/Decode-4                      2.78kB ± 0%    0.56kB ± 0%   -79.72%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Encode-4     1.30kB ± 0%    0.41kB ± 0%   -68.71%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Decode-4     12.3kB ± 0%    11.0kB ± 0%   -10.66%  (p=0.008 n=5+5)

name                                        old allocs/op  new allocs/op  delta
RoundTrip/PrimitiveOptionalStruct/Encode-4      1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
RoundTrip/PrimitiveOptionalStruct/Decode-4      14.0 ± 0%      11.0 ± 0%   -21.43%  (p=0.008 n=5+5)
RoundTrip/Graph/Encode-4                        11.0 ± 0%       1.0 ± 0%   -90.91%  (p=0.008 n=5+5)
RoundTrip/Graph/Decode-4                        32.0 ± 0%      42.0 ± 0%   +31.25%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Encode-4       18.0 ± 0%      17.0 ± 0%    -5.56%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Decode-4        164 ± 0%       161 ± 0%    -1.59%  (p=0.008 n=5+5)
```