### PR TITLE
idl: add a Position struct to wrap reported lines

### DIFF
--- a/idl/error.go
+++ b/idl/error.go
@@ -29,30 +29,33 @@ import (
 
 // ParseError is an error type listing parse errors and the positions
 // that caused them.
-type ParseError struct{ Lines []LineError }
+type ParseError struct{ Errors []Error }
 
-// LineError holds an error and the line number that caused it.
-type LineError struct {
-	Line int
-	Err  error
+// Error holds an error and the position that caused it.
+type Error struct {
+	Pos Position
+	Err error
 }
 
-func newParseError(errors []internal.LineError) error {
+func newParseError(errors []internal.ParseError) error {
 	if len(errors) == 0 {
 		return nil
 	}
-	lines := make([]LineError, len(errors))
+	errs := make([]Error, len(errors))
 	for i, err := range errors {
-		lines[i] = LineError{Line: err.Line, Err: err.Err}
+		errs[i] = Error{
+			Pos: Position{Line: err.Pos.Line},
+			Err: err.Err,
+		}
 	}
-	return &ParseError{Lines: lines}
+	return &ParseError{Errors: errs}
 }
 
 func (pe *ParseError) Error() string {
 	var buffer bytes.Buffer
 	buffer.WriteString("parse error\n")
-	for _, line := range pe.Lines {
-		buffer.WriteString(fmt.Sprintf("  line %d: %s\n", line.Line, line.Err))
+	for _, pe := range pe.Errors {
+		buffer.WriteString(fmt.Sprintf("  line %d: %s\n", pe.Pos.Line, pe.Err))
 	}
 	return buffer.String()
 }

--- a/idl/internal/error.go
+++ b/idl/internal/error.go
@@ -20,8 +20,8 @@
 
 package internal
 
-// LineError holds a parse error and the line number that caused it.
-type LineError struct {
-	Line int
-	Err  error
+// ParseError holds a parse error and the position that caused it.
+type ParseError struct {
+	Pos Position
+	Err error
 }

--- a/idl/internal/lex.go
+++ b/idl/internal/lex.go
@@ -48,7 +48,7 @@ type lexer struct {
 	lastDocstring       string
 	linesSinceDocstring int
 
-	errors      []LineError
+	errors      []ParseError
 	parseFailed bool
 
 	// Ragel:
@@ -16605,7 +16605,7 @@ func (lex *lexer) Error(e string) {
 
 func (lex *lexer) AppendError(err error) {
 	lex.parseFailed = true
-	lex.errors = append(lex.errors, LineError{Line: lex.line, Err: err})
+	lex.errors = append(lex.errors, ParseError{Pos: Position{Line: lex.line}, Err: err})
 }
 
 func (lex *lexer) LastDocstring() string {

--- a/idl/internal/lex.rl
+++ b/idl/internal/lex.rl
@@ -28,7 +28,7 @@ type lexer struct {
     lastDocstring string
     linesSinceDocstring int
 
-    errors []LineError
+    errors []ParseError
     parseFailed bool
 
     // Ragel:
@@ -349,7 +349,7 @@ func (lex *lexer) Error(e string) {
 
 func (lex *lexer) AppendError(err error)  {
   lex.parseFailed = true
-  lex.errors = append(lex.errors, LineError{Line: lex.line, Err: err})
+  lex.errors = append(lex.errors, ParseError{Pos: Position{Line: lex.line}, Err: err})
 }
 
 func (lex *lexer) LastDocstring() string {

--- a/idl/internal/position.go
+++ b/idl/internal/position.go
@@ -20,26 +20,7 @@
 
 package internal
 
-import "go.uber.org/thriftrw/ast"
-
-func init() {
-	yyErrorVerbose = true
+// Position represents a position in the parsed document.
+type Position struct {
+	Line int
 }
-
-// Parse parses the given Thrift document.
-func Parse(s []byte) (*ast.Program, []ParseError) {
-	lex := newLexer(s)
-	e := yyParse(lex)
-	if e == 0 && !lex.parseFailed {
-		return lex.program, nil
-	}
-	return nil, lex.errors
-}
-
-//go:generate ragel -Z -G2 -o lex.go lex.rl
-//go:generate goimports -w ./lex.go
-
-//go:generate goyacc -l thrift.y
-//go:generate goimports -w ./y.go
-
-//go:generate ./generated.sh

--- a/idl/position.go
+++ b/idl/position.go
@@ -18,28 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package internal
+package idl
 
-import "go.uber.org/thriftrw/ast"
-
-func init() {
-	yyErrorVerbose = true
+// Position represents a position in the parsed document.
+type Position struct {
+	Line int
 }
-
-// Parse parses the given Thrift document.
-func Parse(s []byte) (*ast.Program, []ParseError) {
-	lex := newLexer(s)
-	e := yyParse(lex)
-	if e == 0 && !lex.parseFailed {
-		return lex.program, nil
-	}
-	return nil, lex.errors
-}
-
-//go:generate ragel -Z -G2 -o lex.go lex.rl
-//go:generate goimports -w ./lex.go
-
-//go:generate goyacc -l thrift.y
-//go:generate goimports -w ./y.go
-
-//go:generate ./generated.sh


### PR DESCRIPTION
Line-based data types are too limiting should we add support for other
positional information, such as offsets/columns (#349).