### PR TITLE
Generate "Decode" for "enums" that will directly decode

### DIFF
--- a/gen/enum.go
+++ b/gen/enum.go
@@ -70,6 +70,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 
 		<$stream := import "go.uber.org/thriftrw/protocol/stream">
 		<$wire := import "go.uber.org/thriftrw/wire">
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
 
 		<$enumName := goName .Spec>
 		<formatDoc .Spec.Doc>type <$enumName> int32
@@ -199,6 +200,26 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		//   return <$v>, nil
 		func (<$v> *<$enumName>) FromWire(<$w> <$wire>.Value) error {
 			*<$v> = (<$enumName>)(<$w>.GetI32());
+			return nil
+		}
+
+		<$sr := newVar "sr">
+		// Decode reads off the encoded <$enumName> directly off of the wire.
+		//
+		//   sReader := BinaryStreamer.Reader(reader)
+		//
+		//   var <$v> <$enumName>
+		//   if err := <$v>.Decode(sReader); err != nil {
+		//     return <$enumName>(0), err
+		//   }
+		//   return <$v>, nil
+		func (<$v> *<$enumName>) Decode(<$sr> <$stream>.Reader) error {
+			<- $i := newVar "i" ->
+			<$i>, err := <$sr>.ReadInt32()
+			if err != nil {
+				return err
+			}
+			*<$v> = (<$enumName>)(<$i>)
 			return nil
 		}
 

--- a/gen/enum_test.go
+++ b/gen/enum_test.go
@@ -499,6 +499,8 @@ func TestEnumLabelValid(t *testing.T) {
 			t.Run("wire", func(t *testing.T) {
 				assertRoundTrip(t, &tt.item, wire.NewValueI32(int32(tt.item)),
 					"%v", tt.item)
+				testRoundTripCombos(t, &tt.item, wire.NewValueI32(int32(tt.item)),
+					tt.item.String())
 			})
 		})
 	}

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -714,6 +714,24 @@ func (v *MyEnum) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded MyEnum directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v MyEnum
+//   if err := v.Decode(sReader); err != nil {
+//     return MyEnum(0), err
+//   }
+//   return v, nil
+func (v *MyEnum) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (MyEnum)(i)
+	return nil
+}
+
 // String returns a readable string representation of MyEnum.
 func (v MyEnum) String() string {
 	w := int32(v)
@@ -2158,6 +2176,24 @@ func (v MyEnum2) ToWire() (wire.Value, error) {
 //   return v, nil
 func (v *MyEnum2) FromWire(w wire.Value) error {
 	*v = (MyEnum2)(w.GetI32())
+	return nil
+}
+
+// Decode reads off the encoded MyEnum2 directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v MyEnum2
+//   if err := v.Decode(sReader); err != nil {
+//     return MyEnum2(0), err
+//   }
+//   return v, nil
+func (v *MyEnum2) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (MyEnum2)(i)
 	return nil
 }
 

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -133,6 +133,24 @@ func (v *RecordType) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded RecordType directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v RecordType
+//   if err := v.Decode(sReader); err != nil {
+//     return RecordType(0), err
+//   }
+//   return v, nil
+func (v *RecordType) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (RecordType)(i)
+	return nil
+}
+
 // String returns a readable string representation of RecordType.
 func (v RecordType) String() string {
 	w := int32(v)

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -99,6 +99,24 @@ func (v *EmptyEnum) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded EmptyEnum directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v EmptyEnum
+//   if err := v.Decode(sReader); err != nil {
+//     return EmptyEnum(0), err
+//   }
+//   return v, nil
+func (v *EmptyEnum) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (EmptyEnum)(i)
+	return nil
+}
+
 // String returns a readable string representation of EmptyEnum.
 func (v EmptyEnum) String() string {
 	w := int32(v)
@@ -274,6 +292,24 @@ func (v EnumDefault) ToWire() (wire.Value, error) {
 //   return v, nil
 func (v *EnumDefault) FromWire(w wire.Value) error {
 	*v = (EnumDefault)(w.GetI32())
+	return nil
+}
+
+// Decode reads off the encoded EnumDefault directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v EnumDefault
+//   if err := v.Decode(sReader); err != nil {
+//     return EnumDefault(0), err
+//   }
+//   return v, nil
+func (v *EnumDefault) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (EnumDefault)(i)
 	return nil
 }
 
@@ -525,6 +561,24 @@ func (v *EnumWithDuplicateName) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded EnumWithDuplicateName directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v EnumWithDuplicateName
+//   if err := v.Decode(sReader); err != nil {
+//     return EnumWithDuplicateName(0), err
+//   }
+//   return v, nil
+func (v *EnumWithDuplicateName) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (EnumWithDuplicateName)(i)
+	return nil
+}
+
 // String returns a readable string representation of EnumWithDuplicateName.
 func (v EnumWithDuplicateName) String() string {
 	w := int32(v)
@@ -736,6 +790,24 @@ func (v EnumWithDuplicateValues) ToWire() (wire.Value, error) {
 //   return v, nil
 func (v *EnumWithDuplicateValues) FromWire(w wire.Value) error {
 	*v = (EnumWithDuplicateValues)(w.GetI32())
+	return nil
+}
+
+// Decode reads off the encoded EnumWithDuplicateValues directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v EnumWithDuplicateValues
+//   if err := v.Decode(sReader); err != nil {
+//     return EnumWithDuplicateValues(0), err
+//   }
+//   return v, nil
+func (v *EnumWithDuplicateValues) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (EnumWithDuplicateValues)(i)
 	return nil
 }
 
@@ -956,6 +1028,24 @@ func (v *EnumWithLabel) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded EnumWithLabel directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v EnumWithLabel
+//   if err := v.Decode(sReader); err != nil {
+//     return EnumWithLabel(0), err
+//   }
+//   return v, nil
+func (v *EnumWithLabel) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (EnumWithLabel)(i)
+	return nil
+}
+
 // String returns a readable string representation of EnumWithLabel.
 func (v EnumWithLabel) String() string {
 	w := int32(v)
@@ -1162,6 +1252,24 @@ func (v *EnumWithValues) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded EnumWithValues directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v EnumWithValues
+//   if err := v.Decode(sReader); err != nil {
+//     return EnumWithValues(0), err
+//   }
+//   return v, nil
+func (v *EnumWithValues) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (EnumWithValues)(i)
+	return nil
+}
+
 // String returns a readable string representation of EnumWithValues.
 func (v EnumWithValues) String() string {
 	w := int32(v)
@@ -1364,6 +1472,24 @@ func (v *RecordType) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded RecordType directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v RecordType
+//   if err := v.Decode(sReader); err != nil {
+//     return RecordType(0), err
+//   }
+//   return v, nil
+func (v *RecordType) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (RecordType)(i)
+	return nil
+}
+
 // String returns a readable string representation of RecordType.
 func (v RecordType) String() string {
 	w := int32(v)
@@ -1546,6 +1672,24 @@ func (v RecordTypeValues) ToWire() (wire.Value, error) {
 //   return v, nil
 func (v *RecordTypeValues) FromWire(w wire.Value) error {
 	*v = (RecordTypeValues)(w.GetI32())
+	return nil
+}
+
+// Decode reads off the encoded RecordTypeValues directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v RecordTypeValues
+//   if err := v.Decode(sReader); err != nil {
+//     return RecordTypeValues(0), err
+//   }
+//   return v, nil
+func (v *RecordTypeValues) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (RecordTypeValues)(i)
 	return nil
 }
 
@@ -1914,6 +2058,24 @@ func (v LowerCaseEnum) ToWire() (wire.Value, error) {
 //   return v, nil
 func (v *LowerCaseEnum) FromWire(w wire.Value) error {
 	*v = (LowerCaseEnum)(w.GetI32())
+	return nil
+}
+
+// Decode reads off the encoded LowerCaseEnum directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v LowerCaseEnum
+//   if err := v.Decode(sReader); err != nil {
+//     return LowerCaseEnum(0), err
+//   }
+//   return v, nil
+func (v *LowerCaseEnum) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (LowerCaseEnum)(i)
 	return nil
 }
 

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -119,6 +119,24 @@ func (v *EnumDefault) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded EnumDefault directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v EnumDefault
+//   if err := v.Decode(sReader); err != nil {
+//     return EnumDefault(0), err
+//   }
+//   return v, nil
+func (v *EnumDefault) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (EnumDefault)(i)
+	return nil
+}
+
 // String returns a readable string representation of EnumDefault.
 func (v EnumDefault) String() string {
 	w := int32(v)

--- a/gen/roundtrip_test.go
+++ b/gen/roundtrip_test.go
@@ -132,5 +132,4 @@ func testRoundTripCombos(t *testing.T, x thriftType, v wire.Value, msg string) {
 			}
 		})
 	}
