### PR TITLE
idl: Handle escape sequences in string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `double` constants with exponents but without decimal components are now supported.
+- Fix handling of escaped quotes inside string literals.
 
 ## [1.26.0] - 2021-02-18
 ### Changed

--- a/idl/internal/lex.go
+++ b/idl/internal/lex.go
@@ -932,7 +932,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			if len(bs) > 0 && bs[0] == '\'' {
 				str, err = UnquoteSingleQuoted(bs)
 			} else {
-				str, err = strconv.Unquote(string(bs))
+				str, err = UnquoteDoubleQuoted(bs)
 			}
 
 			if err != nil {

--- a/idl/internal/lex.rl
+++ b/idl/internal/lex.rl
@@ -308,7 +308,7 @@ func (lex *lexer) Lex(out *yySymType) int {
                 if len(bs) > 0 && bs[0] == '\'' {
                     str, err = UnquoteSingleQuoted(bs)
                 } else {
-                    str, err = strconv.Unquote(string(bs))
+                    str, err = UnquoteDoubleQuoted(bs)
                 }
 
                 if err != nil {

--- a/idl/internal/quote.go
+++ b/idl/internal/quote.go
@@ -20,14 +20,17 @@
 
 package internal
 
-import "strconv"
+import (
+	"bytes"
+	"strconv"
+)
 
 // UnquoteSingleQuoted unquotes a slice of bytes representing a single quoted
 // string.
 //
 // 	UnquoteSingleQuoted([]byte("'foo'")) == "foo"
 func UnquoteSingleQuoted(in []byte) (string, error) {
-	out := string(swapQuotes(in))
+	out := string(swapQuotes(unescapeQuotes(in, '"')))
 	str, err := strconv.Unquote(out)
 	if err != nil {
 		return str, err
@@ -36,6 +39,22 @@ func UnquoteSingleQuoted(in []byte) (string, error) {
 	// s/'/"/g, s/"/'/g
 	out = string(swapQuotes([]byte(str)))
 	return out, nil
+}
+
+// UnquoteDoubleQuoted unquotes a slice of bytes representing a double quoted
+// string.
+//
+// 	UnquoteDoubleQuoted([]byte("\"foo\"")) == "foo"
+func UnquoteDoubleQuoted(in []byte) (string, error) {
+	return strconv.Unquote(string(unescapeQuotes(in, '\'')))
+}
+
+// unescapeQuotes unescapes all occurences of a quote character in a string.
+//
+//  unescapeQuotes([]byte{'\\', '"'}, '"') == []byte{'"'}
+//  unescapeQuotes([]byte{'\\', '\''}, '\'') == []byte{'\''}
+func unescapeQuotes(in []byte, quote byte) []byte {
+	return bytes.ReplaceAll(in, []byte{'\\', quote}, []byte{quote})
 }
 
 // swapQuotes replaces all single quotes with double quotes and all double

--- a/idl/internal/quote_test.go
+++ b/idl/internal/quote_test.go
@@ -34,11 +34,29 @@ func TestUnquoteSingleQuoted(t *testing.T) {
 		{`'foo'`, "foo"},
 		{`'a "b" c'`, `a "b" c`},
 		{`'a \'b\' c'`, `a 'b' c`},
-		{`'a \\"b\\" c'`, `a \"b\" c`},
+		{`'a \"b\" c'`, `a "b" c`},
 	}
 
 	for _, tt := range tests {
 		got, err := UnquoteSingleQuoted([]byte(tt.in))
+		if assert.NoError(t, err, "Failed to unquote: %#v", tt.in) {
+			assert.Equal(t, tt.out, got, "Unquote incorrect: %#v", tt.in)
+		}
+	}
+}
+
+func TestUnquoteDoubleQuoted(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{`"foo"`, "foo"},
+		{`"a \'b\' c"`, `a 'b' c`},
+		{`"a \"b\" c"`, `a "b" c`},
+	}
+
+	for _, tt := range tests {
+		got, err := UnquoteDoubleQuoted([]byte(tt.in))
 		if assert.NoError(t, err, "Failed to unquote: %#v", tt.in) {
 			assert.Equal(t, tt.out, got, "Unquote incorrect: %#v", tt.in)
 		}

--- a/idl/parser_test.go
+++ b/idl/parser_test.go
@@ -275,6 +275,45 @@ func TestParseConstants(t *testing.T) {
 			}},
 		},
 		{
+			`const string s1 = ""
+			 const string s2 = ''
+			 const string s3 = "\"foo\" \'bar\'"
+			 const string s4 = '\"foo\" \'bar\''
+			 const string s5 = 'foo\tbar\nbaz\\qux'`,
+			&Program{Definitions: []Definition{
+				&Constant{
+					Name:  "s1",
+					Type:  BaseType{ID: StringTypeID, Line: 1},
+					Value: ConstantString(""),
+					Line:  1,
+				},
+				&Constant{
+					Name:  "s2",
+					Type:  BaseType{ID: StringTypeID, Line: 2},
+					Value: ConstantString(""),
+					Line:  2,
+				},
+				&Constant{
+					Name:  "s3",
+					Type:  BaseType{ID: StringTypeID, Line: 3},
+					Value: ConstantString(`"foo" 'bar'`),
+					Line:  3,
+				},
+				&Constant{
+					Name:  "s4",
+					Type:  BaseType{ID: StringTypeID, Line: 4},
+					Value: ConstantString(`"foo" 'bar'`),
+					Line:  4,
+				},
+				&Constant{
+					Name:  "s5",
+					Type:  BaseType{ID: StringTypeID, Line: 5},
+					Value: ConstantString("foo\tbar\nbaz\\qux"),
+					Line:  5,
+				},
+			}},
+		},
+		{
 			`const bool (foo = "a\nb") baz = true
 			 const bool include_something = false`,
 			&Program{Definitions: []Definition{


### PR DESCRIPTION
We pass string literals through strconv.Unquote(), but we need to
perform a little more preprocessing to handle escape quote characters.
Specifically, we need to "unescape" the "opposite" quote characters to
the kind of string we're about to "unquote". That is, for a single-
quoted strings, we need to unescape `\"` sequences, and for double-quoted
strings, we unescape `\'` sequences.