### PR TITLE
Make Streaming interfaces private to allow for safe experimentation

### DIFF
--- a/internal/iface/iface.go
+++ b/internal/iface/iface.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package iface
+
+// Private will be used to make interfaces defined in ThriftRW private.
+// Example usage:
+//
+// 	import ".../internal/iface"
+//
+// 	type PrivateInterface interface {
+// 		iface.Private
+//
+//		Method1()
+// 	}
+type Private interface{ private() }
+
+// Impl is the implementation for the private interface and should also be
+// referenced.
+// Example usage:
+//
+// 	import ".../internal/iface"
+//
+// 	type PrivateImpl struct {
+// 		iface.Impl
+// 		...
+// 	}
+type Impl struct{}
+
+func (Impl) private() {}

--- a/protocol/stream/stream.go
+++ b/protocol/stream/stream.go
@@ -25,12 +25,15 @@ package stream
 import (
 	"io"
 
+	"go.uber.org/thriftrw/internal/iface"
 	"go.uber.org/thriftrw/wire"
 )
 
 // Protocol defines a specific way for a Thrift value to be encoded or
 // decoded, implemented in a streaming fashion.
 type Protocol interface {
+	iface.Private // this interface is meant for internal implementations only
+
 	// Writer returns a streaming implementation of an encoder for a
 	// Thrift value.
 	Writer(w io.Writer) Writer
@@ -72,6 +75,8 @@ type ListHeader struct {
 // Writer defines an encoder for a Thrift value, implemented in a streaming
 // fashion.
 type Writer interface {
+	iface.Private // this interface is meant for internal implementations only
+
 	WriteBool(b bool) error
 	WriteInt8(i int8) error
 	WriteInt16(i int16) error
@@ -95,6 +100,8 @@ type Writer interface {
 // Reader defines an decoder for a Thrift value, implemented in a streaming
 // fashion.
 type Reader interface {
+	iface.Private // this interface is meant for internal implementations only
+
 	ReadBool() (bool, error)
 	ReadInt8() (int8, error)
 	ReadInt16() (int16, error)


### PR DESCRIPTION
The new streaming Reader/Writer/Protocol interfaces will be experimented on in the `streamdev` branch. The interfaces will be made private for now to disallow custom implementations.