### PR TITLE
Add new streaming interfaces for the no-wire representation implementation of ThriftRW

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -71,3 +71,91 @@ type Responder interface {
 	// The EnvelopeType should be either wire.Reply or wire.Exception.
 	EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error
 }
+
+// StreamProtocol defines a specific way for a Thrift value to be encoded or
+// decoded, implemented in a streaming fashion.
+type StreamProtocol interface {
+	// StreamWriter returns a streaming implementation of an encoder for a
+	// Thrift value.
+	StreamWriter(w io.Writer) Writer
+	// StreamReader returns a streaming implementation of a decoder for a
+	// Thrift value.
+	StreamReader(r io.Reader) Reader
+}
+
+// FieldHeader defines the metadata needed to define the beginning of a field
+// in a Thrift value.
+type FieldHeader struct {
+	ID   int16
+	Type wire.Type
+}
+
+// MapHeader defines the metadata needed to define the beginning of a map in a
+// Thrift value.
+type MapHeader struct {
+	KeyType   wire.Type
+	ValueType wire.Type
+	Length    int
+}
+
+// SetHeader defines the metadata needed to define the beginning of a set in a
+// Thrift value.
+type SetHeader struct {
+	Length int
+	Type   wire.Type
+}
+
+// ListHeader defines the metadata needed to define the beginning of a list in a
+// Thrift value.
+type ListHeader struct {
+	Length int
+	Type   wire.Type
+}
+
+// Writer defines an encoder for a Thrift value, implemented in a streaming
+// fashion.
+type Writer interface {
+	WriteBool(b bool) error
+	WriteInt8(i int8) error
+	WriteInt16(i int16) error
+	WriteInt32(i int32) error
+	WriteInt64(i int64) error
+	WriteString(s string) error
+	WriteDouble(f float64) error
+	WriteBinary(b []byte) error
+	WriteStructBegin() error
+	WriteStructEnd() error
+	WriteFieldBegin(f FieldHeader) error
+	WriteFieldEnd() error
+	WriteMapBegin(m MapHeader) error
+	WriteMapEnd() error
+	WriteSetBegin(s SetHeader) error
+	WriteSetEnd() error
+	WriteListBegin(l ListHeader) error
+	WriteListEnd() error
+}
+
+// Reader defines an decoder for a Thrift value, implemented in a streaming
+// fashion.
+type Reader interface {
+	ReadBool() (bool, error)
+	ReadInt8() (int8, error)
+	ReadInt16() (int16, error)
+	ReadInt32() (int32, error)
+	ReadInt64() (int64, error)
+	ReadString() (string, error)
+	ReadDouble() (float64, error)
+	ReadBinary() ([]byte, error)
+	ReadStructBegin() error
+	ReadStructEnd() error
+	ReadFieldBegin() (FieldHeader, bool, error)
+	ReadFieldEnd() error
+	ReadListBegin() (ListHeader, error)
+	ReadListEnd() error
+	ReadSetBegin() (SetHeader, error)
+	ReadSetEnd() error
+	ReadMapBegin() (MapHeader, error)
+	ReadMapEnd() error
+	// Skip skips over the bytes of the wire type and any applicable headers.
+	Skip(w wire.Type) error
+}


### PR DESCRIPTION
Adds the definitions for the StreamProtocol, Reader, and Writer interfaces, which will be implemented in later PRs. 