### PR TITLE
WIP: gen/FromWire: Allocate pointer fields once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,3 +134,4 @@ cover:
 .PHONY: clean
 clean:
 	go clean
+	rm $(GOBIN)/thriftrw

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -97,15 +97,21 @@ func (v *AccessorConflict) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *AccessorConflict) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Name       string
+		GetName2   string
+		IsSetName2 bool
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.Name = &x
+				ptrFields.Name, err = field.Value.GetString(), error(nil)
+				v.Name = &ptrFields.Name
 				if err != nil {
 					return err
 				}
@@ -113,9 +119,8 @@ func (v *AccessorConflict) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.GetName2 = &x
+				ptrFields.GetName2, err = field.Value.GetString(), error(nil)
+				v.GetName2 = &ptrFields.GetName2
 				if err != nil {
 					return err
 				}
@@ -123,9 +128,8 @@ func (v *AccessorConflict) FromWire(w wire.Value) error {
 			}
 		case 3:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.IsSetName2 = &x
+				ptrFields.IsSetName2, err = field.Value.GetBool(), error(nil)
+				v.IsSetName2 = &ptrFields.IsSetName2
 				if err != nil {
 					return err
 				}
@@ -334,15 +338,20 @@ func (v *AccessorNoConflict) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *AccessorNoConflict) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Getname string
+		GetName string
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.Getname = &x
+				ptrFields.Getname, err = field.Value.GetString(), error(nil)
+				v.Getname = &ptrFields.Getname
 				if err != nil {
 					return err
 				}
@@ -350,9 +359,8 @@ func (v *AccessorNoConflict) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.GetName = &x
+				ptrFields.GetName, err = field.Value.GetString(), error(nil)
+				v.GetName = &ptrFields.GetName
 				if err != nil {
 					return err
 				}
@@ -923,6 +931,10 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveContainers) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
@@ -1210,6 +1222,10 @@ func (v *StructCollision) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *StructCollision) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	collisionFieldIsSet := false
@@ -1383,15 +1399,20 @@ func (v *UnionCollision) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *UnionCollision) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		CollisionField  bool
+		CollisionField2 string
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.CollisionField = &x
+				ptrFields.CollisionField, err = field.Value.GetBool(), error(nil)
+				v.CollisionField = &ptrFields.CollisionField
 				if err != nil {
 					return err
 				}
@@ -1399,9 +1420,8 @@ func (v *UnionCollision) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.CollisionField2 = &x
+				ptrFields.CollisionField2, err = field.Value.GetString(), error(nil)
+				v.CollisionField2 = &ptrFields.CollisionField2
 				if err != nil {
 					return err
 				}
@@ -1567,12 +1587,6 @@ func (v *WithDefault) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _StructCollision_Read(w wire.Value) (*StructCollision2, error) {
-	var v StructCollision2
-	err := v.FromWire(w)
-	return &v, err
-}
-
 // FromWire deserializes a WithDefault struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1591,13 +1605,19 @@ func _StructCollision_Read(w wire.Value) (*StructCollision2, error) {
 //   }
 //   return &v, nil
 func (v *WithDefault) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Pouet StructCollision2
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.Pouet, err = _StructCollision_Read(field.Value)
+				err = ptrFields.Pouet.FromWire(field.Value)
+				v.Pouet = &ptrFields.Pouet
 				if err != nil {
 					return err
 				}
@@ -1963,6 +1983,10 @@ func (v *StructCollision2) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *StructCollision2) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	collisionFieldIsSet := false
@@ -2136,15 +2160,20 @@ func (v *UnionCollision2) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *UnionCollision2) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		CollisionField  bool
+		CollisionField2 string
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.CollisionField = &x
+				ptrFields.CollisionField, err = field.Value.GetBool(), error(nil)
+				v.CollisionField = &ptrFields.CollisionField
 				if err != nil {
 					return err
 				}
