### PR TITLE
idl: Return structured ParseError from idl.Parse()

### DIFF
--- a/idl/error.go
+++ b/idl/error.go
@@ -37,7 +37,10 @@ type LineError struct {
 	Err  error
 }
 
-func newParseError(errors []internal.LineError) *ParseError {
+func newParseError(errors []internal.LineError) error {
+	if len(errors) == 0 {
+		return nil
+	}
 	lines := make([]LineError, len(errors))
 	for i, err := range errors {
 		lines[i] = LineError{Line: err.Line, Err: err.Err}

--- a/idl/error.go
+++ b/idl/error.go
@@ -18,28 +18,38 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package internal
+package idl
 
-import "go.uber.org/thriftrw/ast"
+import (
+	"bytes"
+	"fmt"
 
-func init() {
-	yyErrorVerbose = true
+	"go.uber.org/thriftrw/idl/internal"
+)
+
+// ParseError is an error type listing parse errors and the positions
+// that caused them.
+type ParseError struct{ Lines []LineError }
+
+// LineError holds an error and the line number that caused it.
+type LineError struct {
+	Line int
+	Err  error
 }
 
-// Parse parses the given Thrift document.
-func Parse(s []byte) (*ast.Program, []LineError) {
-	lex := newLexer(s)
-	e := yyParse(lex)
-	if e == 0 && !lex.parseFailed {
-		return lex.program, nil
+func newParseError(errors []internal.LineError) *ParseError {
+	lines := make([]LineError, len(errors))
+	for i, err := range errors {
+		lines[i] = LineError{Line: err.Line, Err: err.Err}
 	}
-	return nil, lex.errors
+	return &ParseError{Lines: lines}
 }
 
-//go:generate ragel -Z -G2 -o lex.go lex.rl
-//go:generate goimports -w ./lex.go
-
-//go:generate goyacc -l thrift.y
-//go:generate goimports -w ./y.go
-
-//go:generate ./generated.sh
+func (pe *ParseError) Error() string {
+	var buffer bytes.Buffer
+	buffer.WriteString("parse error\n")
+	for _, line := range pe.Lines {
+		buffer.WriteString(fmt.Sprintf("  line %d: %s\n", line.Line, line.Err))
+	}
+	return buffer.String()
+}

--- a/idl/internal/error.go
+++ b/idl/internal/error.go
@@ -20,32 +20,8 @@
 
 package internal
 
-import (
-	"bytes"
-	"fmt"
-)
-
-// parseError is an error type to keep track of any parse errors and the
-// positions they occur at.
-type parseError struct {
-	Errors map[int][]string
-}
-
-func newParseError() parseError {
-	return parseError{Errors: make(map[int][]string)}
-}
-
-func (pe parseError) add(line int, msg string) {
-	pe.Errors[line] = append(pe.Errors[line], msg)
-}
-
-func (pe parseError) Error() string {
-	var buffer bytes.Buffer
-	buffer.WriteString("parse error\n")
-	for line, msgs := range pe.Errors {
-		for _, msg := range msgs {
-			buffer.WriteString(fmt.Sprintf("  line %d: %s\n", line, msg))
-		}
-	}
-	return buffer.String()
+// LineError holds a parse error and the line number that caused it.
+type LineError struct {
+	Line int
+	Err  error
 }

--- a/idl/internal/lex.go
+++ b/idl/internal/lex.go
@@ -26,6 +26,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -47,7 +48,7 @@ type lexer struct {
 	lastDocstring       string
 	linesSinceDocstring int
 
-	err         parseError
+	errors      []LineError
 	parseFailed bool
 
 	// Ragel:
@@ -58,7 +59,6 @@ type lexer struct {
 func newLexer(data []byte) *lexer {
 	lex := &lexer{
 		line:        1,
-		err:         newParseError(),
 		parseFailed: false,
 		data:        data,
 		p:           0,
@@ -936,7 +936,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 
 			if err != nil {
-				lex.Error(err.Error())
+				lex.AppendError(err)
 			} else {
 				out.str = str
 				tok = LITERAL
@@ -1263,7 +1263,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				}
 
 				if i64, err := strconv.ParseInt(str, base, 64); err != nil {
-					lex.Error(err.Error())
+					lex.AppendError(err)
 				} else {
 					out.i64 = i64
 					tok = INTCONSTANT
@@ -1280,7 +1280,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 
 				str := string(lex.data[lex.ts:lex.te])
 				if dub, err := strconv.ParseFloat(str, 64); err != nil {
-					lex.Error(err.Error())
+					lex.AppendError(err)
 				} else {
 					out.dub = dub
 					tok = DUBCONSTANT
@@ -1295,7 +1295,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			{
 				(lex.p) = (lex.te) - 1
 
-				lex.Error(fmt.Sprintf("%q is a reserved keyword", reservedKeyword))
+				lex.AppendError(fmt.Errorf("%q is a reserved keyword", reservedKeyword))
 				{
 					(lex.p)++
 					lex.cs = 19
@@ -1344,7 +1344,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 
 			if i64, err := strconv.ParseInt(str, base, 64); err != nil {
-				lex.Error(err.Error())
+				lex.AppendError(err)
 			} else {
 				out.i64 = i64
 				tok = INTCONSTANT
@@ -1396,7 +1396,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 
 			if i64, err := strconv.ParseInt(str, base, 64); err != nil {
-				lex.Error(err.Error())
+				lex.AppendError(err)
 			} else {
 				out.i64 = i64
 				tok = INTCONSTANT
@@ -1414,7 +1414,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		{
 			str := string(lex.data[lex.ts:lex.te])
 			if dub, err := strconv.ParseFloat(str, 64); err != nil {
-				lex.Error(err.Error())
+				lex.AppendError(err)
 			} else {
 				out.dub = dub
 				tok = DUBCONSTANT
@@ -1448,7 +1448,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		lex.te = (lex.p)
 		(lex.p)--
 		{
-			lex.Error(fmt.Sprintf("%q is a reserved keyword", reservedKeyword))
+			lex.AppendError(fmt.Errorf("%q is a reserved keyword", reservedKeyword))
 			{
 				(lex.p)++
 				lex.cs = 19
@@ -16594,14 +16594,18 @@ func (lex *lexer) Lex(out *yySymType) int {
 
 
 	if lex.cs == thrift_error {
-		lex.Error(fmt.Sprintf("unknown token at index %d", lex.p))
+		lex.AppendError(fmt.Errorf("unknown token at index %d", lex.p))
 	}
 	return tok
 }
 
 func (lex *lexer) Error(e string) {
+	lex.AppendError(errors.New(e))
+}
+
+func (lex *lexer) AppendError(err error) {
 	lex.parseFailed = true
-	lex.err.add(lex.line, e)
+	lex.errors = append(lex.errors, LineError{Line: lex.line, Err: err})
 }
 
 func (lex *lexer) LastDocstring() string {

--- a/idl/parser.go
+++ b/idl/parser.go
@@ -29,9 +29,6 @@ import (
 // Parse parses a Thrift document. If there is an error, it will be of type
 // *ParseError.
 func Parse(s []byte) (*ast.Program, error) {
-	program, errors := internal.Parse(s)
-	if len(errors) == 0 {
-		return program, nil
-	}
-	return nil, newParseError(errors)
+	prog, errors := internal.Parse(s)
+	return prog, newParseError(errors)
 }

--- a/idl/parser.go
+++ b/idl/parser.go
@@ -21,10 +21,17 @@
 // Package idl provides a parser for Thrift IDL files.
 package idl
 
-import "go.uber.org/thriftrw/ast"
-import "go.uber.org/thriftrw/idl/internal"
+import (
+	"go.uber.org/thriftrw/ast"
+	"go.uber.org/thriftrw/idl/internal"
+)
 
-// Parse parses a Thrift document.
+// Parse parses a Thrift document. If there is an error, it will be of type
+// *ParseError.
 func Parse(s []byte) (*ast.Program, error) {
-	return internal.Parse(s)
+	program, errors := internal.Parse(s)
+	if len(errors) == 0 {
+		return program, nil
+	}
+	return nil, newParseError(errors)
 }

--- a/idl/parser_test.go
+++ b/idl/parser_test.go
@@ -153,6 +153,7 @@ func TestParseErrors(t *testing.T) {
 	for _, tt := range tests {
 		_, err := Parse([]byte(tt.give))
 		if assert.Error(t, err, "expected error while parsing:\n%s", tt.give) {
+			assert.IsType(t, &ParseError{}, err)
 			for _, msg := range tt.wantErrors {
 				assert.Contains(t, err.Error(), msg, "error for %q must contain %q", tt.give, err.Error(), msg)
 			}


### PR DESCRIPTION
Previously, parse errors (`idl.internal.parseError`) weren't visible to
`idl.Parse()`'s callers. This was inconvenient because it's useful to have
access to (a) the full list of parse errors and (b) the line number that
caused each parse error.

This change introduces `idl.ParseError` which provides a list of errors
and their lines.

Fixes #489