### PR TITLE
Provide "decode" code generation for the streaming variants for all other types

### DIFF
--- a/gen/field.go
+++ b/gen/field.go
@@ -42,9 +42,10 @@ const (
 var reservedIdentifiers = map[string]struct{}{
 	"ToWire":   {},
 	"FromWire": {},
+	"Encode":   {},
+	"Decode":   {},
 	"String":   {},
 	"Equals":   {},
-	"Encode":   {},
 }
 
 // fieldGroupGenerator is responsible for generating code for FieldGroups.
@@ -97,6 +98,10 @@ func (f fieldGroupGenerator) Generate(g Generator) error {
 	}
 
 	if err := f.Encode(g); err != nil {
+		return err
+	}
+
+	if err := f.Decode(g); err != nil {
 		return err
 	}
 
@@ -560,6 +565,112 @@ func (f fieldGroupGenerator) Encode(g Generator) error {
 			<end>
 
 			return <$sw>.WriteStructEnd()
+		}
+		`, f, TemplateFunc("constantValuePtr", ConstantValuePtr))
+}
+
+func (f fieldGroupGenerator) Decode(g Generator) error {
+	return g.DeclareFromTemplate(
+		`
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
+
+		<$sr := newVar "sr">
+		<$v := newVar "v">
+		// Decode deserializes a <.Name> struct directly from its Thrift-level
+		// representation, without going through an intemediary type.
+		//
+		// An error is returned if a <.Name> struct could not be generated from the wire
+		// representation.
+		func (<$v> *<.Name>) Decode(<$sr> <$stream>.Reader) error {
+			<$isSet := newNamespace>
+			<range .Fields>
+				<- if .Required ->
+					<$isSet.NewName (printf "%sIsSet" .Name)> := false
+				<- end>
+			<end>
+
+			if err := <$sr>.ReadStructBegin(); err != nil {
+				return err
+			}
+
+			<$fh := newVar "fh">
+			<$ok := newVar "ok">
+			<$fh>, <$ok>, err := <$sr>.ReadFieldBegin()
+			if err != nil {
+				return err
+			}
+
+			for <$ok> {
+				switch <$fh>.ID {
+				<range .Fields ->
+				case <.ID>:
+					if <$fh>.Type == <typeCode .Type> {
+						<- $lhs := printf "%s.%s" $v (goName .) ->
+						<- if .Required ->
+							<$lhs>, err = <decode .Type $sr>
+						<- else ->
+							<decodePtr .Type $lhs $sr>
+						<- end>
+						if err != nil {
+							return err
+						}
+						<if .Required ->
+							<$isSet.Rotate (printf "%sIsSet" .Name)> = true
+						<- end>
+					}
+				<end ->
+				}
+
+				if err := <$sr>.ReadFieldEnd(); err != nil {
+					return err
+				}
+
+				if <$fh>, <$ok>, err = <$sr>.ReadFieldBegin(); err != nil {
+					return err
+				}
+			}
+
+			if err := <$sr>.ReadStructEnd(); err != nil {
+				return err
+			}
+
+			<$structName := .Name>
+			<range .Fields>
+				<$fname := goName .>
+				<$f := printf "%s.%s" $v $fname>
+				<if isNotNil .Default>
+					if <$f> == nil {
+						<$f> = <constantValuePtr .Default .Type>
+					}
+				<else>
+					<if .Required>
+						if !<$isSet.Rotate (printf "%sIsSet" .Name)> {
+							return <import "errors">.New("field <$fname> of <$structName> is required")
+						}
+					<end>
+				<end>
+			<end>
+
+			<if and .IsUnion (len .Fields)>
+				<$fmt := import "fmt">
+				<$count := newVar "count">
+				<$count> := 0
+				<range .Fields ->
+					if <$v>.<goName .> != nil {
+						<$count>++
+					}
+				<end>
+				<- if .AllowEmptyUnion ->
+					if <$count> > 1 {
+						return <$fmt>.Errorf( "<.Name> should have at most one field: got %v fields", <$count>)
+					}
+				<- else ->
+					if <$count> != 1 {
+						return <$fmt>.Errorf( "<.Name> should have exactly one field: got %v fields", <$count>)
+					}
+				<- end>
+			<end>
+			return nil
 		}
 		`, f, TemplateFunc("constantValuePtr", ConstantValuePtr))
 }

--- a/gen/field.go
+++ b/gen/field.go
@@ -309,8 +309,8 @@ func (f fieldGroupGenerator) ToWire(g Generator) error {
 		//     return err
 		//   }
 		func (<$v> *<.Name>) ToWire() (<$wire>.Value, error) {
-    		<$fields := newVar "fields" ->
-    		<- $i := newVar "i" ->
+			<$fields := newVar "fields" ->
+			<- $i := newVar "i" ->
 			<- $wVal := newVar "w" ->
 
 			var (

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -127,9 +127,9 @@ type generator struct {
 	ImportPath  string
 
 	w              WireGenerator
+	s              StreamGenerator
 	e              equalsGenerator
 	z              zapGenerator
-	s              StreamGenerator
 	noZap          bool
 	decls          []ast.Decl
 	thriftImporter ThriftPackageImporter
@@ -238,6 +238,8 @@ func (g *generator) TextTemplate(s string, data interface{}, opts ...TemplateOpt
 		"encodePtr":        curryGenerator(g.s.EncodePtr, g),
 		"toWire":           curryGenerator(g.w.ToWire, g),
 		"toWirePtr":        curryGenerator(g.w.ToWirePtr, g),
+		"decode":           curryGenerator(g.s.Decode, g),
+		"decodePtr":        curryGenerator(g.s.DecodePtr, g),
 		"typeCode":         curryGenerator(TypeCode, g),
 		"equals":           curryGenerator(g.e.Equals, g),
 		"equalsPtr":        curryGenerator(g.e.EqualsPtr, g),

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -186,6 +186,72 @@ func (v *AccessorConflict) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a AccessorConflict struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a AccessorConflict struct could not be generated from the wire
+// representation.
+func (v *AccessorConflict) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Name = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.GetName2 = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.IsSetName2 = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a AccessorConflict
 // struct.
 func (v *AccessorConflict) String() string {
@@ -449,6 +515,62 @@ func (v *AccessorNoConflict) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a AccessorNoConflict struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a AccessorNoConflict struct could not be generated from the wire
+// representation.
+func (v *AccessorNoConflict) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Getname = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.GetName = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a AccessorNoConflict
 // struct.
 func (v *AccessorNoConflict) String() string {
@@ -566,6 +688,13 @@ func (v LittlePotatoe) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *LittlePotatoe) FromWire(w wire.Value) error {
 	x, err := w.GetI64(), error(nil)
+	*v = (LittlePotatoe)(x)
+	return err
+}
+
+// Decode deserializes LittlePotatoe directly off the wire.
+func (v *LittlePotatoe) Decode(sr stream.Reader) error {
+	x, err := sr.ReadInt64()
 	*v = (LittlePotatoe)(x)
 	return err
 }
@@ -1184,6 +1313,167 @@ func (v *PrimitiveContainers) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _List_String_Decode(sr stream.Reader) ([]string, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TBinary {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]string, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_String_mapType_Decode(sr stream.Reader) (map[string]struct{}, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TBinary {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make(map[string]struct{}, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o[v] = struct{}{}
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_String_String_Decode(sr stream.Reader) (map[string]string, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TBinary {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string]string, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a PrimitiveContainers struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveContainers struct could not be generated from the wire
+// representation.
+func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.A, err = _List_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TSet {
+				v.B, err = _Set_String_mapType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TMap {
+				v.C, err = _Map_String_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a PrimitiveContainers
 // struct.
 func (v *PrimitiveContainers) String() string {
@@ -1506,6 +1796,69 @@ func (v *StructCollision) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a StructCollision struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a StructCollision struct could not be generated from the wire
+// representation.
+func (v *StructCollision) Decode(sr stream.Reader) error {
+
+	collisionFieldIsSet := false
+	collision_fieldIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBool {
+				v.CollisionField, err = sr.ReadBool()
+				if err != nil {
+					return err
+				}
+				collisionFieldIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.CollisionField2, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				collision_fieldIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !collisionFieldIsSet {
+		return errors.New("field CollisionField of StructCollision is required")
+	}
+
+	if !collision_fieldIsSet {
+		return errors.New("field CollisionField2 of StructCollision is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a StructCollision
 // struct.
 func (v *StructCollision) String() string {
@@ -1731,6 +2084,73 @@ func (v *UnionCollision) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a UnionCollision struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a UnionCollision struct could not be generated from the wire
+// representation.
+func (v *UnionCollision) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.CollisionField = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.CollisionField2 = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.CollisionField != nil {
+		count++
+	}
+	if v.CollisionField2 != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("UnionCollision should have exactly one field: got %v fields", count)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a UnionCollision
 // struct.
 func (v *UnionCollision) String() string {
@@ -1954,6 +2374,63 @@ func (v *WithDefault) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _StructCollision_Decode(sr stream.Reader) (*StructCollision2, error) {
+	var v StructCollision2
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a WithDefault struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a WithDefault struct could not be generated from the wire
+// representation.
+func (v *WithDefault) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.Pouet, err = _StructCollision_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if v.Pouet == nil {
+		v.Pouet = &StructCollision2{
+			CollisionField:  false,
+			CollisionField2: "false indeed",
+		}
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a WithDefault
 // struct.
 func (v *WithDefault) String() string {
@@ -2049,6 +2526,13 @@ func (v LittlePotatoe2) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *LittlePotatoe2) FromWire(w wire.Value) error {
 	x, err := w.GetDouble(), error(nil)
+	*v = (LittlePotatoe2)(x)
+	return err
+}
+
+// Decode deserializes LittlePotatoe2 directly off the wire.
+func (v *LittlePotatoe2) Decode(sr stream.Reader) error {
+	x, err := sr.ReadDouble()
 	*v = (LittlePotatoe2)(x)
 	return err
 }
@@ -2403,6 +2887,69 @@ func (v *StructCollision2) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a StructCollision2 struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a StructCollision2 struct could not be generated from the wire
+// representation.
+func (v *StructCollision2) Decode(sr stream.Reader) error {
+
+	collisionFieldIsSet := false
+	collision_fieldIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBool {
+				v.CollisionField, err = sr.ReadBool()
+				if err != nil {
+					return err
+				}
+				collisionFieldIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.CollisionField2, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				collision_fieldIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !collisionFieldIsSet {
+		return errors.New("field CollisionField of StructCollision2 is required")
+	}
+
+	if !collision_fieldIsSet {
+		return errors.New("field CollisionField2 of StructCollision2 is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a StructCollision2
 // struct.
 func (v *StructCollision2) String() string {
@@ -2626,6 +3173,73 @@ func (v *UnionCollision2) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a UnionCollision2 struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a UnionCollision2 struct could not be generated from the wire
+// representation.
+func (v *UnionCollision2) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.CollisionField = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.CollisionField2 = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.CollisionField != nil {
+		count++
+	}
+	if v.CollisionField2 != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("UnionCollision2 should have exactly one field: got %v fields", count)
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a UnionCollision2

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -1728,6 +1728,747 @@ func (v *ContainersOfContainers) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _List_I32_Decode(sr stream.Reader) ([]int32, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TI32 {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]int32, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := sr.ReadInt32()
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _List_List_I32_Decode(sr stream.Reader) ([][]int32, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TList {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([][]int32, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _List_I32_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_I32_mapType_Decode(sr stream.Reader) (map[int32]struct{}, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TI32 {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make(map[int32]struct{}, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadInt32()
+		if err != nil {
+			return nil, err
+		}
+
+		o[v] = struct{}{}
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _List_Set_I32_mapType_Decode(sr stream.Reader) ([]map[int32]struct{}, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TSet {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]map[int32]struct{}, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _Set_I32_mapType_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_I32_I32_Decode(sr stream.Reader) (map[int32]int32, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TI32 || mh.ValueType != wire.TI32 {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[int32]int32, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadInt32()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadInt32()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _List_Map_I32_I32_Decode(sr stream.Reader) ([]map[int32]int32, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TMap {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]map[int32]int32, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _Map_I32_I32_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_String_mapType_Decode(sr stream.Reader) (map[string]struct{}, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TBinary {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make(map[string]struct{}, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o[v] = struct{}{}
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_Set_String_mapType_sliceType_Decode(sr stream.Reader) ([]map[string]struct{}, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TSet {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make([]map[string]struct{}, 0, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := _Set_String_mapType_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, v)
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _List_String_Decode(sr stream.Reader) ([]string, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TBinary {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]string, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_List_String_sliceType_Decode(sr stream.Reader) ([][]string, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TList {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make([][]string, 0, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := _List_String_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, v)
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_String_String_Decode(sr stream.Reader) (map[string]string, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TBinary {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string]string, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_Map_String_String_sliceType_Decode(sr stream.Reader) ([]map[string]string, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TMap {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make([]map[string]string, 0, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := _Map_String_String_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, v)
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_String_I32_Decode(sr stream.Reader) (map[string]int32, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TI32 {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string]int32, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadInt32()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_Map_String_I32_I64_Decode(sr stream.Reader) ([]struct {
+	Key   map[string]int32
+	Value int64
+}, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TMap || mh.ValueType != wire.TI64 {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make([]struct {
+		Key   map[string]int32
+		Value int64
+	}, 0, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := _Map_String_I32_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadInt64()
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, struct {
+			Key   map[string]int32
+			Value int64
+		}{k, v})
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_I64_mapType_Decode(sr stream.Reader) (map[int64]struct{}, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TI64 {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make(map[int64]struct{}, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadInt64()
+		if err != nil {
+			return nil, err
+		}
+
+		o[v] = struct{}{}
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_List_I32_Set_I64_mapType_Decode(sr stream.Reader) ([]struct {
+	Key   []int32
+	Value map[int64]struct{}
+}, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TList || mh.ValueType != wire.TSet {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make([]struct {
+		Key   []int32
+		Value map[int64]struct{}
+	}, 0, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := _List_I32_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := _Set_I64_mapType_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, struct {
+			Key   []int32
+			Value map[int64]struct{}
+		}{k, v})
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _List_Double_Decode(sr stream.Reader) ([]float64, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TDouble {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]float64, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := sr.ReadDouble()
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_Set_I32_mapType_List_Double_Decode(sr stream.Reader) ([]struct {
+	Key   map[int32]struct{}
+	Value []float64
+}, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TSet || mh.ValueType != wire.TList {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make([]struct {
+		Key   map[int32]struct{}
+		Value []float64
+	}, 0, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := _Set_I32_mapType_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := _List_Double_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, struct {
+			Key   map[int32]struct{}
+			Value []float64
+		}{k, v})
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a ContainersOfContainers struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ContainersOfContainers struct could not be generated from the wire
+// representation.
+func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.ListOfLists, err = _List_List_I32_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TList {
+				v.ListOfSets, err = _List_Set_I32_mapType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TList {
+				v.ListOfMaps, err = _List_Map_I32_I32_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 4:
+			if fh.Type == wire.TSet {
+				v.SetOfSets, err = _Set_Set_String_mapType_sliceType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TSet {
+				v.SetOfLists, err = _Set_List_String_sliceType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 6:
+			if fh.Type == wire.TSet {
+				v.SetOfMaps, err = _Set_Map_String_String_sliceType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 7:
+			if fh.Type == wire.TMap {
+				v.MapOfMapToInt, err = _Map_Map_String_I32_I64_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 8:
+			if fh.Type == wire.TMap {
+				v.MapOfListToSet, err = _Map_List_I32_Set_I64_mapType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 9:
+			if fh.Type == wire.TMap {
+				v.MapOfSetToListOfDouble, err = _Map_Set_I32_mapType_List_Double_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a ContainersOfContainers
 // struct.
 func (v *ContainersOfContainers) String() string {
@@ -2996,6 +3737,185 @@ func (v *EnumContainers) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _EnumDefault_Decode(sr stream.Reader) (enums.EnumDefault, error) {
+	var v enums.EnumDefault
+	err := v.Decode(sr)
+	return v, err
+}
+
+func _List_EnumDefault_Decode(sr stream.Reader) ([]enums.EnumDefault, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TI32 {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]enums.EnumDefault, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _EnumDefault_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _EnumWithValues_Decode(sr stream.Reader) (enums.EnumWithValues, error) {
+	var v enums.EnumWithValues
+	err := v.Decode(sr)
+	return v, err
+}
+
+func _Set_EnumWithValues_mapType_Decode(sr stream.Reader) (map[enums.EnumWithValues]struct{}, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TI32 {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make(map[enums.EnumWithValues]struct{}, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := _EnumWithValues_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o[v] = struct{}{}
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _EnumWithDuplicateValues_Decode(sr stream.Reader) (enums.EnumWithDuplicateValues, error) {
+	var v enums.EnumWithDuplicateValues
+	err := v.Decode(sr)
+	return v, err
+}
+
+func _Map_EnumWithDuplicateValues_I32_Decode(sr stream.Reader) (map[enums.EnumWithDuplicateValues]int32, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TI32 || mh.ValueType != wire.TI32 {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[enums.EnumWithDuplicateValues]int32, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := _EnumWithDuplicateValues_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadInt32()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a EnumContainers struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a EnumContainers struct could not be generated from the wire
+// representation.
+func (v *EnumContainers) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.ListOfEnums, err = _List_EnumDefault_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TSet {
+				v.SetOfEnums, err = _Set_EnumWithValues_mapType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TMap {
+				v.MapOfEnums, err = _Map_EnumWithDuplicateValues_I32_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a EnumContainers
 // struct.
 func (v *EnumContainers) String() string {
@@ -3467,6 +4387,141 @@ func (v *ListOfConflictingEnums) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _RecordType_Decode(sr stream.Reader) (enum_conflict.RecordType, error) {
+	var v enum_conflict.RecordType
+	err := v.Decode(sr)
+	return v, err
+}
+
+func _List_RecordType_Decode(sr stream.Reader) ([]enum_conflict.RecordType, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TI32 {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]enum_conflict.RecordType, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _RecordType_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _RecordType_1_Decode(sr stream.Reader) (enums.RecordType, error) {
+	var v enums.RecordType
+	err := v.Decode(sr)
+	return v, err
+}
+
+func _List_RecordType_1_Decode(sr stream.Reader) ([]enums.RecordType, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TI32 {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]enums.RecordType, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _RecordType_1_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a ListOfConflictingEnums struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ListOfConflictingEnums struct could not be generated from the wire
+// representation.
+func (v *ListOfConflictingEnums) Decode(sr stream.Reader) error {
+
+	recordsIsSet := false
+	otherRecordsIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.Records, err = _List_RecordType_Decode(sr)
+				if err != nil {
+					return err
+				}
+				recordsIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TList {
+				v.OtherRecords, err = _List_RecordType_1_Decode(sr)
+				if err != nil {
+					return err
+				}
+				otherRecordsIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !recordsIsSet {
+		return errors.New("field Records of ListOfConflictingEnums is required")
+	}
+
+	if !otherRecordsIsSet {
+		return errors.New("field OtherRecords of ListOfConflictingEnums is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a ListOfConflictingEnums
 // struct.
 func (v *ListOfConflictingEnums) String() string {
@@ -3866,6 +4921,141 @@ func (v *ListOfConflictingUUIDs) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _UUID_Decode(sr stream.Reader) (*typedefs.UUID, error) {
+	var x typedefs.UUID
+	err := x.Decode(sr)
+	return &x, err
+}
+
+func _List_UUID_Decode(sr stream.Reader) ([]*typedefs.UUID, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TStruct {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]*typedefs.UUID, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _UUID_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _UUID_1_Decode(sr stream.Reader) (uuid_conflict.UUID, error) {
+	var x uuid_conflict.UUID
+	err := x.Decode(sr)
+	return x, err
+}
+
+func _List_UUID_1_Decode(sr stream.Reader) ([]uuid_conflict.UUID, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TBinary {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]uuid_conflict.UUID, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _UUID_1_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a ListOfConflictingUUIDs struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ListOfConflictingUUIDs struct could not be generated from the wire
+// representation.
+func (v *ListOfConflictingUUIDs) Decode(sr stream.Reader) error {
+
+	uuidsIsSet := false
+	otherUUIDsIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.Uuids, err = _List_UUID_Decode(sr)
+				if err != nil {
+					return err
+				}
+				uuidsIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TList {
+				v.OtherUUIDs, err = _List_UUID_1_Decode(sr)
+				if err != nil {
+					return err
+				}
+				otherUUIDsIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !uuidsIsSet {
+		return errors.New("field Uuids of ListOfConflictingUUIDs is required")
+	}
+
+	if !otherUUIDsIsSet {
+		return errors.New("field OtherUUIDs of ListOfConflictingUUIDs is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a ListOfConflictingUUIDs
 // struct.
 func (v *ListOfConflictingUUIDs) String() string {
@@ -4093,6 +5283,50 @@ func (v *ListOfOptionalPrimitives) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a ListOfOptionalPrimitives struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ListOfOptionalPrimitives struct could not be generated from the wire
+// representation.
+func (v *ListOfOptionalPrimitives) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.ListOfStrings, err = _List_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a ListOfOptionalPrimitives
 // struct.
 func (v *ListOfOptionalPrimitives) String() string {
@@ -4253,6 +5487,56 @@ func (v *ListOfRequiredPrimitives) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a ListOfRequiredPrimitives struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ListOfRequiredPrimitives struct could not be generated from the wire
+// representation.
+func (v *ListOfRequiredPrimitives) Decode(sr stream.Reader) error {
+
+	listOfStringsIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.ListOfStrings, err = _List_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+				listOfStringsIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !listOfStringsIsSet {
+		return errors.New("field ListOfStrings of ListOfRequiredPrimitives is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a ListOfRequiredPrimitives
@@ -4637,6 +5921,147 @@ func (v *MapOfBinaryAndString) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _Map_Binary_String_Decode(sr stream.Reader) ([]struct {
+	Key   []byte
+	Value string
+}, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TBinary {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make([]struct {
+		Key   []byte
+		Value string
+	}, 0, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, struct {
+			Key   []byte
+			Value string
+		}{k, v})
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_String_Binary_Decode(sr stream.Reader) (map[string][]byte, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TBinary {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string][]byte, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a MapOfBinaryAndString struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a MapOfBinaryAndString struct could not be generated from the wire
+// representation.
+func (v *MapOfBinaryAndString) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TMap {
+				v.BinaryToString, err = _Map_Binary_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TMap {
+				v.StringToBinary, err = _Map_String_Binary_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a MapOfBinaryAndString
@@ -5426,6 +6851,261 @@ func (v *PrimitiveContainers) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _List_Binary_Decode(sr stream.Reader) ([][]byte, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TBinary {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([][]byte, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := sr.ReadBinary()
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _List_I64_Decode(sr stream.Reader) ([]int64, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TI64 {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]int64, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := sr.ReadInt64()
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_Byte_mapType_Decode(sr stream.Reader) (map[int8]struct{}, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TI8 {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make(map[int8]struct{}, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadInt8()
+		if err != nil {
+			return nil, err
+		}
+
+		o[v] = struct{}{}
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_I32_String_Decode(sr stream.Reader) (map[int32]string, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TI32 || mh.ValueType != wire.TBinary {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[int32]string, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadInt32()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_String_Bool_Decode(sr stream.Reader) (map[string]bool, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TBool {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string]bool, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadBool()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a PrimitiveContainers struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveContainers struct could not be generated from the wire
+// representation.
+func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.ListOfBinary, err = _List_Binary_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TList {
+				v.ListOfInts, err = _List_I64_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TSet {
+				v.SetOfStrings, err = _Set_String_mapType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 4:
+			if fh.Type == wire.TSet {
+				v.SetOfBytes, err = _Set_Byte_mapType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TMap {
+				v.MapOfIntToString, err = _Map_I32_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 6:
+			if fh.Type == wire.TMap {
+				v.MapOfStringToBool, err = _Map_String_Bool_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a PrimitiveContainers
 // struct.
 func (v *PrimitiveContainers) String() string {
@@ -6015,6 +7695,122 @@ func (v *PrimitiveContainersRequired) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _Map_I64_Double_Decode(sr stream.Reader) (map[int64]float64, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TI64 || mh.ValueType != wire.TDouble {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[int64]float64, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadInt64()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadDouble()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a PrimitiveContainersRequired struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveContainersRequired struct could not be generated from the wire
+// representation.
+func (v *PrimitiveContainersRequired) Decode(sr stream.Reader) error {
+
+	listOfStringsIsSet := false
+	setOfIntsIsSet := false
+	mapOfIntsToDoublesIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.ListOfStrings, err = _List_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+				listOfStringsIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TSet {
+				v.SetOfInts, err = _Set_I32_mapType_Decode(sr)
+				if err != nil {
+					return err
+				}
+				setOfIntsIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TMap {
+				v.MapOfIntsToDoubles, err = _Map_I64_Double_Decode(sr)
+				if err != nil {
+					return err
+				}
+				mapOfIntsToDoublesIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !listOfStringsIsSet {
+		return errors.New("field ListOfStrings of PrimitiveContainersRequired is required")
+	}
+
+	if !setOfIntsIsSet {
+		return errors.New("field SetOfInts of PrimitiveContainersRequired is required")
+	}
+
+	if !mapOfIntsToDoublesIsSet {
+		return errors.New("field MapOfIntsToDoubles of PrimitiveContainersRequired is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a PrimitiveContainersRequired

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -406,6 +406,82 @@ func (v *Records) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _RecordType_Decode(sr stream.Reader) (RecordType, error) {
+	var v RecordType
+	err := v.Decode(sr)
+	return v, err
+}
+
+func _RecordType_1_Decode(sr stream.Reader) (enums.RecordType, error) {
+	var v enums.RecordType
+	err := v.Decode(sr)
+	return v, err
+}
+
+// Decode deserializes a Records struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Records struct could not be generated from the wire
+// representation.
+func (v *Records) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TI32 {
+				var x RecordType
+				x, err = _RecordType_Decode(sr)
+				v.RecordType = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TI32 {
+				var x enums.RecordType
+				x, err = _RecordType_1_Decode(sr)
+				v.OtherRecordType = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if v.RecordType == nil {
+		v.RecordType = _RecordType_ptr(DefaultRecordType)
+	}
+
+	if v.OtherRecordType == nil {
+		v.OtherRecordType = _RecordType_1_ptr(DefaultOtherRecordType)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Records
 // struct.
 func (v *Records) String() string {

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -1870,6 +1870,58 @@ func (v *StructWithOptionalEnum) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _EnumDefault_Decode(sr stream.Reader) (EnumDefault, error) {
+	var v EnumDefault
+	err := v.Decode(sr)
+	return v, err
+}
+
+// Decode deserializes a StructWithOptionalEnum struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a StructWithOptionalEnum struct could not be generated from the wire
+// representation.
+func (v *StructWithOptionalEnum) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TI32 {
+				var x EnumDefault
+				x, err = _EnumDefault_Decode(sr)
+				v.E = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a StructWithOptionalEnum
 // struct.
 func (v *StructWithOptionalEnum) String() string {

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -147,6 +147,66 @@ func (v *DoesNotExistException) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a DoesNotExistException struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DoesNotExistException struct could not be generated from the wire
+// representation.
+func (v *DoesNotExistException) Decode(sr stream.Reader) error {
+
+	keyIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Key, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				keyIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Error2 = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !keyIsSet {
+		return errors.New("field Key of DoesNotExistException is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a DoesNotExistException
 // struct.
 func (v *DoesNotExistException) String() string {
@@ -376,6 +436,66 @@ func (v *DoesNotExistException2) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a DoesNotExistException2 struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DoesNotExistException2 struct could not be generated from the wire
+// representation.
+func (v *DoesNotExistException2) Decode(sr stream.Reader) error {
+
+	keyIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Key, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				keyIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Error2 = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !keyIsSet {
+		return errors.New("field Key of DoesNotExistException2 is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a DoesNotExistException2
 // struct.
 func (v *DoesNotExistException2) String() string {
@@ -526,6 +646,42 @@ func (v *EmptyException) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a EmptyException struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a EmptyException struct could not be generated from the wire
+// representation.
+func (v *EmptyException) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a EmptyException

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -128,6 +128,62 @@ func (v *DocumentStruct) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _Second_Decode(sr stream.Reader) (*non_hyphenated.Second, error) {
+	var v non_hyphenated.Second
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a DocumentStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DocumentStruct struct could not be generated from the wire
+// representation.
+func (v *DocumentStruct) Decode(sr stream.Reader) error {
+
+	secondIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.Second, err = _Second_Decode(sr)
+				if err != nil {
+					return err
+				}
+				secondIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !secondIsSet {
+		return errors.New("field Second of DocumentStruct is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a DocumentStruct
 // struct.
 func (v *DocumentStruct) String() string {

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -128,6 +128,62 @@ func (v *DocumentStructure) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _Second_Decode(sr stream.Reader) (*non_hyphenated.Second, error) {
+	var v non_hyphenated.Second
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a DocumentStructure struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DocumentStructure struct could not be generated from the wire
+// representation.
+func (v *DocumentStructure) Decode(sr stream.Reader) error {
+
+	r2IsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.R2, err = _Second_Decode(sr)
+				if err != nil {
+					return err
+				}
+				r2IsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !r2IsSet {
+		return errors.New("field R2 of DocumentStructure is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a DocumentStructure
 // struct.
 func (v *DocumentStructure) String() string {

--- a/gen/internal/tests/non_hyphenated/non_hyphenated.go
+++ b/gen/internal/tests/non_hyphenated/non_hyphenated.go
@@ -78,6 +78,42 @@ func (v *First) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a First struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a First struct could not be generated from the wire
+// representation.
+func (v *First) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a First
 // struct.
 func (v *First) String() string {
@@ -178,6 +214,42 @@ func (v *Second) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a Second struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Second struct could not be generated from the wire
+// representation.
+func (v *Second) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Second

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -850,6 +850,287 @@ func (v *PrimitiveRequiredStruct) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _List_String_Decode(sr stream.Reader) ([]string, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TBinary {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]string, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_I32_mapType_Decode(sr stream.Reader) (map[int32]struct{}, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TI32 {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make(map[int32]struct{}, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadInt32()
+		if err != nil {
+			return nil, err
+		}
+
+		o[v] = struct{}{}
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_I64_Double_Decode(sr stream.Reader) (map[int64]float64, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TI64 || mh.ValueType != wire.TDouble {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[int64]float64, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadInt64()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadDouble()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a PrimitiveRequiredStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveRequiredStruct struct could not be generated from the wire
+// representation.
+func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
+
+	boolFieldIsSet := false
+	byteFieldIsSet := false
+	int16FieldIsSet := false
+	int32FieldIsSet := false
+	int64FieldIsSet := false
+	doubleFieldIsSet := false
+	stringFieldIsSet := false
+	binaryFieldIsSet := false
+	listOfStringsIsSet := false
+	setOfIntsIsSet := false
+	mapOfIntsToDoublesIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBool {
+				v.BoolField, err = sr.ReadBool()
+				if err != nil {
+					return err
+				}
+				boolFieldIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TI8 {
+				v.ByteField, err = sr.ReadInt8()
+				if err != nil {
+					return err
+				}
+				byteFieldIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TI16 {
+				v.Int16Field, err = sr.ReadInt16()
+				if err != nil {
+					return err
+				}
+				int16FieldIsSet = true
+			}
+		case 4:
+			if fh.Type == wire.TI32 {
+				v.Int32Field, err = sr.ReadInt32()
+				if err != nil {
+					return err
+				}
+				int32FieldIsSet = true
+			}
+		case 5:
+			if fh.Type == wire.TI64 {
+				v.Int64Field, err = sr.ReadInt64()
+				if err != nil {
+					return err
+				}
+				int64FieldIsSet = true
+			}
+		case 6:
+			if fh.Type == wire.TDouble {
+				v.DoubleField, err = sr.ReadDouble()
+				if err != nil {
+					return err
+				}
+				doubleFieldIsSet = true
+			}
+		case 7:
+			if fh.Type == wire.TBinary {
+				v.StringField, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				stringFieldIsSet = true
+			}
+		case 8:
+			if fh.Type == wire.TBinary {
+				v.BinaryField, err = sr.ReadBinary()
+				if err != nil {
+					return err
+				}
+				binaryFieldIsSet = true
+			}
+		case 9:
+			if fh.Type == wire.TList {
+				v.ListOfStrings, err = _List_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+				listOfStringsIsSet = true
+			}
+		case 10:
+			if fh.Type == wire.TSet {
+				v.SetOfInts, err = _Set_I32_mapType_Decode(sr)
+				if err != nil {
+					return err
+				}
+				setOfIntsIsSet = true
+			}
+		case 11:
+			if fh.Type == wire.TMap {
+				v.MapOfIntsToDoubles, err = _Map_I64_Double_Decode(sr)
+				if err != nil {
+					return err
+				}
+				mapOfIntsToDoublesIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !boolFieldIsSet {
+		return errors.New("field BoolField of PrimitiveRequiredStruct is required")
+	}
+
+	if !byteFieldIsSet {
+		return errors.New("field ByteField of PrimitiveRequiredStruct is required")
+	}
+
+	if !int16FieldIsSet {
+		return errors.New("field Int16Field of PrimitiveRequiredStruct is required")
+	}
+
+	if !int32FieldIsSet {
+		return errors.New("field Int32Field of PrimitiveRequiredStruct is required")
+	}
+
+	if !int64FieldIsSet {
+		return errors.New("field Int64Field of PrimitiveRequiredStruct is required")
+	}
+
+	if !doubleFieldIsSet {
+		return errors.New("field DoubleField of PrimitiveRequiredStruct is required")
+	}
+
+	if !stringFieldIsSet {
+		return errors.New("field StringField of PrimitiveRequiredStruct is required")
+	}
+
+	if !binaryFieldIsSet {
+		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
+	}
+
+	if !listOfStringsIsSet {
+		return errors.New("field ListOfStrings of PrimitiveRequiredStruct is required")
+	}
+
+	if !setOfIntsIsSet {
+		return errors.New("field SetOfInts of PrimitiveRequiredStruct is required")
+	}
+
+	if !mapOfIntsToDoublesIsSet {
+		return errors.New("field MapOfIntsToDoubles of PrimitiveRequiredStruct is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a PrimitiveRequiredStruct
 // struct.
 func (v *PrimitiveRequiredStruct) String() string {
@@ -1125,6 +1406,11 @@ func (v *Primitives) FromWire(w wire.Value) error {
 	return (*PrimitiveRequiredStruct)(v).FromWire(w)
 }
 
+// Decode deserializes Primitives directly off the wire.
+func (v *Primitives) Decode(sr stream.Reader) error {
+	return (*PrimitiveRequiredStruct)(v).Decode(sr)
+}
+
 // Equals returns true if this Primitives is equal to the provided
 // Primitives.
 func (lhs *Primitives) Equals(rhs *Primitives) bool {
@@ -1157,6 +1443,13 @@ func (v StringList) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *StringList) FromWire(w wire.Value) error {
 	x, err := _List_String_Read(w.GetList())
+	*v = (StringList)(x)
+	return err
+}
+
+// Decode deserializes StringList directly off the wire.
+func (v *StringList) Decode(sr stream.Reader) error {
+	x, err := _List_String_Decode(sr)
 	*v = (StringList)(x)
 	return err
 }
@@ -1253,6 +1546,46 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 	return o, err
 }
 
+func _Map_String_String_Decode(sr stream.Reader) (map[string]string, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TBinary {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string]string, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
 func _Map_String_String_Equals(lhs, rhs map[string]string) bool {
 	if len(lhs) != len(rhs) {
 		return false
@@ -1296,6 +1629,13 @@ func (v StringMap) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *StringMap) FromWire(w wire.Value) error {
 	x, err := _Map_String_String_Read(w.GetMap())
+	*v = (StringMap)(x)
+	return err
+}
+
+// Decode deserializes StringMap directly off the wire.
+func (v *StringMap) Decode(sr stream.Reader) error {
+	x, err := _Map_String_String_Decode(sr)
 	*v = (StringMap)(x)
 	return err
 }

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -155,6 +155,69 @@ func (v *ConflictingNamesSetValueArgs) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a ConflictingNamesSetValueArgs struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ConflictingNamesSetValueArgs struct could not be generated from the wire
+// representation.
+func (v *ConflictingNamesSetValueArgs) Decode(sr stream.Reader) error {
+
+	keyIsSet := false
+	valueIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Key, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				keyIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.Value, err = sr.ReadBinary()
+				if err != nil {
+					return err
+				}
+				valueIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !keyIsSet {
+		return errors.New("field Key of ConflictingNamesSetValueArgs is required")
+	}
+
+	if !valueIsSet {
+		return errors.New("field Value of ConflictingNamesSetValueArgs is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a ConflictingNamesSetValueArgs
 // struct.
 func (v *ConflictingNamesSetValueArgs) String() string {
@@ -327,6 +390,52 @@ func (v *InternalError) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a InternalError struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a InternalError struct could not be generated from the wire
+// representation.
+func (v *InternalError) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Message = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a InternalError
 // struct.
 func (v *InternalError) String() string {
@@ -443,6 +552,13 @@ func (v *Key) FromWire(w wire.Value) error {
 	return err
 }
 
+// Decode deserializes Key directly off the wire.
+func (v *Key) Decode(sr stream.Reader) error {
+	x, err := sr.ReadString()
+	*v = (Key)(x)
+	return err
+}
+
 // Equals returns true if this Key is equal to the provided
 // Key.
 func (lhs Key) Equals(rhs Key) bool {
@@ -531,6 +647,42 @@ func (v *Cache_Clear_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a Cache_Clear_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Cache_Clear_Args struct could not be generated from the wire
+// representation.
+func (v *Cache_Clear_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Cache_Clear_Args
@@ -702,6 +854,52 @@ func (v *Cache_ClearAfter_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a Cache_ClearAfter_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Cache_ClearAfter_Args struct could not be generated from the wire
+// representation.
+func (v *Cache_ClearAfter_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TI64 {
+				var x int64
+				x, err = sr.ReadInt64()
+				v.DurationMS = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Cache_ClearAfter_Args
@@ -918,6 +1116,56 @@ func (v *ConflictingNames_SetValue_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _ConflictingNamesSetValueArgs_Decode(sr stream.Reader) (*ConflictingNamesSetValueArgs, error) {
+	var v ConflictingNamesSetValueArgs
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a ConflictingNames_SetValue_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ConflictingNames_SetValue_Args struct could not be generated from the wire
+// representation.
+func (v *ConflictingNames_SetValue_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.Request, err = _ConflictingNamesSetValueArgs_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a ConflictingNames_SetValue_Args
@@ -1140,6 +1388,42 @@ func (v *ConflictingNames_SetValue_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a ConflictingNames_SetValue_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ConflictingNames_SetValue_Result struct could not be generated from the wire
+// representation.
+func (v *ConflictingNames_SetValue_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a ConflictingNames_SetValue_Result
 // struct.
 func (v *ConflictingNames_SetValue_Result) String() string {
@@ -1299,6 +1583,58 @@ func (v *KeyValue_DeleteValue_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _Key_Decode(sr stream.Reader) (Key, error) {
+	var x Key
+	err := x.Decode(sr)
+	return x, err
+}
+
+// Decode deserializes a KeyValue_DeleteValue_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_DeleteValue_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_DeleteValue_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				var x Key
+				x, err = _Key_Decode(sr)
+				v.Key = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a KeyValue_DeleteValue_Args
@@ -1658,6 +1994,81 @@ func (v *KeyValue_DeleteValue_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _DoesNotExistException_Decode(sr stream.Reader) (*exceptions.DoesNotExistException, error) {
+	var v exceptions.DoesNotExistException
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _InternalError_Decode(sr stream.Reader) (*InternalError, error) {
+	var v InternalError
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a KeyValue_DeleteValue_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_DeleteValue_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_DeleteValue_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.DoesNotExist, err = _DoesNotExistException_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.InternalError, err = _InternalError_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.DoesNotExist != nil {
+		count++
+	}
+	if v.InternalError != nil {
+		count++
+	}
+	if count > 1 {
+		return fmt.Errorf("KeyValue_DeleteValue_Result should have at most one field: got %v fields", count)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a KeyValue_DeleteValue_Result
 // struct.
 func (v *KeyValue_DeleteValue_Result) String() string {
@@ -1921,6 +2332,80 @@ func (v *KeyValue_GetManyValues_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _List_Key_Decode(sr stream.Reader) ([]Key, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TBinary {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]Key, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _Key_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a KeyValue_GetManyValues_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_GetManyValues_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_GetManyValues_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.Range, err = _List_Key_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a KeyValue_GetManyValues_Args
@@ -2352,6 +2837,105 @@ func (v *KeyValue_GetManyValues_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _ArbitraryValue_Decode(sr stream.Reader) (*unions.ArbitraryValue, error) {
+	var v unions.ArbitraryValue
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _List_ArbitraryValue_Decode(sr stream.Reader) ([]*unions.ArbitraryValue, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TStruct {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]*unions.ArbitraryValue, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _ArbitraryValue_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a KeyValue_GetManyValues_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_GetManyValues_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_GetManyValues_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 0:
+			if fh.Type == wire.TList {
+				v.Success, err = _List_ArbitraryValue_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.DoesNotExist, err = _DoesNotExistException_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+	if v.DoesNotExist != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("KeyValue_GetManyValues_Result should have exactly one field: got %v fields", count)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a KeyValue_GetManyValues_Result
 // struct.
 func (v *KeyValue_GetManyValues_Result) String() string {
@@ -2581,6 +3165,52 @@ func (v *KeyValue_GetValue_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a KeyValue_GetValue_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_GetValue_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_GetValue_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				var x Key
+				x, err = _Key_Decode(sr)
+				v.Key = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a KeyValue_GetValue_Args
@@ -2915,6 +3545,69 @@ func (v *KeyValue_GetValue_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a KeyValue_GetValue_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_GetValue_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_GetValue_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 0:
+			if fh.Type == wire.TStruct {
+				v.Success, err = _ArbitraryValue_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.DoesNotExist, err = _DoesNotExistException_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+	if v.DoesNotExist != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("KeyValue_GetValue_Result should have exactly one field: got %v fields", count)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a KeyValue_GetValue_Result
 // struct.
 func (v *KeyValue_GetValue_Result) String() string {
@@ -3147,6 +3840,60 @@ func (v *KeyValue_SetValue_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a KeyValue_SetValue_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_SetValue_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_SetValue_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				var x Key
+				x, err = _Key_Decode(sr)
+				v.Key = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.Value, err = _ArbitraryValue_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a KeyValue_SetValue_Args
@@ -3397,6 +4144,42 @@ func (v *KeyValue_SetValue_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a KeyValue_SetValue_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_SetValue_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_SetValue_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a KeyValue_SetValue_Result
 // struct.
 func (v *KeyValue_SetValue_Result) String() string {
@@ -3590,6 +4373,69 @@ func (v *KeyValue_SetValueV2_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a KeyValue_SetValueV2_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_SetValueV2_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_SetValueV2_Args) Decode(sr stream.Reader) error {
+
+	keyIsSet := false
+	valueIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Key, err = _Key_Decode(sr)
+				if err != nil {
+					return err
+				}
+				keyIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.Value, err = _ArbitraryValue_Decode(sr)
+				if err != nil {
+					return err
+				}
+				valueIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !keyIsSet {
+		return errors.New("field Key of KeyValue_SetValueV2_Args is required")
+	}
+
+	if !valueIsSet {
+		return errors.New("field Value of KeyValue_SetValueV2_Args is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a KeyValue_SetValueV2_Args
@@ -3825,6 +4671,42 @@ func (v *KeyValue_SetValueV2_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a KeyValue_SetValueV2_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_SetValueV2_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_SetValueV2_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a KeyValue_SetValueV2_Result
 // struct.
 func (v *KeyValue_SetValueV2_Result) String() string {
@@ -3943,6 +4825,42 @@ func (v *KeyValue_Size_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a KeyValue_Size_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_Size_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_Size_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a KeyValue_Size_Args
@@ -4199,6 +5117,60 @@ func (v *KeyValue_Size_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a KeyValue_Size_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_Size_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_Size_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 0:
+			if fh.Type == wire.TI64 {
+				var x int64
+				x, err = sr.ReadInt64()
+				v.Success = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("KeyValue_Size_Result should have exactly one field: got %v fields", count)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a KeyValue_Size_Result
 // struct.
 func (v *KeyValue_Size_Result) String() string {
@@ -4342,6 +5314,42 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) Encode(sw stream.W
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a NonStandardServiceName_NonStandardFunctionName_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a NonStandardServiceName_NonStandardFunctionName_Args struct could not be generated from the wire
+// representation.
+func (v *NonStandardServiceName_NonStandardFunctionName_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a NonStandardServiceName_NonStandardFunctionName_Args
@@ -4531,6 +5539,42 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) Encode(sw stream
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a NonStandardServiceName_NonStandardFunctionName_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a NonStandardServiceName_NonStandardFunctionName_Result struct could not be generated from the wire
+// representation.
+func (v *NonStandardServiceName_NonStandardFunctionName_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a NonStandardServiceName_NonStandardFunctionName_Result

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -33,6 +33,12 @@ func _MyStringList_Read(w wire.Value) (MyStringList, error) {
 	return x, err
 }
 
+func _MyStringList_Decode(sr stream.Reader) (MyStringList, error) {
+	var x MyStringList
+	err := x.Decode(sr)
+	return x, err
+}
+
 type _Set_String_sliceType_Zapper []string
 
 // MarshalLogArray implements zapcore.ArrayMarshaler, enabling
@@ -70,6 +76,13 @@ func (v AnotherStringList) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *AnotherStringList) FromWire(w wire.Value) error {
 	x, err := _MyStringList_Read(w)
+	*v = (AnotherStringList)(x)
+	return err
+}
+
+// Decode deserializes AnotherStringList directly off the wire.
+func (v *AnotherStringList) Decode(sr stream.Reader) error {
+	x, err := _MyStringList_Decode(sr)
 	*v = (AnotherStringList)(x)
 	return err
 }
@@ -781,6 +794,305 @@ func (v *Bar) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _Set_I32_sliceType_Decode(sr stream.Reader) ([]int32, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TI32 {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make([]int32, 0, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadInt32()
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, v)
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Set_String_sliceType_Decode(sr stream.Reader) ([]string, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TBinary {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make([]string, 0, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, v)
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _StringList_Decode(sr stream.Reader) (StringList, error) {
+	var x StringList
+	err := x.Decode(sr)
+	return x, err
+}
+
+func _Foo_Decode(sr stream.Reader) (*Foo, error) {
+	var v Foo
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _Set_Foo_sliceType_Decode(sr stream.Reader) ([]*Foo, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TStruct {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make([]*Foo, 0, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := _Foo_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, v)
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _FooList_Decode(sr stream.Reader) (FooList, error) {
+	var x FooList
+	err := x.Decode(sr)
+	return x, err
+}
+
+func _Set_Set_String_sliceType_sliceType_Decode(sr stream.Reader) ([][]string, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TSet {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make([][]string, 0, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := _Set_String_sliceType_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, v)
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _StringListList_Decode(sr stream.Reader) (StringListList, error) {
+	var x StringListList
+	err := x.Decode(sr)
+	return x, err
+}
+
+// Decode deserializes a Bar struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Bar struct could not be generated from the wire
+// representation.
+func (v *Bar) Decode(sr stream.Reader) error {
+
+	requiredInt32ListFieldIsSet := false
+
+	requiredTypedefStringListFieldIsSet := false
+
+	requiredFooListFieldIsSet := false
+
+	requiredTypedefFooListFieldIsSet := false
+
+	requiredStringListListFieldIsSet := false
+	requiredTypedefStringListListFieldIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TSet {
+				v.RequiredInt32ListField, err = _Set_I32_sliceType_Decode(sr)
+				if err != nil {
+					return err
+				}
+				requiredInt32ListFieldIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TSet {
+				v.OptionalStringListField, err = _Set_String_sliceType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TSet {
+				v.RequiredTypedefStringListField, err = _StringList_Decode(sr)
+				if err != nil {
+					return err
+				}
+				requiredTypedefStringListFieldIsSet = true
+			}
+		case 4:
+			if fh.Type == wire.TSet {
+				v.OptionalTypedefStringListField, err = _StringList_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TSet {
+				v.RequiredFooListField, err = _Set_Foo_sliceType_Decode(sr)
+				if err != nil {
+					return err
+				}
+				requiredFooListFieldIsSet = true
+			}
+		case 6:
+			if fh.Type == wire.TSet {
+				v.OptionalFooListField, err = _Set_Foo_sliceType_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 7:
+			if fh.Type == wire.TSet {
+				v.RequiredTypedefFooListField, err = _FooList_Decode(sr)
+				if err != nil {
+					return err
+				}
+				requiredTypedefFooListFieldIsSet = true
+			}
+		case 8:
+			if fh.Type == wire.TSet {
+				v.OptionalTypedefFooListField, err = _FooList_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 9:
+			if fh.Type == wire.TSet {
+				v.RequiredStringListListField, err = _Set_Set_String_sliceType_sliceType_Decode(sr)
+				if err != nil {
+					return err
+				}
+				requiredStringListListFieldIsSet = true
+			}
+		case 10:
+			if fh.Type == wire.TSet {
+				v.RequiredTypedefStringListListField, err = _StringListList_Decode(sr)
+				if err != nil {
+					return err
+				}
+				requiredTypedefStringListListFieldIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !requiredInt32ListFieldIsSet {
+		return errors.New("field RequiredInt32ListField of Bar is required")
+	}
+
+	if !requiredTypedefStringListFieldIsSet {
+		return errors.New("field RequiredTypedefStringListField of Bar is required")
+	}
+
+	if !requiredFooListFieldIsSet {
+		return errors.New("field RequiredFooListField of Bar is required")
+	}
+
+	if !requiredTypedefFooListFieldIsSet {
+		return errors.New("field RequiredTypedefFooListField of Bar is required")
+	}
+
+	if !requiredStringListListFieldIsSet {
+		return errors.New("field RequiredStringListListField of Bar is required")
+	}
+
+	if !requiredTypedefStringListListFieldIsSet {
+		return errors.New("field RequiredTypedefStringListListField of Bar is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Bar
 // struct.
 func (v *Bar) String() string {
@@ -1255,6 +1567,56 @@ func (v *Foo) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a Foo struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Foo struct could not be generated from the wire
+// representation.
+func (v *Foo) Decode(sr stream.Reader) error {
+
+	stringFieldIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.StringField, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				stringFieldIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !stringFieldIsSet {
+		return errors.New("field StringField of Foo is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Foo
 // struct.
 func (v *Foo) String() string {
@@ -1336,6 +1698,13 @@ func (v *FooList) FromWire(w wire.Value) error {
 	return err
 }
 
+// Decode deserializes FooList directly off the wire.
+func (v *FooList) Decode(sr stream.Reader) error {
+	x, err := _Set_Foo_sliceType_Decode(sr)
+	*v = (FooList)(x)
+	return err
+}
+
 // Equals returns true if this FooList is equal to the provided
 // FooList.
 func (lhs FooList) Equals(rhs FooList) bool {
@@ -1372,6 +1741,13 @@ func (v MyStringList) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *MyStringList) FromWire(w wire.Value) error {
 	x, err := _StringList_Read(w)
+	*v = (MyStringList)(x)
+	return err
+}
+
+// Decode deserializes MyStringList directly off the wire.
+func (v *MyStringList) Decode(sr stream.Reader) error {
+	x, err := _StringList_Decode(sr)
 	*v = (MyStringList)(x)
 	return err
 }
@@ -1416,6 +1792,13 @@ func (v *StringList) FromWire(w wire.Value) error {
 	return err
 }
 
+// Decode deserializes StringList directly off the wire.
+func (v *StringList) Decode(sr stream.Reader) error {
+	x, err := _Set_String_sliceType_Decode(sr)
+	*v = (StringList)(x)
+	return err
+}
+
 // Equals returns true if this StringList is equal to the provided
 // StringList.
 func (lhs StringList) Equals(rhs StringList) bool {
@@ -1452,6 +1835,13 @@ func (v StringListList) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *StringListList) FromWire(w wire.Value) error {
 	x, err := _Set_Set_String_sliceType_sliceType_Read(w.GetSet())
+	*v = (StringListList)(x)
+	return err
+}
+
+// Decode deserializes StringListList directly off the wire.
+func (v *StringListList) Decode(sr stream.Reader) error {
+	x, err := _Set_Set_String_sliceType_sliceType_Decode(sr)
 	*v = (StringListList)(x)
 	return err
 }
@@ -1531,6 +1921,37 @@ func _Set_String_mapType_Read(s wire.ValueList) (map[string]struct{}, error) {
 	return o, err
 }
 
+func _Set_String_mapType_Decode(sr stream.Reader) (map[string]struct{}, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TBinary {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make(map[string]struct{}, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o[v] = struct{}{}
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
 func _Set_String_mapType_Equals(lhs, rhs map[string]struct{}) bool {
 	if len(lhs) != len(rhs) {
 		return false
@@ -1582,6 +2003,13 @@ func (v StringSet) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *StringSet) FromWire(w wire.Value) error {
 	x, err := _Set_String_mapType_Read(w.GetSet())
+	*v = (StringSet)(x)
+	return err
+}
+
+// Decode deserializes StringSet directly off the wire.
+func (v *StringSet) Decode(sr stream.Reader) error {
+	x, err := _Set_String_mapType_Decode(sr)
 	*v = (StringSet)(x)
 	return err
 }

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -119,6 +119,56 @@ func (v *ContactInfo) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a ContactInfo struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ContactInfo struct could not be generated from the wire
+// representation.
+func (v *ContactInfo) Decode(sr stream.Reader) error {
+
+	emailAddressIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.EmailAddress, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				emailAddressIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !emailAddressIsSet {
+		return errors.New("field EmailAddress of ContactInfo is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a ContactInfo
 // struct.
 func (v *ContactInfo) String() string {
@@ -1013,6 +1063,305 @@ func (v *DefaultsStruct) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _EnumDefault_Decode(sr stream.Reader) (enums.EnumDefault, error) {
+	var v enums.EnumDefault
+	err := v.Decode(sr)
+	return v, err
+}
+
+func _List_String_Decode(sr stream.Reader) ([]string, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TBinary {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]string, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _List_Double_Decode(sr stream.Reader) ([]float64, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TDouble {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]float64, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := sr.ReadDouble()
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Frame_Decode(sr stream.Reader) (*Frame, error) {
+	var v Frame
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _Edge_Decode(sr stream.Reader) (*Edge, error) {
+	var v Edge
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a DefaultsStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DefaultsStruct struct could not be generated from the wire
+// representation.
+func (v *DefaultsStruct) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TI32 {
+				var x int32
+				x, err = sr.ReadInt32()
+				v.RequiredPrimitive = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TI32 {
+				var x int32
+				x, err = sr.ReadInt32()
+				v.OptionalPrimitive = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TI32 {
+				var x enums.EnumDefault
+				x, err = _EnumDefault_Decode(sr)
+				v.RequiredEnum = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 4:
+			if fh.Type == wire.TI32 {
+				var x enums.EnumDefault
+				x, err = _EnumDefault_Decode(sr)
+				v.OptionalEnum = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TList {
+				v.RequiredList, err = _List_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 6:
+			if fh.Type == wire.TList {
+				v.OptionalList, err = _List_Double_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 7:
+			if fh.Type == wire.TStruct {
+				v.RequiredStruct, err = _Frame_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 8:
+			if fh.Type == wire.TStruct {
+				v.OptionalStruct, err = _Edge_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 9:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.RequiredBoolDefaultTrue = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 10:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.OptionalBoolDefaultTrue = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 11:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.RequiredBoolDefaultFalse = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 12:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.OptionalBoolDefaultFalse = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if v.RequiredPrimitive == nil {
+		v.RequiredPrimitive = ptr.Int32(100)
+	}
+
+	if v.OptionalPrimitive == nil {
+		v.OptionalPrimitive = ptr.Int32(200)
+	}
+
+	if v.RequiredEnum == nil {
+		v.RequiredEnum = _EnumDefault_ptr(enums.EnumDefaultBar)
+	}
+
+	if v.OptionalEnum == nil {
+		v.OptionalEnum = _EnumDefault_ptr(enums.EnumDefaultBaz)
+	}
+
+	if v.RequiredList == nil {
+		v.RequiredList = []string{
+			"hello",
+			"world",
+		}
+	}
+
+	if v.OptionalList == nil {
+		v.OptionalList = []float64{
+			1,
+			2,
+			3,
+		}
+	}
+
+	if v.RequiredStruct == nil {
+		v.RequiredStruct = &Frame{
+			Size: &Size{
+				Height: 200,
+				Width:  100,
+			},
+			TopLeft: &Point{
+				X: 1,
+				Y: 2,
+			},
+		}
+	}
+
+	if v.OptionalStruct == nil {
+		v.OptionalStruct = &Edge{
+			EndPoint: &Point{
+				X: 3,
+				Y: 4,
+			},
+			StartPoint: &Point{
+				X: 1,
+				Y: 2,
+			},
+		}
+	}
+
+	if v.RequiredBoolDefaultTrue == nil {
+		v.RequiredBoolDefaultTrue = ptr.Bool(true)
+	}
+
+	if v.OptionalBoolDefaultTrue == nil {
+		v.OptionalBoolDefaultTrue = ptr.Bool(true)
+	}
+
+	if v.RequiredBoolDefaultFalse == nil {
+		v.RequiredBoolDefaultFalse = ptr.Bool(false)
+	}
+
+	if v.OptionalBoolDefaultFalse == nil {
+		v.OptionalBoolDefaultFalse = ptr.Bool(false)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a DefaultsStruct
 // struct.
 func (v *DefaultsStruct) String() string {
@@ -1605,6 +1954,75 @@ func (v *Edge) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _Point_Decode(sr stream.Reader) (*Point, error) {
+	var v Point
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a Edge struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Edge struct could not be generated from the wire
+// representation.
+func (v *Edge) Decode(sr stream.Reader) error {
+
+	startPointIsSet := false
+	endPointIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.StartPoint, err = _Point_Decode(sr)
+				if err != nil {
+					return err
+				}
+				startPointIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.EndPoint, err = _Point_Decode(sr)
+				if err != nil {
+					return err
+				}
+				endPointIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !startPointIsSet {
+		return errors.New("field StartPoint of Edge is required")
+	}
+
+	if !endPointIsSet {
+		return errors.New("field EndPoint of Edge is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Edge
 // struct.
 func (v *Edge) String() string {
@@ -1745,6 +2163,42 @@ func (v *EmptyStruct) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a EmptyStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a EmptyStruct struct could not be generated from the wire
+// representation.
+func (v *EmptyStruct) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a EmptyStruct
@@ -1930,6 +2384,75 @@ func (v *Frame) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _Size_Decode(sr stream.Reader) (*Size, error) {
+	var v Size
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a Frame struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Frame struct could not be generated from the wire
+// representation.
+func (v *Frame) Decode(sr stream.Reader) error {
+
+	topLeftIsSet := false
+	sizeIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.TopLeft, err = _Point_Decode(sr)
+				if err != nil {
+					return err
+				}
+				topLeftIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.Size, err = _Size_Decode(sr)
+				if err != nil {
+					return err
+				}
+				sizeIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !topLeftIsSet {
+		return errors.New("field TopLeft of Frame is required")
+	}
+
+	if !sizeIsSet {
+		return errors.New("field Size of Frame is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Frame
@@ -2266,6 +2789,117 @@ func (v *GoTags) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a GoTags struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a GoTags struct could not be generated from the wire
+// representation.
+func (v *GoTags) Decode(sr stream.Reader) error {
+
+	FooIsSet := false
+
+	FooBarIsSet := false
+	FooBarWithSpaceIsSet := false
+
+	FooBarWithRequiredIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Foo, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				FooIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Bar = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TBinary {
+				v.FooBar, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				FooBarIsSet = true
+			}
+		case 4:
+			if fh.Type == wire.TBinary {
+				v.FooBarWithSpace, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				FooBarWithSpaceIsSet = true
+			}
+		case 5:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.FooBarWithOmitEmpty = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 6:
+			if fh.Type == wire.TBinary {
+				v.FooBarWithRequired, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				FooBarWithRequiredIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !FooIsSet {
+		return errors.New("field Foo of GoTags is required")
+	}
+
+	if !FooBarIsSet {
+		return errors.New("field FooBar of GoTags is required")
+	}
+
+	if !FooBarWithSpaceIsSet {
+		return errors.New("field FooBarWithSpace of GoTags is required")
+	}
+
+	if !FooBarWithRequiredIsSet {
+		return errors.New("field FooBarWithRequired of GoTags is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a GoTags
 // struct.
 func (v *GoTags) String() string {
@@ -2592,6 +3226,86 @@ func (v *Graph) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _List_Edge_Decode(sr stream.Reader) ([]*Edge, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TStruct {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]*Edge, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _Edge_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a Graph struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Graph struct could not be generated from the wire
+// representation.
+func (v *Graph) Decode(sr stream.Reader) error {
+
+	edgesIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.Edges, err = _List_Edge_Decode(sr)
+				if err != nil {
+					return err
+				}
+				edgesIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !edgesIsSet {
+		return errors.New("field Edges of Graph is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Graph
 // struct.
 func (v *Graph) String() string {
@@ -2700,6 +3414,11 @@ func (v *List) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *List) FromWire(w wire.Value) error {
 	return (*Node)(v).FromWire(w)
+}
+
+// Decode deserializes List directly off the wire.
+func (v *List) Decode(sr stream.Reader) error {
+	return (*Node)(v).Decode(sr)
 }
 
 // Equals returns true if this List is equal to the provided
@@ -2848,6 +3567,70 @@ func (v *Node) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _List_Decode(sr stream.Reader) (*List, error) {
+	var x List
+	err := x.Decode(sr)
+	return &x, err
+}
+
+// Decode deserializes a Node struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Node struct could not be generated from the wire
+// representation.
+func (v *Node) Decode(sr stream.Reader) error {
+
+	valueIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TI32 {
+				v.Value, err = sr.ReadInt32()
+				if err != nil {
+					return err
+				}
+				valueIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.Tail, err = _List_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !valueIsSet {
+		return errors.New("field Value of Node is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Node
@@ -3322,6 +4105,154 @@ func (v *NotOmitEmpty) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _Map_String_String_Decode(sr stream.Reader) (map[string]string, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TBinary {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string]string, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a NotOmitEmpty struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a NotOmitEmpty struct could not be generated from the wire
+// representation.
+func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.NotOmitEmptyString = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.NotOmitEmptyInt = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.NotOmitEmptyBool = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 4:
+			if fh.Type == wire.TList {
+				v.NotOmitEmptyList, err = _List_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TMap {
+				v.NotOmitEmptyMap, err = _Map_String_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 6:
+			if fh.Type == wire.TList {
+				v.NotOmitEmptyListMixedWithOmitEmpty, err = _List_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 7:
+			if fh.Type == wire.TList {
+				v.NotOmitEmptyListMixedWithOmitEmptyV2, err = _List_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 8:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.OmitEmptyString = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a NotOmitEmpty
 // struct.
 func (v *NotOmitEmpty) String() string {
@@ -3718,6 +4649,69 @@ func (v *Omit) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a Omit struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Omit struct could not be generated from the wire
+// representation.
+func (v *Omit) Decode(sr stream.Reader) error {
+
+	serializedIsSet := false
+	hiddenIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Serialized, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				serializedIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.Hidden, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				hiddenIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !serializedIsSet {
+		return errors.New("field Serialized of Omit is required")
+	}
+
+	if !hiddenIsSet {
+		return errors.New("field Hidden of Omit is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Omit
 // struct.
 func (v *Omit) String() string {
@@ -3883,6 +4877,52 @@ func (v *PersonalInfo) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a PersonalInfo struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PersonalInfo struct could not be generated from the wire
+// representation.
+func (v *PersonalInfo) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TI32 {
+				var x int32
+				x, err = sr.ReadInt32()
+				v.Age = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a PersonalInfo
@@ -4077,6 +5117,69 @@ func (v *Point) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a Point struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Point struct could not be generated from the wire
+// representation.
+func (v *Point) Decode(sr stream.Reader) error {
+
+	xIsSet := false
+	yIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TDouble {
+				v.X, err = sr.ReadDouble()
+				if err != nil {
+					return err
+				}
+				xIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TDouble {
+				v.Y, err = sr.ReadDouble()
+				if err != nil {
+					return err
+				}
+				yIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !xIsSet {
+		return errors.New("field X of Point is required")
+	}
+
+	if !yIsSet {
+		return errors.New("field Y of Point is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Point
@@ -4462,6 +5565,120 @@ func (v *PrimitiveOptionalStruct) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a PrimitiveOptionalStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveOptionalStruct struct could not be generated from the wire
+// representation.
+func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.BoolField = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TI8 {
+				var x int8
+				x, err = sr.ReadInt8()
+				v.ByteField = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TI16 {
+				var x int16
+				x, err = sr.ReadInt16()
+				v.Int16Field = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 4:
+			if fh.Type == wire.TI32 {
+				var x int32
+				x, err = sr.ReadInt32()
+				v.Int32Field = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TI64 {
+				var x int64
+				x, err = sr.ReadInt64()
+				v.Int64Field = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 6:
+			if fh.Type == wire.TDouble {
+				var x float64
+				x, err = sr.ReadDouble()
+				v.DoubleField = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 7:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.StringField = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 8:
+			if fh.Type == wire.TBinary {
+				v.BinaryField, err = sr.ReadBinary()
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a PrimitiveOptionalStruct
@@ -5066,6 +6283,147 @@ func (v *PrimitiveRequiredStruct) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a PrimitiveRequiredStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveRequiredStruct struct could not be generated from the wire
+// representation.
+func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
+
+	boolFieldIsSet := false
+	byteFieldIsSet := false
+	int16FieldIsSet := false
+	int32FieldIsSet := false
+	int64FieldIsSet := false
+	doubleFieldIsSet := false
+	stringFieldIsSet := false
+	binaryFieldIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBool {
+				v.BoolField, err = sr.ReadBool()
+				if err != nil {
+					return err
+				}
+				boolFieldIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TI8 {
+				v.ByteField, err = sr.ReadInt8()
+				if err != nil {
+					return err
+				}
+				byteFieldIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TI16 {
+				v.Int16Field, err = sr.ReadInt16()
+				if err != nil {
+					return err
+				}
+				int16FieldIsSet = true
+			}
+		case 4:
+			if fh.Type == wire.TI32 {
+				v.Int32Field, err = sr.ReadInt32()
+				if err != nil {
+					return err
+				}
+				int32FieldIsSet = true
+			}
+		case 5:
+			if fh.Type == wire.TI64 {
+				v.Int64Field, err = sr.ReadInt64()
+				if err != nil {
+					return err
+				}
+				int64FieldIsSet = true
+			}
+		case 6:
+			if fh.Type == wire.TDouble {
+				v.DoubleField, err = sr.ReadDouble()
+				if err != nil {
+					return err
+				}
+				doubleFieldIsSet = true
+			}
+		case 7:
+			if fh.Type == wire.TBinary {
+				v.StringField, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				stringFieldIsSet = true
+			}
+		case 8:
+			if fh.Type == wire.TBinary {
+				v.BinaryField, err = sr.ReadBinary()
+				if err != nil {
+					return err
+				}
+				binaryFieldIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !boolFieldIsSet {
+		return errors.New("field BoolField of PrimitiveRequiredStruct is required")
+	}
+
+	if !byteFieldIsSet {
+		return errors.New("field ByteField of PrimitiveRequiredStruct is required")
+	}
+
+	if !int16FieldIsSet {
+		return errors.New("field Int16Field of PrimitiveRequiredStruct is required")
+	}
+
+	if !int32FieldIsSet {
+		return errors.New("field Int32Field of PrimitiveRequiredStruct is required")
+	}
+
+	if !int64FieldIsSet {
+		return errors.New("field Int64Field of PrimitiveRequiredStruct is required")
+	}
+
+	if !doubleFieldIsSet {
+		return errors.New("field DoubleField of PrimitiveRequiredStruct is required")
+	}
+
+	if !stringFieldIsSet {
+		return errors.New("field StringField of PrimitiveRequiredStruct is required")
+	}
+
+	if !binaryFieldIsSet {
+		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a PrimitiveRequiredStruct
 // struct.
 func (v *PrimitiveRequiredStruct) String() string {
@@ -5359,6 +6717,69 @@ func (v *Rename) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a Rename struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Rename struct could not be generated from the wire
+// representation.
+func (v *Rename) Decode(sr stream.Reader) error {
+
+	DefaultIsSet := false
+	camelCaseIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Default, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				DefaultIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.CamelCase, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				camelCaseIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !DefaultIsSet {
+		return errors.New("field Default of Rename is required")
+	}
+
+	if !camelCaseIsSet {
+		return errors.New("field CamelCase of Rename is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Rename
 // struct.
 func (v *Rename) String() string {
@@ -5558,6 +6979,69 @@ func (v *Size) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a Size struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Size struct could not be generated from the wire
+// representation.
+func (v *Size) Decode(sr stream.Reader) error {
+
+	widthIsSet := false
+	heightIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TDouble {
+				v.Width, err = sr.ReadDouble()
+				if err != nil {
+					return err
+				}
+				widthIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TDouble {
+				v.Height, err = sr.ReadDouble()
+				if err != nil {
+					return err
+				}
+				heightIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !widthIsSet {
+		return errors.New("field Width of Size is required")
+	}
+
+	if !heightIsSet {
+		return errors.New("field Height of Size is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Size
@@ -5818,6 +7302,82 @@ func (v *StructLabels) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a StructLabels struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a StructLabels struct could not be generated from the wire
+// representation.
+func (v *StructLabels) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.IsRequired = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Foo = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Qux = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 4:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Quux = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a StructLabels
@@ -6127,6 +7687,84 @@ func (v *User) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _ContactInfo_Decode(sr stream.Reader) (*ContactInfo, error) {
+	var v ContactInfo
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _PersonalInfo_Decode(sr stream.Reader) (*PersonalInfo, error) {
+	var v PersonalInfo
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a User struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a User struct could not be generated from the wire
+// representation.
+func (v *User) Decode(sr stream.Reader) error {
+
+	nameIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Name, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				nameIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.Contact, err = _ContactInfo_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TStruct {
+				v.Personal, err = _PersonalInfo_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !nameIsSet {
+		return errors.New("field Name of User is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a User
 // struct.
 func (v *User) String() string {
@@ -6323,6 +7961,52 @@ func _Map_String_User_Read(m wire.MapItemList) (map[string]*User, error) {
 	return o, err
 }
 
+func _User_Decode(sr stream.Reader) (*User, error) {
+	var v User
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _Map_String_User_Decode(sr stream.Reader) (map[string]*User, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TStruct {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string]*User, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := _User_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
 func _Map_String_User_Equals(lhs, rhs map[string]*User) bool {
 	if len(lhs) != len(rhs) {
 		return false
@@ -6377,6 +8061,13 @@ func (v UserMap) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *UserMap) FromWire(w wire.Value) error {
 	x, err := _Map_String_User_Read(w.GetMap())
+	*v = (UserMap)(x)
+	return err
+}
+
+// Decode deserializes UserMap directly off the wire.
+func (v *UserMap) Decode(sr stream.Reader) error {
+	x, err := _Map_String_User_Decode(sr)
 	*v = (UserMap)(x)
 	return err
 }
@@ -6521,6 +8212,69 @@ func (v *ZapOptOutStruct) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a ZapOptOutStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ZapOptOutStruct struct could not be generated from the wire
+// representation.
+func (v *ZapOptOutStruct) Decode(sr stream.Reader) error {
+
+	nameIsSet := false
+	optoutIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Name, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				nameIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.Optout, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				optoutIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !nameIsSet {
+		return errors.New("field Name of ZapOptOutStruct is required")
+	}
+
+	if !optoutIsSet {
+		return errors.New("field Optout of ZapOptOutStruct is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a ZapOptOutStruct

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -86,6 +86,37 @@ func _Set_Binary_sliceType_Read(s wire.ValueList) ([][]byte, error) {
 	return o, err
 }
 
+func _Set_Binary_sliceType_Decode(sr stream.Reader) ([][]byte, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TBinary {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make([][]byte, 0, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := sr.ReadBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, v)
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
 func _Set_Binary_sliceType_Equals(lhs, rhs [][]byte) bool {
 	if len(lhs) != len(rhs) {
 		return false
@@ -144,6 +175,13 @@ func (v BinarySet) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *BinarySet) FromWire(w wire.Value) error {
 	x, err := _Set_Binary_sliceType_Read(w.GetSet())
+	*v = (BinarySet)(x)
+	return err
+}
+
+// Decode deserializes BinarySet directly off the wire.
+func (v *BinarySet) Decode(sr stream.Reader) error {
+	x, err := _Set_Binary_sliceType_Decode(sr)
 	*v = (BinarySet)(x)
 	return err
 }
@@ -287,6 +325,62 @@ func (v *DefaultPrimitiveTypedef) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _State_Decode(sr stream.Reader) (State, error) {
+	var x State
+	err := x.Decode(sr)
+	return x, err
+}
+
+// Decode deserializes a DefaultPrimitiveTypedef struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DefaultPrimitiveTypedef struct could not be generated from the wire
+// representation.
+func (v *DefaultPrimitiveTypedef) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				var x State
+				x, err = _State_Decode(sr)
+				v.State = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if v.State == nil {
+		v.State = _State_ptr("hello")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a DefaultPrimitiveTypedef
@@ -477,6 +571,61 @@ func _Map_Edge_Edge_Read(m wire.MapItemList) ([]struct {
 	return o, err
 }
 
+func _Edge_Decode(sr stream.Reader) (*structs.Edge, error) {
+	var v structs.Edge
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _Map_Edge_Edge_Decode(sr stream.Reader) ([]struct {
+	Key   *structs.Edge
+	Value *structs.Edge
+}, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TStruct || mh.ValueType != wire.TStruct {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make([]struct {
+		Key   *structs.Edge
+		Value *structs.Edge
+	}, 0, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := _Edge_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := _Edge_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, struct {
+			Key   *structs.Edge
+			Value *structs.Edge
+		}{k, v})
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
 func _Map_Edge_Edge_Equals(lhs, rhs []struct {
 	Key   *structs.Edge
 	Value *structs.Edge
@@ -577,6 +726,13 @@ func (v EdgeMap) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *EdgeMap) FromWire(w wire.Value) error {
 	x, err := _Map_Edge_Edge_Read(w.GetMap())
+	*v = (EdgeMap)(x)
+	return err
+}
+
+// Decode deserializes EdgeMap directly off the wire.
+func (v *EdgeMap) Decode(sr stream.Reader) error {
+	x, err := _Map_Edge_Edge_Decode(sr)
 	*v = (EdgeMap)(x)
 	return err
 }
@@ -750,6 +906,78 @@ func (v *Event) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _UUID_Decode(sr stream.Reader) (*UUID, error) {
+	var x UUID
+	err := x.Decode(sr)
+	return &x, err
+}
+
+func _Timestamp_Decode(sr stream.Reader) (Timestamp, error) {
+	var x Timestamp
+	err := x.Decode(sr)
+	return x, err
+}
+
+// Decode deserializes a Event struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Event struct could not be generated from the wire
+// representation.
+func (v *Event) Decode(sr stream.Reader) error {
+
+	uuidIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.UUID, err = _UUID_Decode(sr)
+				if err != nil {
+					return err
+				}
+				uuidIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TI64 {
+				var x Timestamp
+				x, err = _Timestamp_Decode(sr)
+				v.Time = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !uuidIsSet {
+		return errors.New("field UUID of Event is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Event
 // struct.
 func (v *Event) String() string {
@@ -912,6 +1140,42 @@ func _List_Event_Read(l wire.ValueList) ([]*Event, error) {
 	return o, err
 }
 
+func _Event_Decode(sr stream.Reader) (*Event, error) {
+	var v Event
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _List_Event_Decode(sr stream.Reader) ([]*Event, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TStruct {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]*Event, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _Event_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
 func _List_Event_Equals(lhs, rhs []*Event) bool {
 	if len(lhs) != len(rhs) {
 		return false
@@ -964,6 +1228,13 @@ func (v EventGroup) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *EventGroup) FromWire(w wire.Value) error {
 	x, err := _List_Event_Read(w.GetList())
+	*v = (EventGroup)(x)
+	return err
+}
+
+// Decode deserializes EventGroup directly off the wire.
+func (v *EventGroup) Decode(sr stream.Reader) error {
+	x, err := _List_Event_Decode(sr)
 	*v = (EventGroup)(x)
 	return err
 }
@@ -1052,6 +1323,43 @@ func _Set_Frame_sliceType_Read(s wire.ValueList) ([]*structs.Frame, error) {
 	return o, err
 }
 
+func _Frame_Decode(sr stream.Reader) (*structs.Frame, error) {
+	var v structs.Frame
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _Set_Frame_sliceType_Decode(sr stream.Reader) ([]*structs.Frame, error) {
+	sh, err := sr.ReadSetBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if sh.Type != wire.TStruct {
+		for i := 0; i < sh.Length; i++ {
+			if err := sr.Skip(sh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadSetEnd()
+	}
+
+	o := make([]*structs.Frame, 0, sh.Length)
+	for i := 0; i < sh.Length; i++ {
+		v, err := _Frame_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, v)
+	}
+
+	if err = sr.ReadSetEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
 func _Set_Frame_sliceType_Equals(lhs, rhs []*structs.Frame) bool {
 	if len(lhs) != len(rhs) {
 		return false
@@ -1114,6 +1422,13 @@ func (v *FrameGroup) FromWire(w wire.Value) error {
 	return err
 }
 
+// Decode deserializes FrameGroup directly off the wire.
+func (v *FrameGroup) Decode(sr stream.Reader) error {
+	x, err := _Set_Frame_sliceType_Decode(sr)
+	*v = (FrameGroup)(x)
+	return err
+}
+
 // Equals returns true if this FrameGroup is equal to the provided
 // FrameGroup.
 func (lhs FrameGroup) Equals(rhs FrameGroup) bool {
@@ -1127,6 +1442,12 @@ func (v FrameGroup) MarshalLogArray(enc zapcore.ArrayEncoder) error {
 func _EnumWithValues_Read(w wire.Value) (enums.EnumWithValues, error) {
 	var v enums.EnumWithValues
 	err := v.FromWire(w)
+	return v, err
+}
+
+func _EnumWithValues_Decode(sr stream.Reader) (enums.EnumWithValues, error) {
+	var v enums.EnumWithValues
+	err := v.Decode(sr)
 	return v, err
 }
 
@@ -1161,6 +1482,13 @@ func (v MyEnum) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *MyEnum) FromWire(w wire.Value) error {
 	x, err := _EnumWithValues_Read(w)
+	*v = (MyEnum)(x)
+	return err
+}
+
+// Decode deserializes MyEnum directly off the wire.
+func (v *MyEnum) Decode(sr stream.Reader) error {
+	x, err := _EnumWithValues_Decode(sr)
 	*v = (MyEnum)(x)
 	return err
 }
@@ -1203,6 +1531,11 @@ func (v *MyUUID) FromWire(w wire.Value) error {
 	return (*UUID)(v).FromWire(w)
 }
 
+// Decode deserializes MyUUID directly off the wire.
+func (v *MyUUID) Decode(sr stream.Reader) error {
+	return (*UUID)(v).Decode(sr)
+}
+
 // Equals returns true if this MyUUID is equal to the provided
 // MyUUID.
 func (lhs *MyUUID) Equals(rhs *MyUUID) bool {
@@ -1239,6 +1572,13 @@ func (v PDF) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *PDF) FromWire(w wire.Value) error {
 	x, err := w.GetBinary(), error(nil)
+	*v = (PDF)(x)
+	return err
+}
+
+// Decode deserializes PDF directly off the wire.
+func (v *PDF) Decode(sr stream.Reader) error {
+	x, err := sr.ReadBinary()
 	*v = (PDF)(x)
 	return err
 }
@@ -1366,6 +1706,61 @@ func _Map_Point_Point_Read(m wire.MapItemList) ([]struct {
 	return o, err
 }
 
+func _Point_Decode(sr stream.Reader) (*structs.Point, error) {
+	var v structs.Point
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _Map_Point_Point_Decode(sr stream.Reader) ([]struct {
+	Key   *structs.Point
+	Value *structs.Point
+}, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TStruct || mh.ValueType != wire.TStruct {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make([]struct {
+		Key   *structs.Point
+		Value *structs.Point
+	}, 0, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := _Point_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := _Point_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, struct {
+			Key   *structs.Point
+			Value *structs.Point
+		}{k, v})
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
 func _Map_Point_Point_Equals(lhs, rhs []struct {
 	Key   *structs.Point
 	Value *structs.Point
@@ -1470,6 +1865,13 @@ func (v *PointMap) FromWire(w wire.Value) error {
 	return err
 }
 
+// Decode deserializes PointMap directly off the wire.
+func (v *PointMap) Decode(sr stream.Reader) error {
+	x, err := _Map_Point_Point_Decode(sr)
+	*v = (PointMap)(x)
+	return err
+}
+
 // Equals returns true if this PointMap is equal to the provided
 // PointMap.
 func (lhs PointMap) Equals(rhs PointMap) bool {
@@ -1520,6 +1922,13 @@ func (v State) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *State) FromWire(w wire.Value) error {
 	x, err := w.GetString(), error(nil)
+	*v = (State)(x)
+	return err
+}
+
+// Decode deserializes State directly off the wire.
+func (v *State) Decode(sr stream.Reader) error {
+	x, err := sr.ReadString()
 	*v = (State)(x)
 	return err
 }
@@ -1616,6 +2025,46 @@ func _Map_State_I64_Read(m wire.MapItemList) (map[State]int64, error) {
 	return o, err
 }
 
+func _Map_State_I64_Decode(sr stream.Reader) (map[State]int64, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TI64 {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[State]int64, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := _State_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadInt64()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
 func _Map_State_I64_Equals(lhs, rhs map[State]int64) bool {
 	if len(lhs) != len(rhs) {
 		return false
@@ -1674,6 +2123,13 @@ func (v *StateMap) FromWire(w wire.Value) error {
 	return err
 }
 
+// Decode deserializes StateMap directly off the wire.
+func (v *StateMap) Decode(sr stream.Reader) error {
+	x, err := _Map_State_I64_Decode(sr)
+	*v = (StateMap)(x)
+	return err
+}
+
 // Equals returns true if this StateMap is equal to the provided
 // StateMap.
 func (lhs StateMap) Equals(rhs StateMap) bool {
@@ -1718,6 +2174,13 @@ func (v Timestamp) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *Timestamp) FromWire(w wire.Value) error {
 	x, err := w.GetI64(), error(nil)
+	*v = (Timestamp)(x)
+	return err
+}
+
+// Decode deserializes Timestamp directly off the wire.
+func (v *Timestamp) Decode(sr stream.Reader) error {
+	x, err := sr.ReadInt64()
 	*v = (Timestamp)(x)
 	return err
 }
@@ -1893,6 +2356,83 @@ func (v *Transition) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _EventGroup_Decode(sr stream.Reader) (EventGroup, error) {
+	var x EventGroup
+	err := x.Decode(sr)
+	return x, err
+}
+
+// Decode deserializes a Transition struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Transition struct could not be generated from the wire
+// representation.
+func (v *Transition) Decode(sr stream.Reader) error {
+
+	fromStateIsSet := false
+	toStateIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.FromState, err = _State_Decode(sr)
+				if err != nil {
+					return err
+				}
+				fromStateIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.ToState, err = _State_Decode(sr)
+				if err != nil {
+					return err
+				}
+				toStateIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TList {
+				v.Events, err = _EventGroup_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !fromStateIsSet {
+		return errors.New("field FromState of Transition is required")
+	}
+
+	if !toStateIsSet {
+		return errors.New("field ToState of Transition is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Transition
@@ -2099,6 +2639,62 @@ func (v *TransitiveTypedefField) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _MyUUID_Decode(sr stream.Reader) (*MyUUID, error) {
+	var x MyUUID
+	err := x.Decode(sr)
+	return &x, err
+}
+
+// Decode deserializes a TransitiveTypedefField struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a TransitiveTypedefField struct could not be generated from the wire
+// representation.
+func (v *TransitiveTypedefField) Decode(sr stream.Reader) error {
+
+	defUUIDIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.DefUUID, err = _MyUUID_Decode(sr)
+				if err != nil {
+					return err
+				}
+				defUUIDIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !defUUIDIsSet {
+		return errors.New("field DefUUID of TransitiveTypedefField is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a TransitiveTypedefField
 // struct.
 func (v *TransitiveTypedefField) String() string {
@@ -2181,6 +2777,11 @@ func (v *UUID) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *UUID) FromWire(w wire.Value) error {
 	return (*I128)(v).FromWire(w)
+}
+
+// Decode deserializes UUID directly off the wire.
+func (v *UUID) Decode(sr stream.Reader) error {
+	return (*I128)(v).Decode(sr)
 }
 
 // Equals returns true if this UUID is equal to the provided
@@ -2323,6 +2924,69 @@ func (v *I128) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a I128 struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a I128 struct could not be generated from the wire
+// representation.
+func (v *I128) Decode(sr stream.Reader) error {
+
+	highIsSet := false
+	lowIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TI64 {
+				v.High, err = sr.ReadInt64()
+				if err != nil {
+					return err
+				}
+				highIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TI64 {
+				v.Low, err = sr.ReadInt64()
+				if err != nil {
+					return err
+				}
+				lowIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !highIsSet {
+		return errors.New("field High of I128 is required")
+	}
+
+	if !lowIsSet {
+		return errors.New("field Low of I128 is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a I128

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -450,6 +450,184 @@ func (v *ArbitraryValue) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _ArbitraryValue_Decode(sr stream.Reader) (*ArbitraryValue, error) {
+	var v ArbitraryValue
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _List_ArbitraryValue_Decode(sr stream.Reader) ([]*ArbitraryValue, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TStruct {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]*ArbitraryValue, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _ArbitraryValue_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Map_String_ArbitraryValue_Decode(sr stream.Reader) (map[string]*ArbitraryValue, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TStruct {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string]*ArbitraryValue, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := _ArbitraryValue_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a ArbitraryValue struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ArbitraryValue struct could not be generated from the wire
+// representation.
+func (v *ArbitraryValue) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.BoolValue = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TI64 {
+				var x int64
+				x, err = sr.ReadInt64()
+				v.Int64Value = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.StringValue = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 4:
+			if fh.Type == wire.TList {
+				v.ListValue, err = _List_ArbitraryValue_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TMap {
+				v.MapValue, err = _Map_String_ArbitraryValue_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.BoolValue != nil {
+		count++
+	}
+	if v.Int64Value != nil {
+		count++
+	}
+	if v.StringValue != nil {
+		count++
+	}
+	if v.ListValue != nil {
+		count++
+	}
+	if v.MapValue != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("ArbitraryValue should have exactly one field: got %v fields", count)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a ArbitraryValue
 // struct.
 func (v *ArbitraryValue) String() string {
@@ -858,6 +1036,77 @@ func (v *Document) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _PDF_Decode(sr stream.Reader) (typedefs.PDF, error) {
+	var x typedefs.PDF
+	err := x.Decode(sr)
+	return x, err
+}
+
+// Decode deserializes a Document struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Document struct could not be generated from the wire
+// representation.
+func (v *Document) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Pdf, err = _PDF_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.PlainText = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.Pdf != nil {
+		count++
+	}
+	if v.PlainText != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("Document should have exactly one field: got %v fields", count)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Document
 // struct.
 func (v *Document) String() string {
@@ -1008,6 +1257,42 @@ func (v *EmptyUnion) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a EmptyUnion struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a EmptyUnion struct could not be generated from the wire
+// representation.
+func (v *EmptyUnion) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a EmptyUnion

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -50,6 +50,13 @@ func (v *UUID) FromWire(w wire.Value) error {
 	return err
 }
 
+// Decode deserializes UUID directly off the wire.
+func (v *UUID) Decode(sr stream.Reader) error {
+	x, err := sr.ReadString()
+	*v = (UUID)(x)
+	return err
+}
+
 // Equals returns true if this UUID is equal to the provided
 // UUID.
 func (lhs UUID) Equals(rhs UUID) bool {
@@ -203,6 +210,81 @@ func (v *UUIDConflict) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _UUID_Decode(sr stream.Reader) (UUID, error) {
+	var x UUID
+	err := x.Decode(sr)
+	return x, err
+}
+
+func _UUID_1_Decode(sr stream.Reader) (*typedefs.UUID, error) {
+	var x typedefs.UUID
+	err := x.Decode(sr)
+	return &x, err
+}
+
+// Decode deserializes a UUIDConflict struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a UUIDConflict struct could not be generated from the wire
+// representation.
+func (v *UUIDConflict) Decode(sr stream.Reader) error {
+
+	localUUIDIsSet := false
+	importedUUIDIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.LocalUUID, err = _UUID_Decode(sr)
+				if err != nil {
+					return err
+				}
+				localUUIDIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.ImportedUUID, err = _UUID_1_Decode(sr)
+				if err != nil {
+					return err
+				}
+				importedUUIDIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !localUUIDIsSet {
+		return errors.New("field LocalUUID of UUIDConflict is required")
+	}
+
+	if !importedUUIDIsSet {
+		return errors.New("field ImportedUUID of UUIDConflict is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a UUIDConflict

--- a/gen/list.go
+++ b/gen/list.go
@@ -187,6 +187,64 @@ func (l *listGenerator) Encode(g Generator, spec *compile.ListSpec) (string, err
 	return name, wrapGenerateError(spec.ThriftName(), err)
 }
 
+// Decoder generates a function to read a list of the given type from a
+// stream.Reader.
+//
+//     func $name(sr *stream.Reader) ($listType, error) {
+//             ...
+//     }
+//
+// And returns its name.
+func (l *listGenerator) Decoder(g Generator, spec *compile.ListSpec) (string, error) {
+	name := decoderFuncName(g, spec)
+	err := g.EnsureDeclared(
+		`
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
+		<$listType := typeReference .Spec>
+
+		<$sr := newVar "sr">
+		<$lh := newVar "lh">
+		<$o := newVar "o">
+		<$v := newVar "v">
+		func <.Name>(<$sr> <$stream>.Reader) (<$listType>, error) {
+			<$lh>, err := <$sr>.ReadListBegin()
+			if err != nil {
+				return nil, err
+			}
+
+			if <$lh>.Type != <typeCode .Spec.ValueSpec> {
+				for i := 0; i <lessthan> <$lh>.Length; i++ {
+					if err := <$sr>.Skip(<$lh>.Type); err != nil {
+						return nil, err
+					}
+				}
+				return nil, <$sr>.ReadListEnd()
+			}
+
+			<$o> := make(<$listType>, 0, <$lh>.Length)
+			for i := 0; i <lessthan> <$lh>.Length; i++ {
+				<$v>, err := <decode .Spec.ValueSpec $sr>
+				if err != nil {
+					return nil, err
+				}
+				<$o> = append(<$o>, <$v>)
+			}
+
+			if err = <$sr>.ReadListEnd(); err != nil {
+				return nil, err
+			}
+			return <$o>, err
+		}
+		`,
+		struct {
+			Name string
+			Spec *compile.ListSpec
+		}{Name: name, Spec: spec},
+	)
+
+	return name, wrapGenerateError(spec.ThriftName(), err)
+}
+
 // Equals generates a function to compare lists of the given type
 //
 // 	func $name(lhs, rhs $listType) bool {

--- a/gen/list.go
+++ b/gen/list.go
@@ -147,7 +147,7 @@ func (l *listGenerator) Reader(g Generator, spec *compile.ListSpec) (string, err
 //     }
 //
 // And returns its name.
-func (l *listGenerator) Encode(g Generator, spec *compile.ListSpec) (string, error) {
+func (l *listGenerator) Encoder(g Generator, spec *compile.ListSpec) (string, error) {
 	name := encoderFuncName(g, spec)
 	err := g.EnsureDeclared(
 		`

--- a/gen/map.go
+++ b/gen/map.go
@@ -179,6 +179,13 @@ func (m *mapGenerator) Reader(g Generator, spec *compile.MapSpec) (string, error
 	return name, wrapGenerateError(spec.ThriftName(), err)
 }
 
+// Encoder generates a function to encode a map given a stream.Writer
+//
+//     func $name(val $mapType, sr *stream.Writer) error {
+//             ...
+//     }
+//
+// And returns its name.
 func (m *mapGenerator) Encode(g Generator, spec *compile.MapSpec) (string, error) {
 	name := encoderFuncName(g, spec)
 	err := g.EnsureDeclared(
@@ -228,6 +235,86 @@ func (m *mapGenerator) Encode(g Generator, spec *compile.MapSpec) (string, error
 				}
 			<end>
 			return <$sw>.WriteMapEnd()
+		}
+		`,
+		struct {
+			Name string
+			Spec *compile.MapSpec
+		}{Name: name, Spec: spec},
+	)
+
+	return name, wrapGenerateError(spec.ThriftName(), err)
+}
+
+// Decoder generates a function to read a map of the given types from a
+// stream.Reader.
+//
+//     func $name(sr *stream.Reader) ($mapType, error) {
+//             ...
+//     }
+//
+// And returns its name.
+func (m *mapGenerator) Decoder(g Generator, spec *compile.MapSpec) (string, error) {
+	name := decoderFuncName(g, spec)
+	err := g.EnsureDeclared(
+		`
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
+		<$mapType := typeReference .Spec>
+
+		<$sr := newVar "sr">
+		<$mh := newVar "mh">
+		<$o := newVar "o">
+		<$k := newVar "k">
+		<$v := newVar "v">
+		func <.Name>(<$sr> <$stream>.Reader) (<$mapType>, error) {
+			<$mh>, err := <$sr>.ReadMapBegin()
+			if err != nil {
+				return nil, err
+			}
+
+			if <$mh>.KeyType != <typeCode .Spec.KeySpec> || <$mh>.ValueType != <typeCode .Spec.ValueSpec> {
+				for i := 0; i <lessthan> <$mh>.Length; i++ {
+					if err := <$sr>.Skip(<$mh>.KeyType); err != nil {
+						return nil, err
+					}
+
+					if err := <$sr>.Skip(<$mh>.ValueType); err != nil {
+						return nil, err
+					}
+				}
+				return nil, <$sr>.ReadMapEnd()
+			}
+
+			<if isHashable .Spec.KeySpec>
+				<$o> := make(<$mapType>, <$mh>.Length)
+			<else>
+				<$o> := make(<$mapType>, 0, <$mh>.Length)
+			<end ->
+			for i := 0; i <lessthan> <$mh>.Length; i++ {
+				<$k>, err := <decode .Spec.KeySpec $sr>
+				if err != nil {
+					return nil, err
+				}
+
+				<$v>, err := <decode .Spec.ValueSpec $sr>
+				if err != nil {
+					return nil, err
+				}
+
+				<if isHashable .Spec.KeySpec>
+					<$o>[<$k>] = <$v>
+				<else>
+					<$o> = append(<$o>, struct {
+						Key <typeReference .Spec.KeySpec>
+						Value <typeReference .Spec.ValueSpec>
+					}{<$k>, <$v>})
+				<end ->
+			}
+
+			if err = <$sr>.ReadMapEnd(); err != nil {
+				return nil, err
+			}
+			return <$o>, err
 		}
 		`,
 		struct {

--- a/gen/map.go
+++ b/gen/map.go
@@ -186,7 +186,7 @@ func (m *mapGenerator) Reader(g Generator, spec *compile.MapSpec) (string, error
 //     }
 //
 // And returns its name.
-func (m *mapGenerator) Encode(g Generator, spec *compile.MapSpec) (string, error) {
+func (m *mapGenerator) Encoder(g Generator, spec *compile.MapSpec) (string, error) {
 	name := encoderFuncName(g, spec)
 	err := g.EnsureDeclared(
 		`

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -764,6 +764,7 @@ func (q *quickSuite) testThriftRoundTripStreaming(t *testing.T, give, defaults t
 
 	sw := binary.BorrowStreamWriter(&buf)
 	require.NoError(t, sGive.Encode(sw), "failed to streaming encode %v", sGive)
+	binary.ReturnStreamWriter(sw)
 
 	gType := reflect.TypeOf(sGive)
 	if gType.Kind() == reflect.Ptr {

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -42,6 +42,7 @@ import (
 	tx "go.uber.org/thriftrw/gen/internal/tests/exceptions"
 	ahf "go.uber.org/thriftrw/gen/internal/tests/hyphenated-file"
 	hf "go.uber.org/thriftrw/gen/internal/tests/hyphenated_file"
+	nf "go.uber.org/thriftrw/gen/internal/tests/non_hyphenated"
 	tz "go.uber.org/thriftrw/gen/internal/tests/nozap"
 	tf "go.uber.org/thriftrw/gen/internal/tests/services"
 	tss "go.uber.org/thriftrw/gen/internal/tests/set_to_slice"
@@ -338,6 +339,8 @@ func TestQuickSuite(t *testing.T) {
 		{Sample: tf.KeyValue_GetManyValues_Args{}, Kind: thriftStruct},
 		{Sample: ahf.DocumentStruct{}, Kind: thriftStruct},
 		{Sample: hf.DocumentStructure{}, Kind: thriftStruct},
+		{Sample: nf.First{}, Kind: thriftStruct},
+		{Sample: nf.Second{}, Kind: thriftStruct},
 
 		{
 			Sample:    tf.KeyValue_GetManyValues_Result{},

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -21,6 +21,7 @@
 package gen
 
 import (
+	"bytes"
 	"encoding"
 	"encoding/json"
 	"fmt"
@@ -49,6 +50,7 @@ import (
 	tu "go.uber.org/thriftrw/gen/internal/tests/unions"
 	tul "go.uber.org/thriftrw/gen/internal/tests/uuid_conflict"
 	envex "go.uber.org/thriftrw/internal/envelope/exception"
+	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/wire"
 )
 
@@ -570,6 +572,12 @@ func TestQuickSuite(t *testing.T) {
 				}
 			})
 
+			t.Run("Thrift Streaming", func(t *testing.T) {
+				for _, give := range values {
+					suite.testThriftRoundTripStreaming(t, give, tt.DefaultThriftType)
+				}
+			})
+
 			t.Run("String", func(t *testing.T) {
 				for _, give := range values {
 					suite.testString(t, give)
@@ -736,6 +744,38 @@ func (q *quickSuite) testThriftRoundTrip(t *testing.T, give, defaults thriftType
 	if shouldCheckForMutation {
 		// assert that give has not been mutated to the want object during the ToWire call
 		assert.NotEqual(t, want, give)
+	}
+}
+
+func (q *quickSuite) testThriftRoundTripStreaming(t *testing.T, give, defaults thriftType) {
+	var buf bytes.Buffer
+
+	want := populateDefaults(give, defaults)
+	shouldCheckForMutation := defaults != nil && !assert.ObjectsAreEqual(want, give)
+
+	sGive, ok := give.(streamingThriftType)
+	require.True(t, ok, "given thrift type must satisfy streaming requirements")
+
+	sWant, ok := want.(streamingThriftType)
+	require.True(t, ok, "default thrift type must satisfy streaming requirements")
+
+	sw := binary.BorrowStreamWriter(&buf)
+	require.NoError(t, sGive.Encode(sw), "failed to streaming encode %v", sGive)
+
+	gType := reflect.TypeOf(sGive)
+	if gType.Kind() == reflect.Ptr {
+		gType = gType.Elem()
+	}
+
+	got := reflect.New(gType).Interface().(streamingThriftType)
+
+	sr := binary.NewStreamReader(&buf)
+	require.NoError(t, got.Decode(&sr), "failed to streaming decode from %v", buf)
+
+	assert.Equal(t, want, got)
+	if shouldCheckForMutation {
+		// assert that give has not been mutated to the want object during the ToWire call
+		assert.NotEqual(t, sWant, sGive)
 	}
 }
 

--- a/gen/service_test.go
+++ b/gen/service_test.go
@@ -200,6 +200,10 @@ func TestServiceArgsAndResult(t *testing.T) {
 		assertRoundTrip(t, tt.x, tt.value, tt.desc)
 		assert.Equal(t, tt.methodName, tt.x.MethodName(), tt.desc)
 		assert.Equal(t, tt.envelopeType, tt.x.EnvelopeType(), tt.desc)
+
+		testRoundTripCombos(t, tt.x, tt.value, tt.desc)
+		assert.Equal(t, tt.methodName, tt.x.MethodName(), tt.desc)
+		assert.Equal(t, tt.envelopeType, tt.x.EnvelopeType(), tt.desc)
 	}
 }
 

--- a/gen/set.go
+++ b/gen/set.go
@@ -142,7 +142,7 @@ func (s *setGenerator) Reader(g Generator, spec *compile.SetSpec) (string, error
 	return name, wrapGenerateError(spec.ThriftName(), err)
 }
 
-func (s *setGenerator) Encode(g Generator, spec *compile.SetSpec) (string, error) {
+func (s *setGenerator) Encoder(g Generator, spec *compile.SetSpec) (string, error) {
 	name := encoderFuncName(g, spec)
 	err := g.EnsureDeclared(
 		`

--- a/gen/set.go
+++ b/gen/set.go
@@ -185,7 +185,72 @@ func (s *setGenerator) Encode(g Generator, spec *compile.SetSpec) (string, error
 	)
 
 	return name, wrapGenerateError(spec.ThriftName(), err)
+}
 
+// Decoder generates a function to read a set of the given type from a
+// stream.Reader.
+//
+//     func $name(sr *stream.Reader) ($setType, error) {
+//             ...
+//     }
+//
+// And returns its name.
+func (s *setGenerator) Decoder(g Generator, spec *compile.SetSpec) (string, error) {
+	name := decoderFuncName(g, spec)
+	err := g.EnsureDeclared(
+		`
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
+		<$setType := typeReference .Spec>
+
+		<$sr := newVar "sr">
+		<$sh := newVar "sh">
+		<$o := newVar "o">
+		<$v := newVar "v">
+		func <.Name>(<$sr> <$stream>.Reader) (<$setType>, error) {
+			<$sh>, err := <$sr>.ReadSetBegin()
+			if err != nil {
+				return nil, err
+			}
+
+			if <$sh>.Type != <typeCode .Spec.ValueSpec> {
+				for i := 0; i <lessthan> <$sh>.Length; i++ {
+					if err := <$sr>.Skip(<$sh>.Type); err != nil {
+						return nil, err
+					}
+				}
+				return nil, <$sr>.ReadSetEnd()
+			}
+
+			<if setUsesMap .Spec>
+				<$o> := make(<$setType>, <$sh>.Length)
+			<else>
+				<$o> := make(<$setType>, 0, <$sh>.Length)
+			<end ->
+			for i := 0; i <lessthan> <$sh>.Length; i++ {
+				<$v>, err := <decode .Spec.ValueSpec $sr>
+				if err != nil {
+					return nil, err
+				}
+				<if setUsesMap .Spec>
+					<$o>[<$v>] = struct{}{}
+				<else>
+					<$o> = append(<$o>, <$v>)
+				<end ->
+			}
+
+			if err = <$sr>.ReadSetEnd(); err != nil {
+				return nil, err
+			}
+			return <$o>, err
+		}
+		`,
+		struct {
+			Name string
+			Spec *compile.SetSpec
+		}{Name: name, Spec: spec},
+	)
+
+	return name, wrapGenerateError(spec.ThriftName(), err)
 }
 
 // Equals generates a function to compare sets of the given type

--- a/gen/stream.go
+++ b/gen/stream.go
@@ -32,6 +32,10 @@ type StreamGenerator struct {
 	mapG  mapGenerator
 	setG  setGenerator
 	listG listGenerator
+
+	enumG    enumGenerator
+	structG  structGenerator
+	typedefG typedefGenerator
 }
 
 // Encode generates code that knows how to serialize Thrift types into bytes.
@@ -79,4 +83,90 @@ func (sg *StreamGenerator) EncodePtr(g Generator, spec compile.TypeSpec, varName
 		// on it that does automatic dereferencing.
 		return sg.Encode(g, spec, varName, sw)
 	}
+}
+
+// Decode generates an expression that can deserialize Thrift data into their
+// raw types.
+func (sg *StreamGenerator) Decode(g Generator, spec compile.TypeSpec, reader string) (string, error) {
+	switch s := spec.(type) {
+	case *compile.BoolSpec:
+		return fmt.Sprintf("%s.ReadBool()", reader), nil
+	case *compile.I8Spec:
+		return fmt.Sprintf("%s.ReadInt8()", reader), nil
+	case *compile.I16Spec:
+		return fmt.Sprintf("%s.ReadInt16()", reader), nil
+	case *compile.I32Spec:
+		return fmt.Sprintf("%s.ReadInt32()", reader), nil
+	case *compile.I64Spec:
+		return fmt.Sprintf("%s.ReadInt64()", reader), nil
+	case *compile.DoubleSpec:
+		return fmt.Sprintf("%s.ReadDouble()", reader), nil
+	case *compile.StringSpec:
+		return fmt.Sprintf("%s.ReadString()", reader), nil
+	case *compile.BinarySpec:
+		return fmt.Sprintf("%s.ReadBinary()", reader), nil
+	case *compile.MapSpec:
+		decoder, err := sg.mapG.Decoder(g, s)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s(%s)", decoder, reader), nil
+	case *compile.ListSpec:
+		decoder, err := sg.listG.Decoder(g, s)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s(%s)", decoder, reader), nil
+	case *compile.SetSpec:
+		decoder, err := sg.setG.Decoder(g, s)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s(%s)", decoder, reader), nil
+	case *compile.TypedefSpec:
+		decoder, err := sg.typedefG.Decoder(g, s)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s(%s)", decoder, reader), nil
+	case *compile.EnumSpec:
+		decoder, err := sg.enumG.Decoder(g, s)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s(%s)", decoder, reader), nil
+	case *compile.StructSpec:
+		decoder, err := sg.structG.Decoder(g, s)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s(%s)", decoder, reader), nil
+	default:
+		panic(fmt.Sprintf("Unknown TypeSpec (%T) %v", spec, spec))
+	}
+}
+
+// DecodePtr generates an expression that assigns the "lhs" to a pointer of the
+// decoded value.
+func (sg *StreamGenerator) DecodePtr(g Generator, spec compile.TypeSpec, lhs string, reader string) (string, error) {
+	if !isPrimitiveType(spec) {
+		out, err := sg.Decode(g, spec, reader)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s, err = %s", lhs, out), err
+	}
+	return g.TextTemplate(
+		`
+		<- $x := newVar "x" ->
+		var <$x> <typeReference .Spec>
+		<$x>, err = <decode .Spec .Reader>
+		<.LHS> = &<$x ->
+		`,
+		struct {
+			Spec   compile.TypeSpec
+			LHS    string
+			Reader string
+		}{Spec: spec, LHS: lhs, Reader: reader},
+	)
 }

--- a/gen/stream.go
+++ b/gen/stream.go
@@ -58,13 +58,13 @@ func (sg *StreamGenerator) Encode(g Generator, spec compile.TypeSpec, varName st
 	case *compile.BinarySpec:
 		return fmt.Sprintf("%s.WriteBinary(%s)", sw, varName), nil
 	case *compile.MapSpec:
-		encoder, err := sg.mapG.Encode(g, s)
+		encoder, err := sg.mapG.Encoder(g, s)
 		return fmt.Sprintf("%s(%s, %s)", encoder, varName, sw), err
 	case *compile.ListSpec:
-		encoder, err := sg.listG.Encode(g, s)
+		encoder, err := sg.listG.Encoder(g, s)
 		return fmt.Sprintf("%s(%s, %s)", encoder, varName, sw), err
 	case *compile.SetSpec:
-		encoder, err := sg.setG.Encode(g, s)
+		encoder, err := sg.setG.Encoder(g, s)
 		return fmt.Sprintf("%s(%s, %s)", encoder, varName, sw), err
 	default:
 		return fmt.Sprintf("%s.Encode(%s)", varName, sw), nil

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -471,7 +471,13 @@ func TestStructRoundTripAndString(t *testing.T) {
 		} else {
 			assert.NotPanics(t, func() { _ = tt.x.String() }, "ToString: %v", tt.desc)
 		}
+
 		testRoundTripCombos(t, tt.x, tt.v, tt.desc)
+		if tt.s != "" {
+			assert.Equal(t, tt.s, tt.x.String(), "ToString: %v", tt.desc)
+		} else {
+			assert.NotPanics(t, func() { _ = tt.x.String() }, "ToString: %v", tt.desc)
+		}
 	}
 }
 
@@ -652,8 +658,11 @@ func TestBasicException(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.s, tt.v, "DoesNotExistException")
-		testRoundTripCombos(t, &tt.s, tt.v, "DoesNotExistException")
 		err := error(&tt.s) // should implement the error interface
+		assert.Equal(t, "DoesNotExistException{Key: foo}", err.Error())
+
+		testRoundTripCombos(t, &tt.s, tt.v, "DoesNotExistException")
+		err = error(&tt.s) // should implement the error interface
 		assert.Equal(t, "DoesNotExistException{Key: foo}", err.Error())
 	}
 }
@@ -673,12 +682,19 @@ func TestCollisionException(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.s, tt.v, "DoesNotExistException2")
-		testRoundTripCombos(t, &tt.s, tt.v, "DoesNotExistException2")
 		assert.Equal(t, "Does_Not_Exist_Exception_Collision", tt.s.ErrorName(),
 			"Thrift name of exception incorrect")
 
 		err := error(&tt.s) // should implement the error interface
 		assert.Equal(t, "DoesNotExistException2{Key: foo}", err.Error())
+
+		testRoundTripCombos(t, &tt.s, tt.v, "DoesNotExistException2")
+		assert.Equal(t, "Does_Not_Exist_Exception_Collision", tt.s.ErrorName(),
+			"Thrift name of exception incorrect")
+
+		err = error(&tt.s) // should implement the error interface
+		assert.Equal(t, "DoesNotExistException2{Key: foo}", err.Error())
+
 	}
 }
 

--- a/gen/type.go
+++ b/gen/type.go
@@ -204,6 +204,10 @@ func readerFuncName(g Generator, spec compile.TypeSpec) string {
 	return fmt.Sprintf("_%s_Read", g.MangleType(spec))
 }
 
+func decoderFuncName(g Generator, spec compile.TypeSpec) string {
+	return fmt.Sprintf("_%s_Decode", g.MangleType(spec))
+}
+
 func valueListName(g Generator, spec compile.TypeSpec) string {
 	return fmt.Sprintf("_%s_ValueList", g.MangleType(spec))
 }

--- a/gen/typedef_test.go
+++ b/gen/typedef_test.go
@@ -49,6 +49,9 @@ func TestTypedefI64(t *testing.T) {
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "Timestamp")
 		assert.True(t, tt.x.Equals(tt.x), "Timestamp equal")
+
+		testRoundTripCombos(t, &tt.x, tt.v, "Timestamp")
+		assert.True(t, tt.x.Equals(tt.x), "Timestamp equal")
 	}
 }
 
@@ -89,6 +92,8 @@ func TestTypedefString(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "State")
+		assert.True(t, tt.x.Equals(tt.x), "State equal")
+
 		testRoundTripCombos(t, &tt.x, tt.v, "State")
 		assert.True(t, tt.x.Equals(tt.x), "State equal")
 	}
@@ -127,6 +132,8 @@ func TestTypedefBinary(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "PDF")
+		assert.True(t, tt.x.Equals(tt.x))
+
 		testRoundTripCombos(t, &tt.x, tt.v, "PDF")
 		assert.True(t, tt.x.Equals(tt.x))
 	}
@@ -164,6 +171,8 @@ func TestTypedefStruct(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, tt.x, tt.v, "UUID")
+		assert.True(t, tt.x.Equals(tt.x), "UUID equal")
+
 		testRoundTripCombos(t, tt.x, tt.v, "UUID")
 		assert.True(t, tt.x.Equals(tt.x), "UUID equal")
 	}
@@ -224,6 +233,8 @@ func TestTypedefContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "EventGroup")
+		assert.True(t, tt.x.Equals(tt.x), "EventGroup equal")
+
 		testRoundTripCombos(t, &tt.x, tt.v, "EventGroup")
 		assert.True(t, tt.x.Equals(tt.x), "EventGroup equal")
 	}
@@ -308,6 +319,8 @@ func TestUnhashableSetAlias(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "FrameGroup")
+		assert.True(t, tt.x.Equals(tt.x), "FrameGroup equal")
+
 		testRoundTripCombos(t, &tt.x, tt.v, "FrameGroup")
 		assert.True(t, tt.x.Equals(tt.x), "FrameGroup equal")
 	}
@@ -406,6 +419,8 @@ func TestUnhashableMapKeyAlias(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "PointMap")
+		assert.True(t, tt.x.Equals(tt.x), "PointMap equal")
+
 		testRoundTripCombos(t, &tt.x, tt.v, "PointMap")
 		assert.True(t, tt.x.Equals(tt.x), "PointMap equal")
 	}
@@ -489,6 +504,8 @@ func TestBinarySet(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "BinarySet")
+		assert.True(t, tt.x.Equals(tt.x), "BinarySet equal")
+
 		testRoundTripCombos(t, &tt.x, tt.v, "BinarySet")
 		assert.True(t, tt.x.Equals(tt.x), "BinarySet equal")
 	}
@@ -585,6 +602,21 @@ func TestTypedefAnnotatedSetToSlice(t *testing.T) {
 	assert.Equal(t, s, e.String())
 
 	assertRoundTrip(t, &g, ll, "StringListList")
+	testRoundTripCombos(t, &g, ll, "StringListList")
+	assert.Equal(t, "[[foo]]", g.String())
+
+	testRoundTripCombos(t, &a, l, "StringList")
+	assert.True(t, a.Equals(b))
+	assert.Equal(t, s, a.String())
+
+	testRoundTripCombos(t, &c, l, "MyStringList")
+	assert.True(t, c.Equals(d))
+	assert.Equal(t, s, c.String())
+
+	testRoundTripCombos(t, &e, l, "AnotherStringList")
+	assert.True(t, e.Equals(f))
+	assert.Equal(t, s, e.String())
+
 	testRoundTripCombos(t, &g, ll, "StringListList")
 	assert.Equal(t, "[[foo]]", g.String())
 }

--- a/gen/util_for_test.go
+++ b/gen/util_for_test.go
@@ -46,5 +46,5 @@ type streamingThriftType interface {
 	thriftType
 
 	Encode(stream.Writer) error
-	//Decode(stream.Reader) error
+	Decode(stream.Reader) error
 }

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -491,6 +491,68 @@ func (v *TApplicationException) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _ExceptionType_Decode(sr stream.Reader) (ExceptionType, error) {
+	var v ExceptionType
+	err := v.Decode(sr)
+	return v, err
+}
+
+// Decode deserializes a TApplicationException struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a TApplicationException struct could not be generated from the wire
+// representation.
+func (v *TApplicationException) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.Message = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TI32 {
+				var x ExceptionType
+				x, err = _ExceptionType_Decode(sr)
+				v.Type = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a TApplicationException
 // struct.
 func (v *TApplicationException) String() string {

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -330,6 +330,123 @@ func (v *Argument) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _Type_Decode(sr stream.Reader) (*Type, error) {
+	var v Type
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _Map_String_String_Decode(sr stream.Reader) (map[string]string, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TBinary {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string]string, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a Argument struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Argument struct could not be generated from the wire
+// representation.
+func (v *Argument) Decode(sr stream.Reader) error {
+
+	nameIsSet := false
+	typeIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Name, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				nameIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.Type, err = _Type_Decode(sr)
+				if err != nil {
+					return err
+				}
+				typeIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TMap {
+				v.Annotations, err = _Map_String_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !nameIsSet {
+		return errors.New("field Name of Argument is required")
+	}
+
+	if !typeIsSet {
+		return errors.New("field Type of Argument is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Argument
 // struct.
 func (v *Argument) String() string {
@@ -1021,6 +1138,152 @@ func (v *Function) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _Argument_Decode(sr stream.Reader) (*Argument, error) {
+	var v Argument
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _List_Argument_Decode(sr stream.Reader) ([]*Argument, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TStruct {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]*Argument, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _Argument_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a Function struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Function struct could not be generated from the wire
+// representation.
+func (v *Function) Decode(sr stream.Reader) error {
+
+	nameIsSet := false
+	thriftNameIsSet := false
+	argumentsIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Name, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				nameIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.ThriftName, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				thriftNameIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TList {
+				v.Arguments, err = _List_Argument_Decode(sr)
+				if err != nil {
+					return err
+				}
+				argumentsIsSet = true
+			}
+		case 4:
+			if fh.Type == wire.TStruct {
+				v.ReturnType, err = _Type_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TList {
+				v.Exceptions, err = _List_Argument_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 6:
+			if fh.Type == wire.TBool {
+				var x bool
+				x, err = sr.ReadBool()
+				v.OneWay = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 7:
+			if fh.Type == wire.TMap {
+				v.Annotations, err = _Map_String_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !nameIsSet {
+		return errors.New("field Name of Function is required")
+	}
+
+	if !thriftNameIsSet {
+		return errors.New("field ThriftName of Function is required")
+	}
+
+	if !argumentsIsSet {
+		return errors.New("field Arguments of Function is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Function
@@ -1862,6 +2125,280 @@ func (v *GenerateServiceRequest) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _ServiceID_Decode(sr stream.Reader) (ServiceID, error) {
+	var x ServiceID
+	err := x.Decode(sr)
+	return x, err
+}
+
+func _List_ServiceID_Decode(sr stream.Reader) ([]ServiceID, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TI32 {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]ServiceID, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _ServiceID_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _Service_Decode(sr stream.Reader) (*Service, error) {
+	var v Service
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _Map_ServiceID_Service_Decode(sr stream.Reader) (map[ServiceID]*Service, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TI32 || mh.ValueType != wire.TStruct {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[ServiceID]*Service, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := _ServiceID_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := _Service_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _ModuleID_Decode(sr stream.Reader) (ModuleID, error) {
+	var x ModuleID
+	err := x.Decode(sr)
+	return x, err
+}
+
+func _Module_Decode(sr stream.Reader) (*Module, error) {
+	var v Module
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _Map_ModuleID_Module_Decode(sr stream.Reader) (map[ModuleID]*Module, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TI32 || mh.ValueType != wire.TStruct {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[ModuleID]*Module, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := _ModuleID_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := _Module_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+func _List_ModuleID_Decode(sr stream.Reader) ([]ModuleID, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TI32 {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]ModuleID, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _ModuleID_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a GenerateServiceRequest struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a GenerateServiceRequest struct could not be generated from the wire
+// representation.
+func (v *GenerateServiceRequest) Decode(sr stream.Reader) error {
+
+	rootServicesIsSet := false
+	servicesIsSet := false
+	modulesIsSet := false
+	packagePrefixIsSet := false
+	thriftRootIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TList {
+				v.RootServices, err = _List_ServiceID_Decode(sr)
+				if err != nil {
+					return err
+				}
+				rootServicesIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TMap {
+				v.Services, err = _Map_ServiceID_Service_Decode(sr)
+				if err != nil {
+					return err
+				}
+				servicesIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TMap {
+				v.Modules, err = _Map_ModuleID_Module_Decode(sr)
+				if err != nil {
+					return err
+				}
+				modulesIsSet = true
+			}
+		case 4:
+			if fh.Type == wire.TBinary {
+				v.PackagePrefix, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				packagePrefixIsSet = true
+			}
+		case 5:
+			if fh.Type == wire.TBinary {
+				v.ThriftRoot, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				thriftRootIsSet = true
+			}
+		case 6:
+			if fh.Type == wire.TList {
+				v.RootModules, err = _List_ModuleID_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !rootServicesIsSet {
+		return errors.New("field RootServices of GenerateServiceRequest is required")
+	}
+
+	if !servicesIsSet {
+		return errors.New("field Services of GenerateServiceRequest is required")
+	}
+
+	if !modulesIsSet {
+		return errors.New("field Modules of GenerateServiceRequest is required")
+	}
+
+	if !packagePrefixIsSet {
+		return errors.New("field PackagePrefix of GenerateServiceRequest is required")
+	}
+
+	if !thriftRootIsSet {
+		return errors.New("field ThriftRoot of GenerateServiceRequest is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a GenerateServiceRequest
 // struct.
 func (v *GenerateServiceRequest) String() string {
@@ -2343,6 +2880,90 @@ func (v *GenerateServiceResponse) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _Map_String_Binary_Decode(sr stream.Reader) (map[string][]byte, error) {
+	mh, err := sr.ReadMapBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if mh.KeyType != wire.TBinary || mh.ValueType != wire.TBinary {
+		for i := 0; i < mh.Length; i++ {
+			if err := sr.Skip(mh.KeyType); err != nil {
+				return nil, err
+			}
+
+			if err := sr.Skip(mh.ValueType); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadMapEnd()
+	}
+
+	o := make(map[string][]byte, mh.Length)
+	for i := 0; i < mh.Length; i++ {
+		k, err := sr.ReadString()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := sr.ReadBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		o[k] = v
+	}
+
+	if err = sr.ReadMapEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a GenerateServiceResponse struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a GenerateServiceResponse struct could not be generated from the wire
+// representation.
+func (v *GenerateServiceResponse) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TMap {
+				v.Files, err = _Map_String_Binary_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a GenerateServiceResponse
 // struct.
 func (v *GenerateServiceResponse) String() string {
@@ -2498,6 +3119,42 @@ func (v *HandshakeRequest) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a HandshakeRequest struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a HandshakeRequest struct could not be generated from the wire
+// representation.
+func (v *HandshakeRequest) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a HandshakeRequest
@@ -2807,6 +3464,128 @@ func (v *HandshakeResponse) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _Feature_Decode(sr stream.Reader) (Feature, error) {
+	var v Feature
+	err := v.Decode(sr)
+	return v, err
+}
+
+func _List_Feature_Decode(sr stream.Reader) ([]Feature, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TI32 {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]Feature, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _Feature_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a HandshakeResponse struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a HandshakeResponse struct could not be generated from the wire
+// representation.
+func (v *HandshakeResponse) Decode(sr stream.Reader) error {
+
+	nameIsSet := false
+	apiVersionIsSet := false
+	featuresIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Name, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				nameIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TI32 {
+				v.APIVersion, err = sr.ReadInt32()
+				if err != nil {
+					return err
+				}
+				apiVersionIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TList {
+				v.Features, err = _List_Feature_Decode(sr)
+				if err != nil {
+					return err
+				}
+				featuresIsSet = true
+			}
+		case 4:
+			if fh.Type == wire.TBinary {
+				var x string
+				x, err = sr.ReadString()
+				v.LibraryVersion = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !nameIsSet {
+		return errors.New("field Name of HandshakeResponse is required")
+	}
+
+	if !apiVersionIsSet {
+		return errors.New("field APIVersion of HandshakeResponse is required")
+	}
+
+	if !featuresIsSet {
+		return errors.New("field Features of HandshakeResponse is required")
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a HandshakeResponse
@@ -3129,6 +3908,82 @@ func (v *Module) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a Module struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Module struct could not be generated from the wire
+// representation.
+func (v *Module) Decode(sr stream.Reader) error {
+
+	importPathIsSet := false
+	directoryIsSet := false
+	thriftFilePathIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.ImportPath, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				importPathIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.Directory, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				directoryIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TBinary {
+				v.ThriftFilePath, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				thriftFilePathIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !importPathIsSet {
+		return errors.New("field ImportPath of Module is required")
+	}
+
+	if !directoryIsSet {
+		return errors.New("field Directory of Module is required")
+	}
+
+	if !thriftFilePathIsSet {
+		return errors.New("field ThriftFilePath of Module is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Module
 // struct.
 func (v *Module) String() string {
@@ -3243,6 +4098,13 @@ func (v ModuleID) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *ModuleID) FromWire(w wire.Value) error {
 	x, err := w.GetI32(), error(nil)
+	*v = (ModuleID)(x)
+	return err
+}
+
+// Decode deserializes ModuleID directly off the wire.
+func (v *ModuleID) Decode(sr stream.Reader) error {
+	x, err := sr.ReadInt32()
 	*v = (ModuleID)(x)
 	return err
 }
@@ -3597,6 +4459,150 @@ func (v *Service) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _Function_Decode(sr stream.Reader) (*Function, error) {
+	var v Function
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _List_Function_Decode(sr stream.Reader) ([]*Function, error) {
+	lh, err := sr.ReadListBegin()
+	if err != nil {
+		return nil, err
+	}
+
+	if lh.Type != wire.TStruct {
+		for i := 0; i < lh.Length; i++ {
+			if err := sr.Skip(lh.Type); err != nil {
+				return nil, err
+			}
+		}
+		return nil, sr.ReadListEnd()
+	}
+
+	o := make([]*Function, 0, lh.Length)
+	for i := 0; i < lh.Length; i++ {
+		v, err := _Function_Decode(sr)
+		if err != nil {
+			return nil, err
+		}
+		o = append(o, v)
+	}
+
+	if err = sr.ReadListEnd(); err != nil {
+		return nil, err
+	}
+	return o, err
+}
+
+// Decode deserializes a Service struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Service struct could not be generated from the wire
+// representation.
+func (v *Service) Decode(sr stream.Reader) error {
+
+	nameIsSet := false
+	thriftNameIsSet := false
+
+	functionsIsSet := false
+	moduleIDIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 7:
+			if fh.Type == wire.TBinary {
+				v.Name, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				nameIsSet = true
+			}
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.ThriftName, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				thriftNameIsSet = true
+			}
+		case 4:
+			if fh.Type == wire.TI32 {
+				var x ServiceID
+				x, err = _ServiceID_Decode(sr)
+				v.ParentID = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TList {
+				v.Functions, err = _List_Function_Decode(sr)
+				if err != nil {
+					return err
+				}
+				functionsIsSet = true
+			}
+		case 6:
+			if fh.Type == wire.TI32 {
+				v.ModuleID, err = _ModuleID_Decode(sr)
+				if err != nil {
+					return err
+				}
+				moduleIDIsSet = true
+			}
+		case 8:
+			if fh.Type == wire.TMap {
+				v.Annotations, err = _Map_String_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !nameIsSet {
+		return errors.New("field Name of Service is required")
+	}
+
+	if !thriftNameIsSet {
+		return errors.New("field ThriftName of Service is required")
+	}
+
+	if !functionsIsSet {
+		return errors.New("field Functions of Service is required")
+	}
+
+	if !moduleIDIsSet {
+		return errors.New("field ModuleID of Service is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Service
 // struct.
 func (v *Service) String() string {
@@ -3817,6 +4823,13 @@ func (v ServiceID) Encode(sw stream.Writer) error {
 // from a ThriftRW protocol implementation.
 func (v *ServiceID) FromWire(w wire.Value) error {
 	x, err := w.GetI32(), error(nil)
+	*v = (ServiceID)(x)
+	return err
+}
+
+// Decode deserializes ServiceID directly off the wire.
+func (v *ServiceID) Decode(sr stream.Reader) error {
+	x, err := sr.ReadInt32()
 	*v = (ServiceID)(x)
 	return err
 }
@@ -4445,6 +5458,133 @@ func (v *Type) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _SimpleType_Decode(sr stream.Reader) (SimpleType, error) {
+	var v SimpleType
+	err := v.Decode(sr)
+	return v, err
+}
+
+func _TypePair_Decode(sr stream.Reader) (*TypePair, error) {
+	var v TypePair
+	err := v.Decode(sr)
+	return &v, err
+}
+
+func _TypeReference_Decode(sr stream.Reader) (*TypeReference, error) {
+	var v TypeReference
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a Type struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Type struct could not be generated from the wire
+// representation.
+func (v *Type) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TI32 {
+				var x SimpleType
+				x, err = _SimpleType_Decode(sr)
+				v.SimpleType = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.SliceType, err = _Type_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if fh.Type == wire.TStruct {
+				v.KeyValueSliceType, err = _TypePair_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 4:
+			if fh.Type == wire.TStruct {
+				v.MapType, err = _TypePair_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 5:
+			if fh.Type == wire.TStruct {
+				v.ReferenceType, err = _TypeReference_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 6:
+			if fh.Type == wire.TStruct {
+				v.PointerType, err = _Type_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.SimpleType != nil {
+		count++
+	}
+	if v.SliceType != nil {
+		count++
+	}
+	if v.KeyValueSliceType != nil {
+		count++
+	}
+	if v.MapType != nil {
+		count++
+	}
+	if v.ReferenceType != nil {
+		count++
+	}
+	if v.PointerType != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("Type should have exactly one field: got %v fields", count)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Type
 // struct.
 func (v *Type) String() string {
@@ -4785,6 +5925,69 @@ func (v *TypePair) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a TypePair struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a TypePair struct could not be generated from the wire
+// representation.
+func (v *TypePair) Decode(sr stream.Reader) error {
+
+	leftIsSet := false
+	rightIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.Left, err = _Type_Decode(sr)
+				if err != nil {
+					return err
+				}
+				leftIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TStruct {
+				v.Right, err = _Type_Decode(sr)
+				if err != nil {
+					return err
+				}
+				rightIsSet = true
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !leftIsSet {
+		return errors.New("field Left of TypePair is required")
+	}
+
+	if !rightIsSet {
+		return errors.New("field Right of TypePair is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a TypePair
 // struct.
 func (v *TypePair) String() string {
@@ -5042,6 +6245,77 @@ func (v *TypeReference) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a TypeReference struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a TypeReference struct could not be generated from the wire
+// representation.
+func (v *TypeReference) Decode(sr stream.Reader) error {
+
+	nameIsSet := false
+	importPathIsSet := false
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TBinary {
+				v.Name, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				nameIsSet = true
+			}
+		case 2:
+			if fh.Type == wire.TBinary {
+				v.ImportPath, err = sr.ReadString()
+				if err != nil {
+					return err
+				}
+				importPathIsSet = true
+			}
+		case 3:
+			if fh.Type == wire.TMap {
+				v.Annotations, err = _Map_String_String_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	if !nameIsSet {
+		return errors.New("field Name of TypeReference is required")
+	}
+
+	if !importPathIsSet {
+		return errors.New("field ImportPath of TypeReference is required")
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a TypeReference
 // struct.
 func (v *TypeReference) String() string {
@@ -5211,6 +6485,42 @@ func (v *Plugin_Goodbye_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+// Decode deserializes a Plugin_Goodbye_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Plugin_Goodbye_Args struct could not be generated from the wire
+// representation.
+func (v *Plugin_Goodbye_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Plugin_Goodbye_Args
@@ -5402,6 +6712,42 @@ func (v *Plugin_Goodbye_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+// Decode deserializes a Plugin_Goodbye_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Plugin_Goodbye_Result struct could not be generated from the wire
+// representation.
+func (v *Plugin_Goodbye_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Plugin_Goodbye_Result
 // struct.
 func (v *Plugin_Goodbye_Result) String() string {
@@ -5559,6 +6905,56 @@ func (v *Plugin_Handshake_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _HandshakeRequest_Decode(sr stream.Reader) (*HandshakeRequest, error) {
+	var v HandshakeRequest
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a Plugin_Handshake_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Plugin_Handshake_Args struct could not be generated from the wire
+// representation.
+func (v *Plugin_Handshake_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.Request, err = _HandshakeRequest_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a Plugin_Handshake_Args
@@ -5850,6 +7246,64 @@ func (v *Plugin_Handshake_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
+func _HandshakeResponse_Decode(sr stream.Reader) (*HandshakeResponse, error) {
+	var v HandshakeResponse
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a Plugin_Handshake_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Plugin_Handshake_Result struct could not be generated from the wire
+// representation.
+func (v *Plugin_Handshake_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 0:
+			if fh.Type == wire.TStruct {
+				v.Success, err = _HandshakeResponse_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("Plugin_Handshake_Result should have exactly one field: got %v fields", count)
+	}
+
+	return nil
+}
+
 // String returns a readable string representation of a Plugin_Handshake_Result
 // struct.
 func (v *Plugin_Handshake_Result) String() string {
@@ -6032,6 +7486,56 @@ func (v *ServiceGenerator_Generate_Args) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _GenerateServiceRequest_Decode(sr stream.Reader) (*GenerateServiceRequest, error) {
+	var v GenerateServiceRequest
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a ServiceGenerator_Generate_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ServiceGenerator_Generate_Args struct could not be generated from the wire
+// representation.
+func (v *ServiceGenerator_Generate_Args) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 1:
+			if fh.Type == wire.TStruct {
+				v.Request, err = _GenerateServiceRequest_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a ServiceGenerator_Generate_Args
@@ -6321,6 +7825,64 @@ func (v *ServiceGenerator_Generate_Result) Encode(sw stream.Writer) error {
 	}
 
 	return sw.WriteStructEnd()
+}
+
+func _GenerateServiceResponse_Decode(sr stream.Reader) (*GenerateServiceResponse, error) {
+	var v GenerateServiceResponse
+	err := v.Decode(sr)
+	return &v, err
+}
+
+// Decode deserializes a ServiceGenerator_Generate_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ServiceGenerator_Generate_Result struct could not be generated from the wire
+// representation.
+func (v *ServiceGenerator_Generate_Result) Decode(sr stream.Reader) error {
+
+	if err := sr.ReadStructBegin(); err != nil {
+		return err
+	}
+
+	fh, ok, err := sr.ReadFieldBegin()
+	if err != nil {
+		return err
+	}
+
+	for ok {
+		switch fh.ID {
+		case 0:
+			if fh.Type == wire.TStruct {
+				v.Success, err = _GenerateServiceResponse_Decode(sr)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		if err := sr.ReadFieldEnd(); err != nil {
+			return err
+		}
+
+		if fh, ok, err = sr.ReadFieldBegin(); err != nil {
+			return err
+		}
+	}
+
+	if err := sr.ReadStructEnd(); err != nil {
+		return err
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("ServiceGenerator_Generate_Result should have exactly one field: got %v fields", count)
+	}
+
+	return nil
 }
 
 // String returns a readable string representation of a ServiceGenerator_Generate_Result


### PR DESCRIPTION
#495 provided the code generation for streaming reads of enums off of the wire.
Provide the streaming read generators for all of the other types.

Doing so meant providing a `StreamGenerator` that plumbs into the existing
generators.  This `StreamGenerator` only provides the "decoding" mechanism,
leveraging #491 for reading the raw Thrift encoding off of the wire.

In addition to providing a `StreamGenerator`, the list, map, set, enum, typdef,
and struct generators all added a `Decoder` method that will appropriately
recurse and iterate to generate the proper, mirrored readers for the raw wire
representation.

The `Decode` and `DecodePtr` methods for `StreamGenerator` then hook into the
templated generator itself, providing the templated `decode` and `decodePtr`
calls that will be used where necessary.

The existing tests were leveraged to make sure that the streaming reads were
compatible with the current binary writes and that no data was lost.  In doing
so, a 'genericized' function that will perform the cross-products of
encoding/writing and decoding/reading.

A benchmark was also added to evaluate the new streaming reads.  The following
represents benchmarks of the original code vs the dedup'd code (the binary
decode/encode leveraging the streaming implementations):
```
name                                        old time/op    new time/op    delta
RoundTrip/PrimitiveOptionalStruct/Encode-8    1.76µs ± 2%    1.86µs ± 5%    +5.93%  (p=0.008 n=5+5)
RoundTrip/PrimitiveOptionalStruct/Decode-8    2.55µs ± 3%    2.82µs ± 5%   +10.68%  (p=0.008 n=5+5)
RoundTrip/Graph/Encode-8                      3.15µs ± 2%    3.16µs ± 1%      ~     (p=1.000 n=5+5)
RoundTrip/Graph/Decode-8                      5.02µs ± 1%    8.95µs ±11%   +78.05%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Encode-8     19.1µs ± 1%    19.8µs ± 3%    +3.76%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Decode-8     45.2µs ± 3%   110.8µs ± 1%  +144.98%  (p=0.008 n=5+5)

name                                        old alloc/op   new alloc/op   delta
RoundTrip/PrimitiveOptionalStruct/Encode-8      704B ± 0%      704B ± 0%      ~     (all equal)
RoundTrip/PrimitiveOptionalStruct/Decode-8    1.40kB ± 0%    1.45kB ± 0%    +3.43%  (p=0.008 n=5+5)
RoundTrip/Graph/Encode-8                      1.70kB ± 0%    1.70kB ± 0%      ~     (all equal)
RoundTrip/Graph/Decode-8                      2.78kB ± 0%    3.55kB ± 0%   +27.98%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Encode-8     1.30kB ± 0%    1.30kB ± 0%      ~     (all equal)
RoundTrip/ContainersOfContainers/Decode-8     12.3kB ± 0%    28.6kB ± 0%  +132.07%  (p=0.008 n=5+5)

name                                        old allocs/op  new allocs/op  delta
RoundTrip/PrimitiveOptionalStruct/Encode-8      1.00 ± 0%      1.00 ± 0%      ~     (all equal)
RoundTrip/PrimitiveOptionalStruct/Decode-8      14.0 ± 0%      15.0 ± 0%    +7.14%  (p=0.008 n=5+5)
RoundTrip/Graph/Encode-8                        11.0 ± 0%      11.0 ± 0%      ~     (all equal)
RoundTrip/Graph/Decode-8                        32.0 ± 0%      63.0 ± 0%   +96.88%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Encode-8       18.0 ± 0%      18.0 ± 0%      ~     (all equal)
RoundTrip/ContainersOfContainers/Decode-8        164 ± 0%       837 ± 0%  +410.37%  (p=0.008 n=5+5)
```
and the original code vs the streaming implementations (benchmarks renamed for
the purpose of benchstat-ing).
```
name                                        old time/op    new time/op    delta
RoundTrip/PrimitiveOptionalStruct/Encode-8    1.76µs ± 2%    1.61µs ± 2%   -8.57%  (p=0.008 n=5+5)
RoundTrip/PrimitiveOptionalStruct/Decode-8    2.55µs ± 3%    1.19µs ± 0%  -53.36%  (p=0.008 n=5+5)
RoundTrip/Graph/Encode-8                      3.15µs ± 2%    1.88µs ± 1%  -40.29%  (p=0.008 n=5+5)
RoundTrip/Graph/Decode-8                      5.02µs ± 1%    1.87µs ± 2%  -62.76%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Encode-8     19.1µs ± 1%    12.5µs ± 4%  -34.30%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Decode-8     45.2µs ± 3%    27.6µs ± 1%  -38.90%  (p=0.008 n=5+5)

name                                        old alloc/op   new alloc/op   delta
RoundTrip/PrimitiveOptionalStruct/Encode-8      704B ± 0%       24B ± 0%  -96.59%  (p=0.008 n=5+5)
RoundTrip/PrimitiveOptionalStruct/Decode-8    1.40kB ± 0%    0.10kB ± 0%  -92.57%  (p=0.008 n=5+5)
RoundTrip/Graph/Encode-8                      1.70kB ± 0%    0.02kB ± 0%  -98.59%  (p=0.008 n=5+5)
RoundTrip/Graph/Decode-8                      2.78kB ± 0%    0.22kB ± 0%  -92.22%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Encode-8     1.30kB ± 0%    0.02kB ± 0%  -98.16%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Decode-8     12.3kB ± 0%    10.2kB ± 0%  -17.53%  (p=0.016 n=5+4)

name                                        old allocs/op  new allocs/op  delta
RoundTrip/PrimitiveOptionalStruct/Encode-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
RoundTrip/PrimitiveOptionalStruct/Decode-8      14.0 ± 0%      11.0 ± 0%  -21.43%  (p=0.008 n=5+5)
RoundTrip/Graph/Encode-8                        11.0 ± 0%       1.0 ± 0%  -90.91%  (p=0.008 n=5+5)
RoundTrip/Graph/Decode-8                        32.0 ± 0%      11.0 ± 0%  -65.62%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Encode-8       18.0 ± 0%       1.0 ± 0%  -94.44%  (p=0.008 n=5+5)
RoundTrip/ContainersOfContainers/Decode-8        164 ± 0%       146 ± 0%  -10.73%  (p=0.008 n=5+5)
```