@@ -2152,9 +2181,8 @@ func (v *UnionCollision2) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.CollisionField2 = &x
+				ptrFields.CollisionField2, err = field.Value.GetString(), error(nil)
+				v.CollisionField2 = &ptrFields.CollisionField2
 				if err != nil {
 					return err
 				}

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -1144,6 +1144,10 @@ func _Map_Set_I32_mapType_List_Double_Read(m wire.MapItemList) ([]struct {
 //   }
 //   return &v, nil
 func (v *ContainersOfContainers) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
@@ -2351,6 +2355,10 @@ func _Map_EnumWithDuplicateValues_I32_Read(m wire.MapItemList) (map[enums.EnumWi
 //   }
 //   return &v, nil
 func (v *EnumContainers) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
@@ -2751,6 +2759,10 @@ func _List_RecordType_1_Read(l wire.ValueList) ([]enums.RecordType, error) {
 //   }
 //   return &v, nil
 func (v *ListOfConflictingEnums) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	recordsIsSet := false
@@ -3082,6 +3094,10 @@ func _List_UUID_1_Read(l wire.ValueList) ([]uuid_conflict.UUID, error) {
 //   }
 //   return &v, nil
 func (v *ListOfConflictingUUIDs) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	uuidsIsSet := false
@@ -3304,6 +3320,10 @@ func (v *ListOfOptionalPrimitives) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ListOfOptionalPrimitives) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
@@ -3438,6 +3458,10 @@ func (v *ListOfRequiredPrimitives) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ListOfRequiredPrimitives) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	listOfStringsIsSet := false
@@ -3733,6 +3757,10 @@ func _Map_String_Binary_Read(m wire.MapItemList) (map[string][]byte, error) {
 //   }
 //   return &v, nil
 func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
@@ -4302,6 +4330,10 @@ func _Map_String_Bool_Read(m wire.MapItemList) (map[string]bool, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveContainers) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
@@ -4830,6 +4862,10 @@ func _Map_I64_Double_Read(m wire.MapItemList) (map[int64]float64, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveContainersRequired) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	listOfStringsIsSet := false

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -295,15 +295,20 @@ func _RecordType_1_Read(w wire.Value) (enums.RecordType, error) {
 //   }
 //   return &v, nil
 func (v *Records) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		RecordType      RecordType
+		OtherRecordType enums.RecordType
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
-				var x RecordType
-				x, err = _RecordType_Read(field.Value)
-				v.RecordType = &x
+				ptrFields.RecordType, err = _RecordType_Read(field.Value)
+				v.RecordType = &ptrFields.RecordType
 				if err != nil {
 					return err
 				}
@@ -311,9 +316,8 @@ func (v *Records) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TI32 {
-				var x enums.RecordType
-				x, err = _RecordType_1_Read(field.Value)
-				v.OtherRecordType = &x
+				ptrFields.OtherRecordType, err = _RecordType_1_Read(field.Value)
+				v.OtherRecordType = &ptrFields.OtherRecordType
 				if err != nil {
 					return err
 				}

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -1601,15 +1601,19 @@ func _EnumDefault_Read(w wire.Value) (EnumDefault, error) {
 //   }
 //   return &v, nil
 func (v *StructWithOptionalEnum) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		E EnumDefault
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
-				var x EnumDefault
-				x, err = _EnumDefault_Read(field.Value)
-				v.E = &x
+				ptrFields.E, err = _EnumDefault_Read(field.Value)
+				v.E = &ptrFields.E
 				if err != nil {
 					return err
 				}

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -78,6 +78,11 @@ func (v *DoesNotExistException) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *DoesNotExistException) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Error2 string
+	}
+	_ = ptrFields
+
 	var err error
 
 	keyIsSet := false
@@ -94,9 +99,8 @@ func (v *DoesNotExistException) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.Error2 = &x
+				ptrFields.Error2, err = field.Value.GetString(), error(nil)
+				v.Error2 = &ptrFields.Error2
 				if err != nil {
 					return err
 				}
@@ -273,6 +277,11 @@ func (v *DoesNotExistException2) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *DoesNotExistException2) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Error2 string
+	}
+	_ = ptrFields
+
 	var err error
 
 	keyIsSet := false
@@ -289,9 +298,8 @@ func (v *DoesNotExistException2) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.Error2 = &x
+				ptrFields.Error2, err = field.Value.GetString(), error(nil)
+				v.Error2 = &ptrFields.Error2
 				if err != nil {
 					return err
 				}
@@ -438,6 +446,9 @@ func (v *EmptyException) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *EmptyException) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -54,12 +54,6 @@ func (v *DocumentStruct) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
-	var v non_hyphenated.Second
-	err := v.FromWire(w)
-	return &v, err
-}
-
 // FromWire deserializes a DocumentStruct struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -78,6 +72,11 @@ func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
 //   }
 //   return &v, nil
 func (v *DocumentStruct) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Second non_hyphenated.Second
+	}
+	_ = ptrFields
+
 	var err error
 
 	secondIsSet := false
@@ -86,7 +85,8 @@ func (v *DocumentStruct) FromWire(w wire.Value) error {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.Second, err = _Second_Read(field.Value)
+				err = ptrFields.Second.FromWire(field.Value)
+				v.Second = &ptrFields.Second
 				if err != nil {
 					return err
 				}

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -54,12 +54,6 @@ func (v *DocumentStructure) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
-	var v non_hyphenated.Second
-	err := v.FromWire(w)
-	return &v, err
-}
-
 // FromWire deserializes a DocumentStructure struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -78,6 +72,11 @@ func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
 //   }
 //   return &v, nil
 func (v *DocumentStructure) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		R2 non_hyphenated.Second
+	}
+	_ = ptrFields
+
 	var err error
 
 	r2IsSet := false
@@ -86,7 +85,8 @@ func (v *DocumentStructure) FromWire(w wire.Value) error {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.R2, err = _Second_Read(field.Value)
+				err = ptrFields.R2.FromWire(field.Value)
+				v.R2 = &ptrFields.R2
 				if err != nil {
 					return err
 				}

--- a/gen/internal/tests/non_hyphenated/non_hyphenated.go
+++ b/gen/internal/tests/non_hyphenated/non_hyphenated.go
@@ -56,6 +56,9 @@ func (v *First) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *First) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
@@ -146,6 +149,9 @@ func (v *Second) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Second) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -475,6 +475,10 @@ func _Map_I64_Double_Read(m wire.MapItemList) (map[int64]float64, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	boolFieldIsSet := false

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -82,6 +82,10 @@ func (v *ConflictingNamesSetValueArgs) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ConflictingNamesSetValueArgs) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	keyIsSet := false
@@ -247,15 +251,19 @@ func (v *InternalError) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *InternalError) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Message string
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.Message = &x
+				ptrFields.Message, err = field.Value.GetString(), error(nil)
+				v.Message = &ptrFields.Message
 				if err != nil {
 					return err
 				}
