### PR TITLE
fossa: Run separately, only on push

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,0 +1,17 @@
+name: FOSSA Analysis
+on: push
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'thriftrw'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: FOSSA analysis
+        uses: fossas/fossa-action@v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,11 +27,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: FOSSA analysis
-      uses: fossas/fossa-action@v1
-      with:
-        api-key: ${{ secrets.FOSSA_API_KEY }}
-
     - name: Load cached dependencies
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
Currently, the FOSSA analysis is set to run as part of CI. This makes it
impossible to run builds for incoming pull requests because PRs don't
have access to the secrets needed for the FOSSA analysis.

Resolve this by running the FOSSA analysis only when we push to a
branch of the repository.