-
 }

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -229,6 +229,24 @@ func (v *ExceptionType) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded ExceptionType directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v ExceptionType
+//   if err := v.Decode(sReader); err != nil {
+//     return ExceptionType(0), err
+//   }
+//   return v, nil
+func (v *ExceptionType) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (ExceptionType)(i)
+	return nil
+}
+
 // String returns a readable string representation of ExceptionType.
 func (v ExceptionType) String() string {
 	w := int32(v)

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -562,6 +562,24 @@ func (v *Feature) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode reads off the encoded Feature directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v Feature
+//   if err := v.Decode(sReader); err != nil {
+//     return Feature(0), err
+//   }
+//   return v, nil
+func (v *Feature) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (Feature)(i)
+	return nil
+}
+
 // String returns a readable string representation of Feature.
 func (v Feature) String() string {
 	w := int32(v)
@@ -3981,6 +3999,24 @@ func (v SimpleType) ToWire() (wire.Value, error) {
 //   return v, nil
 func (v *SimpleType) FromWire(w wire.Value) error {
 	*v = (SimpleType)(w.GetI32())
+	return nil
+}
+
+// Decode reads off the encoded SimpleType directly off of the wire.
+//
+//   sReader := BinaryStreamer.Reader(reader)
+//
+//   var v SimpleType
+//   if err := v.Decode(sReader); err != nil {
+//     return SimpleType(0), err
+//   }
+//   return v, nil
+func (v *SimpleType) Decode(sr stream.Reader) error {
+	i, err := sr.ReadInt32()
+	if err != nil {
+		return err
+	}
+	*v = (SimpleType)(i)
 	return nil
 }
 


### PR DESCRIPTION
Add templating for generating code for "enums" that will utilize the new
`stream.Reader`, performing the same duties as `binary.Decode` and `FromWire`,
but without going through an intermediary format.