@@ -447,6 +455,9 @@ func (v *Cache_Clear_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Cache_Clear_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
@@ -583,15 +594,19 @@ func (v *Cache_ClearAfter_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Cache_ClearAfter_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		DurationMS int64
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI64 {
-				var x int64
-				x, err = field.Value.GetI64(), error(nil)
-				v.DurationMS = &x
+				ptrFields.DurationMS, err = field.Value.GetI64(), error(nil)
+				v.DurationMS = &ptrFields.DurationMS
 				if err != nil {
 					return err
 				}
@@ -753,12 +768,6 @@ func (v *ConflictingNames_SetValue_Args) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _ConflictingNamesSetValueArgs_Read(w wire.Value) (*ConflictingNamesSetValueArgs, error) {
-	var v ConflictingNamesSetValueArgs
-	err := v.FromWire(w)
-	return &v, err
-}
-
 // FromWire deserializes a ConflictingNames_SetValue_Args struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -777,13 +786,19 @@ func _ConflictingNamesSetValueArgs_Read(w wire.Value) (*ConflictingNamesSetValue
 //   }
 //   return &v, nil
 func (v *ConflictingNames_SetValue_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Request ConflictingNamesSetValueArgs
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.Request, err = _ConflictingNamesSetValueArgs_Read(field.Value)
+				err = ptrFields.Request.FromWire(field.Value)
+				v.Request = &ptrFields.Request
 				if err != nil {
 					return err
 				}
@@ -994,6 +1009,9 @@ func (v *ConflictingNames_SetValue_Result) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ConflictingNames_SetValue_Result) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
@@ -1120,15 +1138,19 @@ func _Key_Read(w wire.Value) (Key, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_DeleteValue_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Key Key
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
-				var x Key
-				x, err = _Key_Read(field.Value)
-				v.Key = &x
+				ptrFields.Key, err = _Key_Read(field.Value)
+				v.Key = &ptrFields.Key
 				if err != nil {
 					return err
 				}
@@ -1382,18 +1404,6 @@ func (v *KeyValue_DeleteValue_Result) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _DoesNotExistException_Read(w wire.Value) (*exceptions.DoesNotExistException, error) {
-	var v exceptions.DoesNotExistException
-	err := v.FromWire(w)
-	return &v, err
-}
-
-func _InternalError_Read(w wire.Value) (*InternalError, error) {
-	var v InternalError
-	err := v.FromWire(w)
-	return &v, err
-}
-
 // FromWire deserializes a KeyValue_DeleteValue_Result struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1412,13 +1422,20 @@ func _InternalError_Read(w wire.Value) (*InternalError, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		DoesNotExist  exceptions.DoesNotExistException
+		InternalError InternalError
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.DoesNotExist, err = _DoesNotExistException_Read(field.Value)
+				err = ptrFields.DoesNotExist.FromWire(field.Value)
+				v.DoesNotExist = &ptrFields.DoesNotExist
 				if err != nil {
 					return err
 				}
@@ -1426,7 +1443,8 @@ func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.InternalError, err = _InternalError_Read(field.Value)
+				err = ptrFields.InternalError.FromWire(field.Value)
+				v.InternalError = &ptrFields.InternalError
 				if err != nil {
 					return err
 				}
@@ -1654,6 +1672,10 @@ func _List_Key_Read(l wire.ValueList) ([]Key, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_GetManyValues_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
@@ -1998,6 +2020,11 @@ func _List_ArbitraryValue_Read(l wire.ValueList) ([]*unions.ArbitraryValue, erro
 //   }
 //   return &v, nil
 func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		DoesNotExist exceptions.DoesNotExistException
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
@@ -2012,7 +2039,8 @@ func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
 			}
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.DoesNotExist, err = _DoesNotExistException_Read(field.Value)
+				err = ptrFields.DoesNotExist.FromWire(field.Value)
+				v.DoesNotExist = &ptrFields.DoesNotExist
 				if err != nil {
 					return err
 				}
@@ -2222,15 +2250,19 @@ func (v *KeyValue_GetValue_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_GetValue_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Key Key
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
-				var x Key
-				x, err = _Key_Read(field.Value)
-				v.Key = &x
+				ptrFields.Key, err = _Key_Read(field.Value)
+				v.Key = &ptrFields.Key
 				if err != nil {
 					return err
 				}
@@ -2489,13 +2521,20 @@ func (v *KeyValue_GetValue_Result) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Success      unions.ArbitraryValue
+		DoesNotExist exceptions.DoesNotExistException
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 0:
 			if field.Value.Type() == wire.TStruct {
-				v.Success, err = _ArbitraryValue_Read(field.Value)
+				err = ptrFields.Success.FromWire(field.Value)
+				v.Success = &ptrFields.Success
 				if err != nil {
 					return err
 				}
@@ -2503,7 +2542,8 @@ func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
 			}
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.DoesNotExist, err = _DoesNotExistException_Read(field.Value)
+				err = ptrFields.DoesNotExist.FromWire(field.Value)
+				v.DoesNotExist = &ptrFields.DoesNotExist
 				if err != nil {
 					return err
 				}
@@ -2696,15 +2736,20 @@ func (v *KeyValue_SetValue_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Key   Key
+		Value unions.ArbitraryValue
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
-				var x Key
-				x, err = _Key_Read(field.Value)
-				v.Key = &x
+				ptrFields.Key, err = _Key_Read(field.Value)
+				v.Key = &ptrFields.Key
 				if err != nil {
 					return err
 				}
@@ -2712,7 +2757,8 @@ func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.Value, err = _ArbitraryValue_Read(field.Value)
+				err = ptrFields.Value.FromWire(field.Value)
+				v.Value = &ptrFields.Value
 				if err != nil {
 					return err
 				}
@@ -2951,6 +2997,9 @@ func (v *KeyValue_SetValue_Result) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_SetValue_Result) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
@@ -3083,6 +3132,11 @@ func (v *KeyValue_SetValueV2_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Value unions.ArbitraryValue
+	}
+	_ = ptrFields
+
 	var err error
 
 	keyIsSet := false
@@ -3100,7 +3154,8 @@ func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.Value, err = _ArbitraryValue_Read(field.Value)
+				err = ptrFields.Value.FromWire(field.Value)
+				v.Value = &ptrFields.Value
 				if err != nil {
 					return err
 				}
@@ -3332,6 +3387,9 @@ func (v *KeyValue_SetValueV2_Result) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_SetValueV2_Result) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
@@ -3440,6 +3498,9 @@ func (v *KeyValue_Size_Args) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_Size_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
@@ -3642,15 +3703,19 @@ func (v *KeyValue_Size_Result) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *KeyValue_Size_Result) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Success int64
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 0:
 			if field.Value.Type() == wire.TI64 {
-				var x int64
-				x, err = field.Value.GetI64(), error(nil)
-				v.Success = &x
+				ptrFields.Success, err = field.Value.GetI64(), error(nil)
+				v.Success = &ptrFields.Success
 				if err != nil {
 					return err
 				}
@@ -3794,6 +3859,9 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) ToWire() (wire.Val
 //   }
 //   return &v, nil
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
@@ -3971,6 +4039,9 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) ToWire() (wire.V
 //   }
 //   return &v, nil
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -432,6 +432,10 @@ func _StringListList_Read(w wire.Value) (StringListList, error) {
 //   }
 //   return &v, nil
 func (v *Bar) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	requiredInt32ListFieldIsSet := false
@@ -985,6 +989,10 @@ func (v *Foo) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Foo) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	stringFieldIsSet := false

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -72,6 +72,10 @@ func (v *ContactInfo) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ContactInfo) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	emailAddressIsSet := false
@@ -500,18 +504,6 @@ func _List_Double_Read(l wire.ValueList) ([]float64, error) {
 	return o, err
 }
 
-func _Frame_Read(w wire.Value) (*Frame, error) {
-	var v Frame
-	err := v.FromWire(w)
-	return &v, err
-}
-
-func _Edge_Read(w wire.Value) (*Edge, error) {
-	var v Edge
-	err := v.FromWire(w)
-	return &v, err
-}
-
 // FromWire deserializes a DefaultsStruct struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -530,15 +522,29 @@ func _Edge_Read(w wire.Value) (*Edge, error) {
 //   }
 //   return &v, nil
 func (v *DefaultsStruct) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		RequiredPrimitive int32
+		OptionalPrimitive int32
+		RequiredEnum      enums.EnumDefault
+		OptionalEnum      enums.EnumDefault
+
+		RequiredStruct           Frame
+		OptionalStruct           Edge
+		RequiredBoolDefaultTrue  bool
+		OptionalBoolDefaultTrue  bool
+		RequiredBoolDefaultFalse bool
+		OptionalBoolDefaultFalse bool
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
-				var x int32
-				x, err = field.Value.GetI32(), error(nil)
-				v.RequiredPrimitive = &x
+				ptrFields.RequiredPrimitive, err = field.Value.GetI32(), error(nil)
+				v.RequiredPrimitive = &ptrFields.RequiredPrimitive
 				if err != nil {
 					return err
 				}
@@ -546,9 +552,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TI32 {
-				var x int32
-				x, err = field.Value.GetI32(), error(nil)
-				v.OptionalPrimitive = &x
+				ptrFields.OptionalPrimitive, err = field.Value.GetI32(), error(nil)
+				v.OptionalPrimitive = &ptrFields.OptionalPrimitive
 				if err != nil {
 					return err
 				}
@@ -556,9 +561,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 			}
 		case 3:
 			if field.Value.Type() == wire.TI32 {
-				var x enums.EnumDefault
-				x, err = _EnumDefault_Read(field.Value)
-				v.RequiredEnum = &x
+				ptrFields.RequiredEnum, err = _EnumDefault_Read(field.Value)
+				v.RequiredEnum = &ptrFields.RequiredEnum
 				if err != nil {
 					return err
 				}
@@ -566,9 +570,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 			}
 		case 4:
 			if field.Value.Type() == wire.TI32 {
-				var x enums.EnumDefault
-				x, err = _EnumDefault_Read(field.Value)
-				v.OptionalEnum = &x
+				ptrFields.OptionalEnum, err = _EnumDefault_Read(field.Value)
+				v.OptionalEnum = &ptrFields.OptionalEnum
 				if err != nil {
 					return err
 				}
@@ -592,7 +595,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 			}
 		case 7:
 			if field.Value.Type() == wire.TStruct {
-				v.RequiredStruct, err = _Frame_Read(field.Value)
+				err = ptrFields.RequiredStruct.FromWire(field.Value)
+				v.RequiredStruct = &ptrFields.RequiredStruct
 				if err != nil {
 					return err
 				}
@@ -600,7 +604,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 			}
 		case 8:
 			if field.Value.Type() == wire.TStruct {
-				v.OptionalStruct, err = _Edge_Read(field.Value)
+				err = ptrFields.OptionalStruct.FromWire(field.Value)
+				v.OptionalStruct = &ptrFields.OptionalStruct
 				if err != nil {
 					return err
 				}
@@ -608,9 +613,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 			}
 		case 9:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.RequiredBoolDefaultTrue = &x
+				ptrFields.RequiredBoolDefaultTrue, err = field.Value.GetBool(), error(nil)
+				v.RequiredBoolDefaultTrue = &ptrFields.RequiredBoolDefaultTrue
 				if err != nil {
 					return err
 				}
@@ -618,9 +622,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 			}
 		case 10:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.OptionalBoolDefaultTrue = &x
+				ptrFields.OptionalBoolDefaultTrue, err = field.Value.GetBool(), error(nil)
+				v.OptionalBoolDefaultTrue = &ptrFields.OptionalBoolDefaultTrue
 				if err != nil {
 					return err
 				}
@@ -628,9 +631,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 			}
 		case 11:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.RequiredBoolDefaultFalse = &x
+				ptrFields.RequiredBoolDefaultFalse, err = field.Value.GetBool(), error(nil)
+				v.RequiredBoolDefaultFalse = &ptrFields.RequiredBoolDefaultFalse
 				if err != nil {
 					return err
 				}
@@ -638,9 +640,8 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 			}
 		case 12:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.OptionalBoolDefaultFalse = &x
+				ptrFields.OptionalBoolDefaultFalse, err = field.Value.GetBool(), error(nil)
+				v.OptionalBoolDefaultFalse = &ptrFields.OptionalBoolDefaultFalse
 				if err != nil {
 					return err
 				}
@@ -1218,12 +1219,6 @@ func (v *Edge) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _Point_Read(w wire.Value) (*Point, error) {
-	var v Point
-	err := v.FromWire(w)
-	return &v, err
-}
-
 // FromWire deserializes a Edge struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1242,6 +1237,12 @@ func _Point_Read(w wire.Value) (*Point, error) {
 //   }
 //   return &v, nil
 func (v *Edge) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		StartPoint Point
+		EndPoint   Point
+	}
+	_ = ptrFields
+
 	var err error
 
 	startPointIsSet := false
