### PR TITLE
[WIP] Pre-allocate slices to prevent resizing at runtime

### DIFF
--- a/protocol/binary/reader.go
+++ b/protocol/binary/reader.go
@@ -261,6 +261,8 @@ func (br *Reader) readBytes(off int64) ([]byte, int64, error) {
 	// bytesAllocThreshold. We don't want bad requests to lock the system up.
 	if length > bytesAllocThreshold {
 		var buff bytes.Buffer
+		buff.Grow(int(length))
+
 		off, err = br.copyN(&buff, off, int64(length))
 		if err != nil {
 			return nil, off, err

--- a/protocol/binary/reader.go
+++ b/protocol/binary/reader.go
@@ -311,6 +311,11 @@ func (br *Reader) readStruct(off int64) (wire.Struct, int64, error) {
 			return wire.Struct{}, off, err
 		}
 	}
+
+	if len(fields) == 0 {
+		// Don't let unused slice escape.
+		return wire.Struct{}, off, err
+	}
 	return wire.Struct{Fields: fields}, off, err
 }
 

--- a/protocol/binary/reader.go
+++ b/protocol/binary/reader.go
@@ -279,7 +279,8 @@ func (br *Reader) readString(off int64) (string, int64, error) {
 }
 
 func (br *Reader) readStruct(off int64) (wire.Struct, int64, error) {
-	var fields []wire.Field
+	// Pre-allocate slice to prevent frequesnt resizing at shorter slice lengths.
+	fields := make([]wire.Field, 0, 128)
 	// TODO(abg) add a lazy FieldList type instead of []Field.
 
 	typ, off, err := br.readByte(off)

--- a/protocol/binary/reader_benchmark_test.go
+++ b/protocol/binary/reader_benchmark_test.go
@@ -1,0 +1,48 @@
+package binary
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"go.uber.org/thriftrw/wire"
+)
+
+func Benchmark_readStruct(b *testing.B) {
+	for _, bench := range []struct {
+		name      string
+		numFields int
+	}{
+		{
+			name:      "small struct with 64 fields",
+			numFields: 64,
+		},
+		{
+			name:      "large struct with 512 fields",
+			numFields: 512,
+		},
+	} {
+		reader := NewReader(constructThriftStruct(bench.numFields))
+
+		b.Run(bench.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				reader.readStruct(0)
+			}
+		})
+	}
+}
+
+// constructThriftStruct constructs a message containing a struct with n bool fields.
+func constructThriftStruct(n int) io.ReaderAt {
+	var buf bytes.Buffer
+	buf.Grow(n*4 + 1)
+	boolField := []byte{byte(wire.TBool), 0, 0, 0}
+
+	for i := 0; i < n; i++ {
+		buf.Write(boolField)
+	}
+	// A zero byte to terminate the message
+	buf.WriteByte(0)
+
+	return bytes.NewReader(buf.Bytes())
+}


### PR DESCRIPTION
It was noticed that some services were spending a lot of time calling `runtime.growSlice` on the `wire.Field` slice. Additionally, it was noticed that most of the time on these slice resize calls were to `runtime.mallocgc`, and not to `runtime.memmove`. This hints the extra calls are commonly due to resizing smaller slice lengths.

This patch pre-allocates the slice to optimize the common case (until PR #469 is merged).

Benchmark results:
```
name                                           old time/op    new time/op    delta
_readStruct/small_struct_with_64_fields-12     8.19µs ± 2%    6.86µs ± 4%    -16.16%  (p=0.008 n=5+5)
_readStruct/large_struct_with_512_fields-12    65.6µs ± 3%    57.2µs ± 1%    -12.74%  (p=0.008 n=5+5)

name                                           old alloc/op   new alloc/op   delta
_readStruct/small_struct_with_64_fields-12     12.0kB ± 0%    12.3kB ± 0%     +2.81%  (p=0.008 n=5+5)
_readStruct/large_struct_with_512_fields-12    98.0kB ± 0%    86.0kB ± 0%    -12.20%  (p=0.008 n=5+5)

name                                           old allocs/op  new allocs/op  delta
_readStruct/small_struct_with_64_fields-12       7.00 ± 0%      1.00 ± 0%    -85.71%  (p=0.008 n=5+5)
_readStruct/large_struct_with_512_fields-12      10.0 ± 0%       3.0 ± 0%    -70.00%  (p=0.008 n=5+5)
```