@@ -1251,7 +1252,8 @@ func (v *Edge) FromWire(w wire.Value) error {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.StartPoint, err = _Point_Read(field.Value)
+				err = ptrFields.StartPoint.FromWire(field.Value)
+				v.StartPoint = &ptrFields.StartPoint
 				if err != nil {
 					return err
 				}
@@ -1259,7 +1261,8 @@ func (v *Edge) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.EndPoint, err = _Point_Read(field.Value)
+				err = ptrFields.EndPoint.FromWire(field.Value)
+				v.EndPoint = &ptrFields.EndPoint
 				if err != nil {
 					return err
 				}
@@ -1400,6 +1403,9 @@ func (v *EmptyStruct) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *EmptyStruct) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
@@ -1495,12 +1501,6 @@ func (v *Frame) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _Size_Read(w wire.Value) (*Size, error) {
-	var v Size
-	err := v.FromWire(w)
-	return &v, err
-}
-
 // FromWire deserializes a Frame struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1519,6 +1519,12 @@ func _Size_Read(w wire.Value) (*Size, error) {
 //   }
 //   return &v, nil
 func (v *Frame) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		TopLeft Point
+		Size    Size
+	}
+	_ = ptrFields
+
 	var err error
 
 	topLeftIsSet := false
@@ -1528,7 +1534,8 @@ func (v *Frame) FromWire(w wire.Value) error {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.TopLeft, err = _Point_Read(field.Value)
+				err = ptrFields.TopLeft.FromWire(field.Value)
+				v.TopLeft = &ptrFields.TopLeft
 				if err != nil {
 					return err
 				}
@@ -1536,7 +1543,8 @@ func (v *Frame) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.Size, err = _Size_Read(field.Value)
+				err = ptrFields.Size.FromWire(field.Value)
+				v.Size = &ptrFields.Size
 				if err != nil {
 					return err
 				}
@@ -1729,6 +1737,13 @@ func (v *GoTags) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *GoTags) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Bar string
+
+		FooBarWithOmitEmpty string
+	}
+	_ = ptrFields
+
 	var err error
 
 	FooIsSet := false
@@ -1750,9 +1765,8 @@ func (v *GoTags) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.Bar = &x
+				ptrFields.Bar, err = field.Value.GetString(), error(nil)
+				v.Bar = &ptrFields.Bar
 				if err != nil {
 					return err
 				}
@@ -1776,9 +1790,8 @@ func (v *GoTags) FromWire(w wire.Value) error {
 			}
 		case 5:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.FooBarWithOmitEmpty = &x
+				ptrFields.FooBarWithOmitEmpty, err = field.Value.GetString(), error(nil)
+				v.FooBarWithOmitEmpty = &ptrFields.FooBarWithOmitEmpty
 				if err != nil {
 					return err
 				}
@@ -2040,6 +2053,12 @@ func (v *Graph) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
+func _Edge_Read(w wire.Value) (*Edge, error) {
+	var v Edge
+	err := v.FromWire(w)
+	return &v, err
+}
+
 func _List_Edge_Read(l wire.ValueList) ([]*Edge, error) {
 	if l.ValueType() != wire.TStruct {
 		return nil, nil
@@ -2076,6 +2095,10 @@ func _List_Edge_Read(l wire.ValueList) ([]*Edge, error) {
 //   }
 //   return &v, nil
 func (v *Graph) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	edgesIsSet := false
@@ -2263,12 +2286,6 @@ func (v *Node) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _List_Read(w wire.Value) (*List, error) {
-	var x List
-	err := x.FromWire(w)
-	return &x, err
-}
-
 // FromWire deserializes a Node struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -2287,6 +2304,11 @@ func _List_Read(w wire.Value) (*List, error) {
 //   }
 //   return &v, nil
 func (v *Node) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Tail List
+	}
+	_ = ptrFields
+
 	var err error
 
 	valueIsSet := false
@@ -2303,7 +2325,8 @@ func (v *Node) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.Tail, err = _List_Read(field.Value)
+				err = ptrFields.Tail.FromWire(field.Value)
+				v.Tail = &ptrFields.Tail
 				if err != nil {
 					return err
 				}
@@ -2578,15 +2601,23 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 //   }
 //   return &v, nil
 func (v *NotOmitEmpty) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		NotOmitEmptyString string
+		NotOmitEmptyInt    string
+		NotOmitEmptyBool   string
+
+		OmitEmptyString string
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.NotOmitEmptyString = &x
+				ptrFields.NotOmitEmptyString, err = field.Value.GetString(), error(nil)
+				v.NotOmitEmptyString = &ptrFields.NotOmitEmptyString
 				if err != nil {
 					return err
 				}
@@ -2594,9 +2625,8 @@ func (v *NotOmitEmpty) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.NotOmitEmptyInt = &x
+				ptrFields.NotOmitEmptyInt, err = field.Value.GetString(), error(nil)
+				v.NotOmitEmptyInt = &ptrFields.NotOmitEmptyInt
 				if err != nil {
 					return err
 				}
@@ -2604,9 +2634,8 @@ func (v *NotOmitEmpty) FromWire(w wire.Value) error {
 			}
 		case 3:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.NotOmitEmptyBool = &x
+				ptrFields.NotOmitEmptyBool, err = field.Value.GetString(), error(nil)
+				v.NotOmitEmptyBool = &ptrFields.NotOmitEmptyBool
 				if err != nil {
 					return err
 				}
@@ -2646,9 +2675,8 @@ func (v *NotOmitEmpty) FromWire(w wire.Value) error {
 			}
 		case 8:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.OmitEmptyString = &x
+				ptrFields.OmitEmptyString, err = field.Value.GetString(), error(nil)
+				v.OmitEmptyString = &ptrFields.OmitEmptyString
 				if err != nil {
 					return err
 				}
@@ -2987,6 +3015,10 @@ func (v *Omit) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Omit) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	serializedIsSet := false
@@ -3147,15 +3179,19 @@ func (v *PersonalInfo) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *PersonalInfo) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Age int32
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TI32 {
-				var x int32
-				x, err = field.Value.GetI32(), error(nil)
-				v.Age = &x
+				ptrFields.Age, err = field.Value.GetI32(), error(nil)
+				v.Age = &ptrFields.Age
 				if err != nil {
 					return err
 				}
@@ -3292,6 +3328,10 @@ func (v *Point) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Point) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	xIsSet := false
@@ -3518,15 +3558,25 @@ func (v *PrimitiveOptionalStruct) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		BoolField   bool
+		ByteField   int8
+		Int16Field  int16
+		Int32Field  int32
+		Int64Field  int64
+		DoubleField float64
+		StringField string
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.BoolField = &x
+				ptrFields.BoolField, err = field.Value.GetBool(), error(nil)
+				v.BoolField = &ptrFields.BoolField
 				if err != nil {
 					return err
 				}
@@ -3534,9 +3584,8 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TI8 {
-				var x int8
-				x, err = field.Value.GetI8(), error(nil)
-				v.ByteField = &x
+				ptrFields.ByteField, err = field.Value.GetI8(), error(nil)
+				v.ByteField = &ptrFields.ByteField
 				if err != nil {
 					return err
 				}
@@ -3544,9 +3593,8 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 			}
 		case 3:
 			if field.Value.Type() == wire.TI16 {
-				var x int16
-				x, err = field.Value.GetI16(), error(nil)
-				v.Int16Field = &x
+				ptrFields.Int16Field, err = field.Value.GetI16(), error(nil)
+				v.Int16Field = &ptrFields.Int16Field
 				if err != nil {
 					return err
 				}
@@ -3554,9 +3602,8 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 			}
 		case 4:
 			if field.Value.Type() == wire.TI32 {
-				var x int32
-				x, err = field.Value.GetI32(), error(nil)
-				v.Int32Field = &x
+				ptrFields.Int32Field, err = field.Value.GetI32(), error(nil)
+				v.Int32Field = &ptrFields.Int32Field
 				if err != nil {
 					return err
 				}
@@ -3564,9 +3611,8 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 			}
 		case 5:
 			if field.Value.Type() == wire.TI64 {
-				var x int64
-				x, err = field.Value.GetI64(), error(nil)
-				v.Int64Field = &x
+				ptrFields.Int64Field, err = field.Value.GetI64(), error(nil)
+				v.Int64Field = &ptrFields.Int64Field
 				if err != nil {
 					return err
 				}
@@ -3574,9 +3620,8 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 			}
 		case 6:
 			if field.Value.Type() == wire.TDouble {
-				var x float64
-				x, err = field.Value.GetDouble(), error(nil)
-				v.DoubleField = &x
+				ptrFields.DoubleField, err = field.Value.GetDouble(), error(nil)
+				v.DoubleField = &ptrFields.DoubleField
 				if err != nil {
 					return err
 				}
@@ -3584,9 +3629,8 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 			}
 		case 7:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.StringField = &x
+				ptrFields.StringField, err = field.Value.GetString(), error(nil)
+				v.StringField = &ptrFields.StringField
 				if err != nil {
 					return err
 				}
@@ -3998,6 +4042,10 @@ func (v *PrimitiveRequiredStruct) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	boolFieldIsSet := false
@@ -4337,6 +4385,10 @@ func (v *Rename) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Rename) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	DefaultIsSet := false
@@ -4506,6 +4558,10 @@ func (v *Size) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *Size) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	widthIsSet := false
@@ -4693,15 +4749,22 @@ func (v *StructLabels) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *StructLabels) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		IsRequired bool
+		Foo        string
+		Qux        string
+		Quux       string
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.IsRequired = &x
+				ptrFields.IsRequired, err = field.Value.GetBool(), error(nil)
+				v.IsRequired = &ptrFields.IsRequired
 				if err != nil {
 					return err
 				}
@@ -4709,9 +4772,8 @@ func (v *StructLabels) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.Foo = &x
+				ptrFields.Foo, err = field.Value.GetString(), error(nil)
+				v.Foo = &ptrFields.Foo
 				if err != nil {
 					return err
 				}
@@ -4719,9 +4781,8 @@ func (v *StructLabels) FromWire(w wire.Value) error {
 			}
 		case 3:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.Qux = &x
+				ptrFields.Qux, err = field.Value.GetString(), error(nil)
+				v.Qux = &ptrFields.Qux
 				if err != nil {
 					return err
 				}
@@ -4729,9 +4790,8 @@ func (v *StructLabels) FromWire(w wire.Value) error {
 			}
 		case 4:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.Quux = &x
+				ptrFields.Quux, err = field.Value.GetString(), error(nil)
+				v.Quux = &ptrFields.Quux
 				if err != nil {
 					return err
 				}
@@ -4934,18 +4994,6 @@ func (v *User) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _ContactInfo_Read(w wire.Value) (*ContactInfo, error) {
-	var v ContactInfo
-	err := v.FromWire(w)
-	return &v, err
-}
-
-func _PersonalInfo_Read(w wire.Value) (*PersonalInfo, error) {
-	var v PersonalInfo
-	err := v.FromWire(w)
-	return &v, err
-}
-
 // FromWire deserializes a User struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -4964,6 +5012,12 @@ func _PersonalInfo_Read(w wire.Value) (*PersonalInfo, error) {
 //   }
 //   return &v, nil
 func (v *User) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		Contact  ContactInfo
+		Personal PersonalInfo
+	}
+	_ = ptrFields
+
 	var err error
 
 	nameIsSet := false
@@ -4980,7 +5034,8 @@ func (v *User) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.Contact, err = _ContactInfo_Read(field.Value)
+				err = ptrFields.Contact.FromWire(field.Value)
+				v.Contact = &ptrFields.Contact
 				if err != nil {
 					return err
 				}
@@ -4988,7 +5043,8 @@ func (v *User) FromWire(w wire.Value) error {
 			}
 		case 3:
 			if field.Value.Type() == wire.TStruct {
-				v.Personal, err = _PersonalInfo_Read(field.Value)
+				err = ptrFields.Personal.FromWire(field.Value)
+				v.Personal = &ptrFields.Personal
 				if err != nil {
 					return err
 				}
@@ -5303,6 +5359,10 @@ func (v *ZapOptOutStruct) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *ZapOptOutStruct) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	nameIsSet := false

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -211,15 +211,19 @@ func _State_Read(w wire.Value) (State, error) {
 //   }
 //   return &v, nil
 func (v *DefaultPrimitiveTypedef) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		State State
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBinary {
-				var x State
-				x, err = _State_Read(field.Value)
-				v.State = &x
+				ptrFields.State, err = _State_Read(field.Value)
+				v.State = &ptrFields.State
 				if err != nil {
 					return err
 				}
@@ -559,12 +563,6 @@ func (v *Event) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _UUID_Read(w wire.Value) (*UUID, error) {
-	var x UUID
-	err := x.FromWire(w)
-	return &x, err
-}
-
 func _Timestamp_Read(w wire.Value) (Timestamp, error) {
 	var x Timestamp
 	err := x.FromWire(w)
@@ -589,6 +587,12 @@ func _Timestamp_Read(w wire.Value) (Timestamp, error) {
 //   }
 //   return &v, nil
 func (v *Event) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		UUID UUID
+		Time Timestamp
+	}
+	_ = ptrFields
+
 	var err error
 
 	uuidIsSet := false
@@ -597,7 +601,8 @@ func (v *Event) FromWire(w wire.Value) error {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.UUID, err = _UUID_Read(field.Value)
+				err = ptrFields.UUID.FromWire(field.Value)
+				v.UUID = &ptrFields.UUID
 				if err != nil {
 					return err
 				}
@@ -605,9 +610,8 @@ func (v *Event) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TI64 {
-				var x Timestamp
-				x, err = _Timestamp_Read(field.Value)
-				v.Time = &x
+				ptrFields.Time, err = _Timestamp_Read(field.Value)
+				v.Time = &ptrFields.Time
 				if err != nil {
 					return err
 				}
@@ -1542,6 +1546,10 @@ func _EventGroup_Read(w wire.Value) (EventGroup, error) {
 //   }
 //   return &v, nil
 func (v *Transition) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	fromStateIsSet := false
@@ -1718,12 +1726,6 @@ func (v *TransitiveTypedefField) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _MyUUID_Read(w wire.Value) (*MyUUID, error) {
-	var x MyUUID
-	err := x.FromWire(w)
-	return &x, err
-}
-
 // FromWire deserializes a TransitiveTypedefField struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1742,6 +1744,11 @@ func _MyUUID_Read(w wire.Value) (*MyUUID, error) {
 //   }
 //   return &v, nil
 func (v *TransitiveTypedefField) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		DefUUID MyUUID
+	}
+	_ = ptrFields
+
 	var err error
 
 	defUUIDIsSet := false
@@ -1750,7 +1757,8 @@ func (v *TransitiveTypedefField) FromWire(w wire.Value) error {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.DefUUID, err = _MyUUID_Read(field.Value)
+				err = ptrFields.DefUUID.FromWire(field.Value)
+				v.DefUUID = &ptrFields.DefUUID
 				if err != nil {
 					return err
 				}
@@ -1918,6 +1926,10 @@ func (v *I128) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *I128) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
+
 	var err error
 
 	highIsSet := false

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -239,15 +239,21 @@ func _Map_String_ArbitraryValue_Read(m wire.MapItemList) (map[string]*ArbitraryV
 //   }
 //   return &v, nil
 func (v *ArbitraryValue) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		BoolValue   bool
+		Int64Value  int64
+		StringValue string
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {
 		case 1:
 			if field.Value.Type() == wire.TBool {
-				var x bool
-				x, err = field.Value.GetBool(), error(nil)
-				v.BoolValue = &x
+				ptrFields.BoolValue, err = field.Value.GetBool(), error(nil)
+				v.BoolValue = &ptrFields.BoolValue
 				if err != nil {
 					return err
 				}
@@ -255,9 +261,8 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TI64 {
-				var x int64
-				x, err = field.Value.GetI64(), error(nil)
-				v.Int64Value = &x
+				ptrFields.Int64Value, err = field.Value.GetI64(), error(nil)
+				v.Int64Value = &ptrFields.Int64Value
 				if err != nil {
 					return err
 				}
@@ -265,9 +270,8 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 			}
 		case 3:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.StringValue = &x
+				ptrFields.StringValue, err = field.Value.GetString(), error(nil)
+				v.StringValue = &ptrFields.StringValue
 				if err != nil {
 					return err
 				}
@@ -636,6 +640,11 @@ func _PDF_Read(w wire.Value) (typedefs.PDF, error) {
 //   }
 //   return &v, nil
 func (v *Document) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		PlainText string
+	}
+	_ = ptrFields
+
 	var err error
 
 	for _, field := range w.GetStruct().Fields {
@@ -650,9 +659,8 @@ func (v *Document) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TBinary {
-				var x string
-				x, err = field.Value.GetString(), error(nil)
-				v.PlainText = &x
+				ptrFields.PlainText, err = field.Value.GetString(), error(nil)
+				v.PlainText = &ptrFields.PlainText
 				if err != nil {
 					return err
 				}
@@ -806,6 +814,9 @@ func (v *EmptyUnion) ToWire() (wire.Value, error) {
 //   }
 //   return &v, nil
 func (v *EmptyUnion) FromWire(w wire.Value) error {
+	var ptrFields struct {
+	}
+	_ = ptrFields
 
 	for _, field := range w.GetStruct().Fields {
 		switch field.ID {

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -103,12 +103,6 @@ func _UUID_Read(w wire.Value) (UUID, error) {
 	return x, err
 }
 
-func _UUID_1_Read(w wire.Value) (*typedefs.UUID, error) {
-	var x typedefs.UUID
-	err := x.FromWire(w)
-	return &x, err
-}
-
 // FromWire deserializes a UUIDConflict struct from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -127,6 +121,11 @@ func _UUID_1_Read(w wire.Value) (*typedefs.UUID, error) {
 //   }
 //   return &v, nil
 func (v *UUIDConflict) FromWire(w wire.Value) error {
+	var ptrFields struct {
+		ImportedUUID typedefs.UUID
+	}
+	_ = ptrFields
+
 	var err error
 
 	localUUIDIsSet := false
@@ -144,7 +143,8 @@ func (v *UUIDConflict) FromWire(w wire.Value) error {
 			}
 		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.ImportedUUID, err = _UUID_1_Read(field.Value)
+				err = ptrFields.ImportedUUID.FromWire(field.Value)
+				v.ImportedUUID = &ptrFields.ImportedUUID
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
In FromWire, when we decode pointer fields, our code takes the form,

```
name := value.GetString()  // Given (value wire.Value)
user.Name = &name
```

This results in an allocation for every optional field present over the
wire.

    name := value.GetString()
    user.Name = &name  // alloc

    // ...

    email := value.GetString()
    user.Email = &email  // alloc

    // ...

    age := value.GetInt8()
    user.Age = &age  // alloc

This changes how we generate FromWire for structs to instead allocate
space for all pointer fields once, and then re-use the same block.

    var ptrFields struct {
        Name string
        Email string
        Age int8
    }  // alloc

    ptrFields.Name = value.GetString()
    user.Name = &ptrFields.Name  // no alloc

    ptrFields.Email = value.GetString()
    user.Email = &ptrFields.Email  // no alloc

    ptrFields.Age = value.GetInt8()
    user.Age = &ptrFields.Age  // no alloc

Note that the pre-allocated struct also includes nested struct fields,
so we can avoid that allocation too.

    user.Comment = _Comment_Read(value)
        // func _Comment_Read(value wire.Value) *Comment {
        //   var c Comment
        //   c.FromWire(value)
        //   return &c  // alloc
        // }

    // Becomes,

    var ptrFields struct {
        // ...
        Comment Comment
    }

    ptrFields.Comment.FromWire(value)
    user.Comment = &ptrFields.Comment  // no alloc

This will have the following effects:

Structs with optional primitive fields, or other structs inside them
will go from N small allocations to one big allocation. For most
structs, the total amount of space allocated will remain largely the
same. However, for sparse structs with lots of optional fields where
only a handful of them are set, this will allocate more bytes and
therefore, hold onto more memory than they need.

We think that since the majority case is going to be structs with most
of their fields filled in, reducing the number of allocations takes
precedence.

Performance:

```
$ git co master
$ go test -run '^$' -bench ././Decode -benchmem -count 5 > before.txt
$ git co -
$ go test -run '^$' -bench ././Decode -benchmem -count 5 > after.txt
$ benchstat before.txt after.txt
name                                        old time/op    new time/op    delta
RoundTrip/PrimitiveOptionalStruct/Decode-4    2.93µs ± 5%    2.81µs ± 6%     ~     (p=0.095 n=5+5)
RoundTrip/Graph/Decode-4                      7.30µs ±17%    6.16µs ± 8%  -15.60%  (p=0.032 n=5+5)
RoundTrip/ContainersOfContainers/Decode-4     52.7µs ± 1%    57.7µs ±12%     ~     (p=0.730 n=4+5)

name                                        old alloc/op   new alloc/op   delta
RoundTrip/PrimitiveOptionalStruct/Decode-4    1.40kB ± 0%    1.41kB ± 0%   +0.43%  (p=0.008 n=5+5)
RoundTrip/Graph/Decode-4                      2.78kB ± 0%    2.78kB ± 0%     ~     (all equal)
RoundTrip/ContainersOfContainers/Decode-4     12.3kB ± 0%    12.3kB ± 0%     ~     (p=0.881 n=5+5)

name                                        old allocs/op  new allocs/op  delta
RoundTrip/PrimitiveOptionalStruct/Decode-4      14.0 ± 0%       8.0 ± 0%  -42.86%  (p=0.008 n=5+5)
RoundTrip/Graph/Decode-4                        32.0 ± 0%      29.0 ± 0%   -9.38%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Decode-4        164 ± 0%       164 ± 0%     ~     (p=0.556 n=5+4)
```
