### PR TITLE
Add code generation for all wire types for stream encoding

### DIFF
--- a/ast/mock_visitor_test.go
+++ b/ast/mock_visitor_test.go
@@ -5,8 +5,9 @@
 package ast
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockVisitor is a mock of Visitor interface

--- a/gen/benchmark_test.go
+++ b/gen/benchmark_test.go
@@ -9,6 +9,8 @@ import (
 	tc "go.uber.org/thriftrw/gen/internal/tests/containers"
 	ts "go.uber.org/thriftrw/gen/internal/tests/structs"
 	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/protocol/binary"
+	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/wire"
 )
@@ -16,6 +18,12 @@ import (
 type thriftType interface {
 	ToWire() (wire.Value, error)
 	FromWire(wire.Value) error
+}
+
+type streamingThriftType interface {
+	thriftType
+
+	Encode(stream.Writer) error
 }
 
 func BenchmarkRoundTrip(b *testing.B) {
@@ -119,6 +127,19 @@ func BenchmarkRoundTrip(b *testing.B) {
 		}
 	}
 
+	benchmarkStreamEncode := func(b *testing.B, bb benchCase) {
+		var buff bytes.Buffer
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			buff.Reset()
+
+			writer := binary.BorrowStreamWriter(&buff)
+			require.NoError(b, bb.give.(streamingThriftType).Encode(writer), "StreamEncode")
+			binary.ReturnStreamWriter(writer)
+		}
+	}
+
 	benchmarkDecode := func(b *testing.B, bb benchCase) {
 		var buff bytes.Buffer
 		w, err := bb.give.ToWire()
@@ -142,6 +163,10 @@ func BenchmarkRoundTrip(b *testing.B) {
 		b.Run(bb.name, func(b *testing.B) {
 			b.Run("Encode", func(b *testing.B) {
 				benchmarkEncode(b, bb)
+			})
+
+			b.Run("Stream Encode", func(b *testing.B) {
+				benchmarkStreamEncode(b, bb)
 			})
 
 			b.Run("Decode", func(b *testing.B) {

--- a/gen/container_test.go
+++ b/gen/container_test.go
@@ -180,6 +180,9 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.p, tt.v, tt.desc)
 		assert.True(t, tt.p.Equals(&tt.p), tt.desc)
+
+		testRoundTripCombos(t, &tt.p, tt.v, tt.desc)
+		assert.True(t, tt.p.Equals(&tt.p), tt.desc)
 	}
 }
 
@@ -351,6 +354,9 @@ func TestEnumContainers(t *testing.T) {
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.r, tt.v, "EnumContainers")
 		assert.True(t, tt.r.Equals(&tt.r), "EnumContainers equal")
+
+		testRoundTripCombos(t, &tt.r, tt.v, "EnumContainers")
+		assert.True(t, tt.r.Equals(&tt.r), "EnumContainers equal")
 	}
 }
 
@@ -505,6 +511,9 @@ func TestListOfStructs(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.r, tt.v, "Graph")
+		assert.True(t, tt.r.Equals(&tt.r), "Graph equal")
+
+		testRoundTripCombos(t, &tt.r, tt.v, "Graph")
 		assert.True(t, tt.r.Equals(&tt.r), "Graph equal")
 	}
 }
@@ -948,6 +957,9 @@ func TestCrazyTown(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, tt.desc)
+		assert.True(t, tt.x.Equals(&tt.x), tt.desc)
+
+		testRoundTripCombos(t, &tt.x, tt.v, tt.desc)
 		assert.True(t, tt.x.Equals(&tt.x), tt.desc)
 	}
 }

--- a/gen/enum_test.go
+++ b/gen/enum_test.go
@@ -185,6 +185,7 @@ func TestOptionalEnum(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.s, tt.v, "StructWithOptionalEnum")
+		testRoundTripCombos(t, &tt.s, tt.v, "StructWithOptionalEnum")
 	}
 }
 

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -129,6 +129,7 @@ type generator struct {
 	w              WireGenerator
 	e              equalsGenerator
 	z              zapGenerator
+	s              StreamGenerator
 	noZap          bool
 	decls          []ast.Decl
 	thriftImporter ThriftPackageImporter
@@ -233,6 +234,8 @@ func (g *generator) TextTemplate(s string, data interface{}, opts ...TemplateOpt
 		"typeReferencePtr": curryGenerator(typeReferencePtr, g),
 		"fromWire":         curryGenerator(g.w.FromWire, g),
 		"fromWirePtr":      curryGenerator(g.w.FromWirePtr, g),
+		"encode":           curryGenerator(g.s.Encode, g),
+		"encodePtr":        curryGenerator(g.s.EncodePtr, g),
 		"toWire":           curryGenerator(g.w.ToWire, g),
 		"toWirePtr":        curryGenerator(g.w.ToWirePtr, g),
 		"typeCode":         curryGenerator(TypeCode, g),

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -215,6 +215,7 @@ func (g *generator) LookupConstantName(c *compile.Constant) (string, error) {
 // TextTemplate renders the given template with the given template context.
 func (g *generator) TextTemplate(s string, data interface{}, opts ...TemplateOption) (string, error) {
 	templateFuncs := template.FuncMap{
+		"lessthan":         lessThanSymbol,
 		"enumItemName":     enumItemName,
 		"formatDoc":        formatDoc,
 		"goCase":           goCase,
@@ -538,4 +539,8 @@ func formatDoc(s string) string {
 		}
 	}
 	return strings.Join(lines, "\n") + "\n"
+}
+
+func lessThanSymbol() string {
+	return "<"
 }

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -8,13 +8,15 @@ import (
 	json "encoding/json"
 	errors "errors"
 	fmt "fmt"
-	multierr "go.uber.org/multierr"
-	thriftreflect "go.uber.org/thriftrw/thriftreflect"
-	wire "go.uber.org/thriftrw/wire"
-	zapcore "go.uber.org/zap/zapcore"
 	math "math"
 	strconv "strconv"
 	strings "strings"
+
+	multierr "go.uber.org/multierr"
+	stream "go.uber.org/thriftrw/protocol/stream"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
 )
 
 var StructConstant *StructCollision2 = &StructCollision2{
@@ -135,6 +137,70 @@ func (v *AccessorConflict) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a AccessorConflict struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a AccessorConflict struct could not be generated from the wire
+// representation.
+func (v *AccessorConflict) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Name != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.Name))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.GetName2 != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.GetName2))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.IsSetName2 != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteBool(*(v.IsSetName2))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a AccessorConflict
@@ -364,6 +430,55 @@ func (v *AccessorNoConflict) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a AccessorNoConflict struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a AccessorNoConflict struct could not be generated from the wire
+// representation.
+func (v *AccessorNoConflict) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Getname != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.Getname))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.GetName != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.GetName))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a AccessorNoConflict
 // struct.
 func (v *AccessorNoConflict) String() string {
@@ -469,6 +584,11 @@ func (v LittlePotatoe) ToWire() (wire.Value, error) {
 func (v LittlePotatoe) String() string {
 	x := (int64)(v)
 	return fmt.Sprint(x)
+}
+
+func (v LittlePotatoe) Encode(sw stream.Writer) error {
+	x := (int64)(v)
+	return sw.WriteInt64(x)
 }
 
 // FromWire deserializes LittlePotatoe from its Thrift-level
@@ -585,6 +705,19 @@ func (v MyEnum) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v MyEnum) Ptr() *MyEnum {
 	return &v
+}
+
+// Encode encodes MyEnum directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v MyEnum
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v MyEnum) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates MyEnum into a Thrift-level intermediate
@@ -957,6 +1090,146 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_String_Encode(val []string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_String_mapType_Encode(val map[string]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_String_String_Encode(val map[string]string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteString(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Decode deserializes a PrimitiveContainers struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveContainers struct could not be generated from the wire
+// representation.
+func (v *PrimitiveContainers) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.A != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_String_Encode(v.A, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.B != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Set_String_mapType_Encode(v.B, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.C != nil {
+		fh = stream.FieldHeader{ID: 5, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_String_String_Encode(v.C, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a PrimitiveContainers
 // struct.
 func (v *PrimitiveContainers) String() string {
@@ -1247,6 +1520,51 @@ func (v *StructCollision) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a StructCollision struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a StructCollision struct could not be generated from the wire
+// representation.
+func (v *StructCollision) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBool}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteBool(v.CollisionField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.CollisionField2)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a StructCollision
 // struct.
 func (v *StructCollision) String() string {
@@ -1422,6 +1740,59 @@ func (v *UnionCollision) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a UnionCollision struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a UnionCollision struct could not be generated from the wire
+// representation.
+func (v *UnionCollision) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.CollisionField != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteBool(*(v.CollisionField))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.CollisionField2 != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.CollisionField2))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if i != 1 {
+		return fmt.Errorf("UnionCollision should have exactly one field: got %v fields", i)
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a UnionCollision
@@ -1616,6 +1987,49 @@ func (v *WithDefault) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a WithDefault struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a WithDefault struct could not be generated from the wire
+// representation.
+func (v *WithDefault) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	vPouet := v.Pouet
+	if vPouet == nil {
+		vPouet = &StructCollision2{
+			CollisionField:  false,
+			CollisionField2: "false indeed",
+		}
+	}
+	{
+		fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := vPouet.Encode(sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a WithDefault
 // struct.
 func (v *WithDefault) String() string {
@@ -1699,6 +2113,11 @@ func (v LittlePotatoe2) ToWire() (wire.Value, error) {
 func (v LittlePotatoe2) String() string {
 	x := (float64)(v)
 	return fmt.Sprint(x)
+}
+
+func (v LittlePotatoe2) Encode(sw stream.Writer) error {
+	x := (float64)(v)
+	return sw.WriteDouble(x)
 }
 
 // FromWire deserializes LittlePotatoe2 from its Thrift-level
@@ -1797,6 +2216,19 @@ func (v MyEnum2) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v MyEnum2) Ptr() *MyEnum2 {
 	return &v
+}
+
+// Encode encodes MyEnum2 directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v MyEnum2
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v MyEnum2) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates MyEnum2 into a Thrift-level intermediate
@@ -2000,6 +2432,51 @@ func (v *StructCollision2) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a StructCollision2 struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a StructCollision2 struct could not be generated from the wire
+// representation.
+func (v *StructCollision2) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBool}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteBool(v.CollisionField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.CollisionField2)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a StructCollision2
 // struct.
 func (v *StructCollision2) String() string {
@@ -2175,6 +2652,59 @@ func (v *UnionCollision2) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a UnionCollision2 struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a UnionCollision2 struct could not be generated from the wire
+// representation.
+func (v *UnionCollision2) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.CollisionField != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteBool(*(v.CollisionField))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.CollisionField2 != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.CollisionField2))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if i != 1 {
+		return fmt.Errorf("UnionCollision2 should have exactly one field: got %v fields", i)
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a UnionCollision2

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -8,15 +8,17 @@ import (
 	base64 "encoding/base64"
 	errors "errors"
 	fmt "fmt"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
 	enum_conflict "go.uber.org/thriftrw/gen/internal/tests/enum_conflict"
 	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
 	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
 	uuid_conflict "go.uber.org/thriftrw/gen/internal/tests/uuid_conflict"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 type ContainersOfContainers struct {
@@ -1226,6 +1228,631 @@ func (v *ContainersOfContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_I32_Encode(val []int32, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = sw.WriteInt32(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_List_I32_Encode(val [][]int32, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TList,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = _List_I32_Encode(v, sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_I32_mapType_Encode(val map[int32]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		err = sw.WriteInt32(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _List_Set_I32_mapType_Encode(val []map[int32]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TSet,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = _Set_I32_mapType_Encode(v, sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Map_I32_I32_Encode(val map[int32]int32, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI32,
+		ValueType: wire.TI32,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteInt32(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteInt32(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _List_Map_I32_I32_Encode(val []map[int32]int32, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TMap,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = _Map_I32_I32_Encode(v, sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_String_mapType_Encode(val map[string]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Set_Set_String_mapType_sliceType_Encode(val []map[string]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TSet,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		err = _Set_String_mapType_Encode(v, sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _List_String_Encode(val []string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_List_String_sliceType_Encode(val [][]string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TList,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		err = _List_String_Encode(v, sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_String_String_Encode(val map[string]string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteString(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Set_Map_String_String_sliceType_Encode(val []map[string]string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TMap,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		err = _Map_String_String_Encode(v, sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_String_I32_Encode(val map[string]int32, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TI32,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteString(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteInt32(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Map_Map_String_I32_I64_Encode(val []struct {
+	Key   map[string]int32
+	Value int64
+}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TMap,
+		ValueType: wire.TI64,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		err = _Map_String_I32_Encode(key, sw)
+		if err != nil {
+			return err
+		}
+		value := v.Value
+		err = sw.WriteInt64(value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Set_I64_mapType_Encode(val map[int64]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TI64,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		err = sw.WriteInt64(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_List_I32_Set_I64_mapType_Encode(val []struct {
+	Key   []int32
+	Value map[int64]struct{}
+}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TList,
+		ValueType: wire.TSet,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		err = _List_I32_Encode(key, sw)
+		if err != nil {
+			return err
+		}
+		value := v.Value
+		err = _Set_I64_mapType_Encode(value, sw)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _List_Double_Encode(val []float64, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TDouble,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = sw.WriteDouble(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Map_Set_I32_mapType_List_Double_Encode(val []struct {
+	Key   map[int32]struct{}
+	Value []float64
+}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TSet,
+		ValueType: wire.TList,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		err = _Set_I32_mapType_Encode(key, sw)
+		if err != nil {
+			return err
+		}
+		value := v.Value
+		err = _List_Double_Encode(value, sw)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Decode deserializes a ContainersOfContainers struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ContainersOfContainers struct could not be generated from the wire
+// representation.
+func (v *ContainersOfContainers) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.ListOfLists != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_List_I32_Encode(v.ListOfLists, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ListOfSets != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_Set_I32_mapType_Encode(v.ListOfSets, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ListOfMaps != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_Map_I32_I32_Encode(v.ListOfMaps, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfSets != nil {
+		fh = stream.FieldHeader{ID: 4, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Set_Set_String_mapType_sliceType_Encode(v.SetOfSets, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfLists != nil {
+		fh = stream.FieldHeader{ID: 5, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Set_List_String_sliceType_Encode(v.SetOfLists, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfMaps != nil {
+		fh = stream.FieldHeader{ID: 6, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Set_Map_String_String_sliceType_Encode(v.SetOfMaps, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfMapToInt != nil {
+		fh = stream.FieldHeader{ID: 7, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_Map_String_I32_I64_Encode(v.MapOfMapToInt, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfListToSet != nil {
+		fh = stream.FieldHeader{ID: 8, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_List_I32_Set_I64_mapType_Encode(v.MapOfListToSet, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfSetToListOfDouble != nil {
+		fh = stream.FieldHeader{ID: 9, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_Set_I32_mapType_List_Double_Encode(v.MapOfSetToListOfDouble, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ContainersOfContainers
 // struct.
 func (v *ContainersOfContainers) String() string {
@@ -2385,6 +3012,146 @@ func (v *EnumContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_EnumDefault_Encode(val []enums.EnumDefault, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_EnumWithValues_mapType_Encode(val map[enums.EnumWithValues]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_EnumWithDuplicateValues_I32_Encode(val map[enums.EnumWithDuplicateValues]int32, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI32,
+		ValueType: wire.TI32,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = k.Encode(sw)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteInt32(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Decode deserializes a EnumContainers struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a EnumContainers struct could not be generated from the wire
+// representation.
+func (v *EnumContainers) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.ListOfEnums != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_EnumDefault_Encode(v.ListOfEnums, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfEnums != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Set_EnumWithValues_mapType_Encode(v.SetOfEnums, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfEnums != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_EnumWithDuplicateValues_I32_Encode(v.MapOfEnums, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a EnumContainers
 // struct.
 func (v *EnumContainers) String() string {
@@ -2788,6 +3555,97 @@ func (v *ListOfConflictingEnums) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_RecordType_Encode(val []enum_conflict.RecordType, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_RecordType_1_Encode(val []enums.RecordType, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Decode deserializes a ListOfConflictingEnums struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ListOfConflictingEnums struct could not be generated from the wire
+// representation.
+func (v *ListOfConflictingEnums) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _List_RecordType_Encode(v.Records, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TList}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _List_RecordType_1_Encode(v.OtherRecords, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ListOfConflictingEnums
 // struct.
 func (v *ListOfConflictingEnums) String() string {
@@ -3119,6 +3977,97 @@ func (v *ListOfConflictingUUIDs) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_UUID_Encode(val []*typedefs.UUID, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_UUID_1_Encode(val []uuid_conflict.UUID, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Decode deserializes a ListOfConflictingUUIDs struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ListOfConflictingUUIDs struct could not be generated from the wire
+// representation.
+func (v *ListOfConflictingUUIDs) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _List_UUID_Encode(v.Uuids, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TList}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _List_UUID_1_Encode(v.OtherUUIDs, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ListOfConflictingUUIDs
 // struct.
 func (v *ListOfConflictingUUIDs) String() string {
@@ -3322,6 +4271,40 @@ func (v *ListOfOptionalPrimitives) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a ListOfOptionalPrimitives struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ListOfOptionalPrimitives struct could not be generated from the wire
+// representation.
+func (v *ListOfOptionalPrimitives) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.ListOfStrings != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_String_Encode(v.ListOfStrings, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ListOfOptionalPrimitives
 // struct.
 func (v *ListOfOptionalPrimitives) String() string {
@@ -3460,6 +4443,38 @@ func (v *ListOfRequiredPrimitives) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a ListOfRequiredPrimitives struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ListOfRequiredPrimitives struct could not be generated from the wire
+// representation.
+func (v *ListOfRequiredPrimitives) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _List_String_Encode(v.ListOfStrings, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ListOfRequiredPrimitives
@@ -3757,6 +4772,118 @@ func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _Map_Binary_String_Encode(val []struct {
+	Key   []byte
+	Value string
+}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		err = sw.WriteBinary(key)
+		if err != nil {
+			return err
+		}
+		value := v.Value
+		err = sw.WriteString(value)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Map_String_Binary_Encode(val map[string][]byte, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteString(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteBinary(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Decode deserializes a MapOfBinaryAndString struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a MapOfBinaryAndString struct could not be generated from the wire
+// representation.
+func (v *MapOfBinaryAndString) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.BinaryToString != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_Binary_String_Encode(v.BinaryToString, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.StringToBinary != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_String_Binary_Encode(v.StringToBinary, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a MapOfBinaryAndString
@@ -4360,6 +5487,243 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_Binary_Encode(val [][]byte, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = sw.WriteBinary(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_I64_Encode(val []int64, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TI64,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = sw.WriteInt64(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_Byte_mapType_Encode(val map[int8]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TI8,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		err = sw.WriteInt8(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_I32_String_Encode(val map[int32]string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI32,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteInt32(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Map_String_Bool_Encode(val map[string]bool, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBool,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteString(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteBool(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Decode deserializes a PrimitiveContainers struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveContainers struct could not be generated from the wire
+// representation.
+func (v *PrimitiveContainers) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.ListOfBinary != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_Binary_Encode(v.ListOfBinary, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ListOfInts != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_I64_Encode(v.ListOfInts, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfStrings != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Set_String_mapType_Encode(v.SetOfStrings, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfBytes != nil {
+		fh = stream.FieldHeader{ID: 4, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Set_Byte_mapType_Encode(v.SetOfBytes, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfIntToString != nil {
+		fh = stream.FieldHeader{ID: 5, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_I32_String_Encode(v.MapOfIntToString, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfStringToBool != nil {
+		fh = stream.FieldHeader{ID: 6, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_String_Bool_Encode(v.MapOfStringToBool, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a PrimitiveContainers
 // struct.
 func (v *PrimitiveContainers) String() string {
@@ -4878,6 +6242,99 @@ func (v *PrimitiveContainersRequired) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _Map_I64_Double_Encode(val map[int64]float64, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI64,
+		ValueType: wire.TDouble,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteInt64(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteDouble(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Decode deserializes a PrimitiveContainersRequired struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveContainersRequired struct could not be generated from the wire
+// representation.
+func (v *PrimitiveContainersRequired) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _List_String_Encode(v.ListOfStrings, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.SetOfInts == nil {
+		return errors.New("field SetOfInts of PrimitiveContainersRequired is required")
+	}
+	fh = stream.FieldHeader{ID: 2, Type: wire.TSet}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _Set_I32_mapType_Encode(v.SetOfInts, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.MapOfIntsToDoubles == nil {
+		return errors.New("field MapOfIntsToDoubles of PrimitiveContainersRequired is required")
+	}
+	fh = stream.FieldHeader{ID: 3, Type: wire.TMap}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _Map_I64_Double_Encode(v.MapOfIntsToDoubles, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a PrimitiveContainersRequired

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -7,14 +7,16 @@ import (
 	bytes "bytes"
 	json "encoding/json"
 	fmt "fmt"
-	multierr "go.uber.org/multierr"
-	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
-	thriftreflect "go.uber.org/thriftrw/thriftreflect"
-	wire "go.uber.org/thriftrw/wire"
-	zapcore "go.uber.org/zap/zapcore"
 	math "math"
 	strconv "strconv"
 	strings "strings"
+
+	multierr "go.uber.org/multierr"
+	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	stream "go.uber.org/thriftrw/protocol/stream"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
 )
 
 const DefaultOtherRecordType enums.RecordType = enums.RecordTypeName
@@ -93,6 +95,19 @@ func (v RecordType) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v RecordType) Ptr() *RecordType {
 	return &v
+}
+
+// Encode encodes RecordType directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v RecordType
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v RecordType) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates RecordType into a Thrift-level intermediate
@@ -331,6 +346,67 @@ func (v *Records) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a Records struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Records struct could not be generated from the wire
+// representation.
+func (v *Records) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	vRecordType := v.RecordType
+	if vRecordType == nil {
+		vRecordType = _RecordType_ptr(DefaultRecordType)
+	}
+	{
+		fh = stream.FieldHeader{ID: 1, Type: wire.TI32}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := vRecordType.Encode(sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOtherRecordType := v.OtherRecordType
+	if vOtherRecordType == nil {
+		vOtherRecordType = _RecordType_1_ptr(DefaultOtherRecordType)
+	}
+	{
+		fh = stream.FieldHeader{ID: 2, Type: wire.TI32}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := vOtherRecordType.Encode(sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Records

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -7,13 +7,15 @@ import (
 	bytes "bytes"
 	json "encoding/json"
 	fmt "fmt"
-	multierr "go.uber.org/multierr"
-	thriftreflect "go.uber.org/thriftrw/thriftreflect"
-	wire "go.uber.org/thriftrw/wire"
-	zapcore "go.uber.org/zap/zapcore"
 	math "math"
 	strconv "strconv"
 	strings "strings"
+
+	multierr "go.uber.org/multierr"
+	stream "go.uber.org/thriftrw/protocol/stream"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
+	wire "go.uber.org/thriftrw/wire"
+	zapcore "go.uber.org/zap/zapcore"
 )
 
 type EmptyEnum int32
@@ -59,6 +61,19 @@ func (v EmptyEnum) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v EmptyEnum) Ptr() *EmptyEnum {
 	return &v
+}
+
+// Encode encodes EmptyEnum directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EmptyEnum
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v EmptyEnum) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates EmptyEnum into a Thrift-level intermediate
@@ -227,6 +242,19 @@ func (v EnumDefault) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v EnumDefault) Ptr() *EnumDefault {
 	return &v
+}
+
+// Encode encodes EnumDefault directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumDefault
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v EnumDefault) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates EnumDefault into a Thrift-level intermediate
@@ -467,6 +495,19 @@ func (v EnumWithDuplicateName) Ptr() *EnumWithDuplicateName {
 	return &v
 }
 
+// Encode encodes EnumWithDuplicateName directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumWithDuplicateName
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v EnumWithDuplicateName) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
+}
+
 // ToWire translates EnumWithDuplicateName into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -669,6 +710,19 @@ func (v EnumWithDuplicateValues) MarshalLogObject(enc zapcore.ObjectEncoder) err
 // Ptr returns a pointer to this enum value.
 func (v EnumWithDuplicateValues) Ptr() *EnumWithDuplicateValues {
 	return &v
+}
+
+// Encode encodes EnumWithDuplicateValues directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumWithDuplicateValues
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v EnumWithDuplicateValues) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates EnumWithDuplicateValues into a Thrift-level intermediate
@@ -878,6 +932,19 @@ func (v EnumWithLabel) Ptr() *EnumWithLabel {
 	return &v
 }
 
+// Encode encodes EnumWithLabel directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumWithLabel
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v EnumWithLabel) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
+}
+
 // ToWire translates EnumWithLabel into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1074,6 +1141,19 @@ func (v EnumWithValues) Ptr() *EnumWithValues {
 	return &v
 }
 
+// Encode encodes EnumWithValues directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumWithValues
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v EnumWithValues) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
+}
+
 // ToWire translates EnumWithValues into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1266,6 +1346,19 @@ func (v RecordType) Ptr() *RecordType {
 	return &v
 }
 
+// Encode encodes RecordType directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v RecordType
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v RecordType) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
+}
+
 // ToWire translates RecordType into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1439,6 +1532,19 @@ func (v RecordTypeValues) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v RecordTypeValues) Ptr() *RecordTypeValues {
 	return &v
+}
+
+// Encode encodes RecordTypeValues directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v RecordTypeValues
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v RecordTypeValues) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates RecordTypeValues into a Thrift-level intermediate
@@ -1621,6 +1727,40 @@ func (v *StructWithOptionalEnum) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a StructWithOptionalEnum struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a StructWithOptionalEnum struct could not be generated from the wire
+// representation.
+func (v *StructWithOptionalEnum) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.E != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TI32}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.E.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a StructWithOptionalEnum
 // struct.
 func (v *StructWithOptionalEnum) String() string {
@@ -1773,6 +1913,19 @@ func (v LowerCaseEnum) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v LowerCaseEnum) Ptr() *LowerCaseEnum {
 	return &v
+}
+
+// Encode encodes LowerCaseEnum directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v LowerCaseEnum
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v LowerCaseEnum) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates LowerCaseEnum into a Thrift-level intermediate

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -6,10 +6,12 @@ package exceptions
 import (
 	errors "errors"
 	fmt "fmt"
+	strings "strings"
+
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 // Raised when something doesn't exist.
@@ -110,6 +112,53 @@ func (v *DoesNotExistException) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a DoesNotExistException struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DoesNotExistException struct could not be generated from the wire
+// representation.
+func (v *DoesNotExistException) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Key)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Error2 != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.Error2))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a DoesNotExistException
@@ -307,6 +356,53 @@ func (v *DoesNotExistException2) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a DoesNotExistException2 struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DoesNotExistException2 struct could not be generated from the wire
+// representation.
+func (v *DoesNotExistException2) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Key)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Error2 != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.Error2))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a DoesNotExistException2
 // struct.
 func (v *DoesNotExistException2) String() string {
@@ -445,6 +541,21 @@ func (v *EmptyException) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a EmptyException struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a EmptyException struct could not be generated from the wire
+// representation.
+func (v *EmptyException) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a EmptyException

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -6,12 +6,14 @@ package hyphenated_file
 import (
 	errors "errors"
 	fmt "fmt"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
 	non_hyphenated "go.uber.org/thriftrw/gen/internal/tests/non_hyphenated"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 type DocumentStruct struct {
@@ -100,6 +102,41 @@ func (v *DocumentStruct) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a DocumentStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DocumentStruct struct could not be generated from the wire
+// representation.
+func (v *DocumentStruct) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Second == nil {
+		return errors.New("field Second of DocumentStruct is required")
+	}
+	fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.Second.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a DocumentStruct

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -6,12 +6,14 @@ package hyphenated_file
 import (
 	errors "errors"
 	fmt "fmt"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
 	non_hyphenated "go.uber.org/thriftrw/gen/internal/tests/non_hyphenated"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 type DocumentStructure struct {
@@ -100,6 +102,41 @@ func (v *DocumentStructure) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a DocumentStructure struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DocumentStructure struct could not be generated from the wire
+// representation.
+func (v *DocumentStructure) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.R2 == nil {
+		return errors.New("field R2 of DocumentStructure is required")
+	}
+	fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.R2.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a DocumentStructure

--- a/gen/internal/tests/non_hyphenated/non_hyphenated.go
+++ b/gen/internal/tests/non_hyphenated/non_hyphenated.go
@@ -5,10 +5,12 @@ package non_hyphenated
 
 import (
 	fmt "fmt"
+	strings "strings"
+
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 type First struct {
@@ -63,6 +65,21 @@ func (v *First) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a First struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a First struct could not be generated from the wire
+// representation.
+func (v *First) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a First
@@ -153,6 +170,21 @@ func (v *Second) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a Second struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Second struct could not be generated from the wire
+// representation.
+func (v *Second) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Second

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -8,11 +8,13 @@ import (
 	json "encoding/json"
 	errors "errors"
 	fmt "fmt"
-	thriftreflect "go.uber.org/thriftrw/thriftreflect"
-	wire "go.uber.org/thriftrw/wire"
 	math "math"
 	strconv "strconv"
 	strings "strings"
+
+	stream "go.uber.org/thriftrw/protocol/stream"
+	thriftreflect "go.uber.org/thriftrw/thriftreflect"
+	wire "go.uber.org/thriftrw/wire"
 )
 
 type EnumDefault int32
@@ -79,6 +81,19 @@ func (v EnumDefault) MarshalText() ([]byte, error) {
 // Ptr returns a pointer to this enum value.
 func (v EnumDefault) Ptr() *EnumDefault {
 	return &v
+}
+
+// Encode encodes EnumDefault directly to the wire.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumDefault
+//   if err := v.Encode(sWriter); err != nil {
+//     return err
+//   }
+//   return nil
+func (v EnumDefault) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates EnumDefault into a Thrift-level intermediate
@@ -629,6 +644,253 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_String_Encode(val []string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_I32_mapType_Encode(val map[int32]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		err = sw.WriteInt32(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_I64_Double_Encode(val map[int64]float64, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI64,
+		ValueType: wire.TDouble,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteInt64(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteDouble(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Decode deserializes a PrimitiveRequiredStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveRequiredStruct struct could not be generated from the wire
+// representation.
+func (v *PrimitiveRequiredStruct) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBool}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteBool(v.BoolField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TI8}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt8(v.ByteField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 3, Type: wire.TI16}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt16(v.Int16Field)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 4, Type: wire.TI32}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt32(v.Int32Field)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 5, Type: wire.TI64}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt64(v.Int64Field)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 6, Type: wire.TDouble}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteDouble(v.DoubleField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 7, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.StringField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.BinaryField == nil {
+		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
+	}
+	fh = stream.FieldHeader{ID: 8, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteBinary(v.BinaryField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 9, Type: wire.TList}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _List_String_Encode(v.ListOfStrings, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.SetOfInts == nil {
+		return errors.New("field SetOfInts of PrimitiveRequiredStruct is required")
+	}
+	fh = stream.FieldHeader{ID: 10, Type: wire.TSet}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _Set_I32_mapType_Encode(v.SetOfInts, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.MapOfIntsToDoubles == nil {
+		return errors.New("field MapOfIntsToDoubles of PrimitiveRequiredStruct is required")
+	}
+	fh = stream.FieldHeader{ID: 11, Type: wire.TMap}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _Map_I64_Double_Encode(v.MapOfIntsToDoubles, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a PrimitiveRequiredStruct
 // struct.
 func (v *PrimitiveRequiredStruct) String() string {
@@ -892,6 +1154,11 @@ func (v *Primitives) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v *Primitives) Encode(sw stream.Writer) error {
+	x := (*PrimitiveRequiredStruct)(v)
+	return x.Encode(sw)
+}
+
 // FromWire deserializes Primitives from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -919,6 +1186,11 @@ func (v StringList) ToWire() (wire.Value, error) {
 func (v StringList) String() string {
 	x := ([]string)(v)
 	return fmt.Sprint(x)
+}
+
+func (v StringList) Encode(sw stream.Writer) error {
+	x := ([]string)(v)
+	return _List_String_Encode(x, sw)
 }
 
 // FromWire deserializes StringList from its Thrift-level
@@ -970,6 +1242,35 @@ func (_Map_String_String_MapItemList) ValueType() wire.Type {
 }
 
 func (_Map_String_String_MapItemList) Close() {}
+
+func _Map_String_String_Encode(val map[string]string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteString(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
 
 func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 	if m.KeyType() != wire.TBinary {
@@ -1030,6 +1331,11 @@ func (v StringMap) ToWire() (wire.Value, error) {
 func (v StringMap) String() string {
 	x := (map[string]string)(v)
 	return fmt.Sprint(x)
+}
+
+func (v StringMap) Encode(sw stream.Writer) error {
+	x := (map[string]string)(v)
+	return _Map_String_String_Encode(x, sw)
 }
 
 // FromWire deserializes StringMap from its Thrift-level

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -8,13 +8,15 @@ import (
 	base64 "encoding/base64"
 	errors "errors"
 	fmt "fmt"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
 	exceptions "go.uber.org/thriftrw/gen/internal/tests/exceptions"
 	unions "go.uber.org/thriftrw/gen/internal/tests/unions"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 type ConflictingNamesSetValueArgs struct {
@@ -117,6 +119,54 @@ func (v *ConflictingNamesSetValueArgs) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a ConflictingNamesSetValueArgs struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ConflictingNamesSetValueArgs struct could not be generated from the wire
+// representation.
+func (v *ConflictingNamesSetValueArgs) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Key)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Value == nil {
+		return errors.New("field Value of ConflictingNamesSetValueArgs is required")
+	}
+	fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteBinary(v.Value)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ConflictingNamesSetValueArgs
@@ -267,6 +317,40 @@ func (v *InternalError) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a InternalError struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a InternalError struct could not be generated from the wire
+// representation.
+func (v *InternalError) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Message != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.Message))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a InternalError
 // struct.
 func (v *InternalError) String() string {
@@ -369,6 +453,11 @@ func (v Key) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v Key) Encode(sw stream.Writer) error {
+	x := (string)(v)
+	return sw.WriteString(x)
+}
+
 // FromWire deserializes Key from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -454,6 +543,21 @@ func (v *Cache_Clear_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a Cache_Clear_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Cache_Clear_Args struct could not be generated from the wire
+// representation.
+func (v *Cache_Clear_Args) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Cache_Clear_Args
@@ -601,6 +705,40 @@ func (v *Cache_ClearAfter_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a Cache_ClearAfter_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Cache_ClearAfter_Args struct could not be generated from the wire
+// representation.
+func (v *Cache_ClearAfter_Args) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.DurationMS != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TI64}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteInt64(*(v.DurationMS))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Cache_ClearAfter_Args
@@ -793,6 +931,40 @@ func (v *ConflictingNames_SetValue_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a ConflictingNames_SetValue_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ConflictingNames_SetValue_Args struct could not be generated from the wire
+// representation.
+func (v *ConflictingNames_SetValue_Args) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Request != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Request.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ConflictingNames_SetValue_Args
@@ -1003,6 +1175,21 @@ func (v *ConflictingNames_SetValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a ConflictingNames_SetValue_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ConflictingNames_SetValue_Result struct could not be generated from the wire
+// representation.
+func (v *ConflictingNames_SetValue_Result) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ConflictingNames_SetValue_Result
 // struct.
 func (v *ConflictingNames_SetValue_Result) String() string {
@@ -1138,6 +1325,40 @@ func (v *KeyValue_DeleteValue_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a KeyValue_DeleteValue_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_DeleteValue_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_DeleteValue_Args) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Key != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Key.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_DeleteValue_Args
@@ -1449,6 +1670,59 @@ func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a KeyValue_DeleteValue_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_DeleteValue_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_DeleteValue_Result) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.DoesNotExist != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.DoesNotExist.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.InternalError != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.InternalError.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if i > 1 {
+		return fmt.Errorf("KeyValue_DeleteValue_Result should have at most one field: got %v fields", i)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_DeleteValue_Result
 // struct.
 func (v *KeyValue_DeleteValue_Result) String() string {
@@ -1670,6 +1944,63 @@ func (v *KeyValue_GetManyValues_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _List_Key_Encode(val []Key, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Decode deserializes a KeyValue_GetManyValues_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_GetManyValues_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_GetManyValues_Args) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Range != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_Key_Encode(v.Range, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_GetManyValues_Args
@@ -2035,6 +2366,82 @@ func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_ArbitraryValue_Encode(val []*unions.ArbitraryValue, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Decode deserializes a KeyValue_GetManyValues_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_GetManyValues_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_GetManyValues_Result) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Success != nil {
+		fh = stream.FieldHeader{ID: 0, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_ArbitraryValue_Encode(v.Success, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.DoesNotExist != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.DoesNotExist.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if i != 1 {
+		return fmt.Errorf("KeyValue_GetManyValues_Result should have exactly one field: got %v fields", i)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_GetManyValues_Result
 // struct.
 func (v *KeyValue_GetManyValues_Result) String() string {
@@ -2240,6 +2647,40 @@ func (v *KeyValue_GetValue_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a KeyValue_GetValue_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_GetValue_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_GetValue_Args) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Key != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Key.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_GetValue_Args
@@ -2526,6 +2967,59 @@ func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a KeyValue_GetValue_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_GetValue_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_GetValue_Result) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Success != nil {
+		fh = stream.FieldHeader{ID: 0, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Success.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.DoesNotExist != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.DoesNotExist.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if i != 1 {
+		return fmt.Errorf("KeyValue_GetValue_Result should have exactly one field: got %v fields", i)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_GetValue_Result
 // struct.
 func (v *KeyValue_GetValue_Result) String() string {
@@ -2722,6 +3216,55 @@ func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a KeyValue_SetValue_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_SetValue_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_SetValue_Args) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Key != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Key.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Value != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Value.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_SetValue_Args
@@ -2960,6 +3503,21 @@ func (v *KeyValue_SetValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a KeyValue_SetValue_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_SetValue_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_SetValue_Result) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_SetValue_Result
 // struct.
 func (v *KeyValue_SetValue_Result) String() string {
@@ -3118,6 +3676,54 @@ func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a KeyValue_SetValueV2_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_SetValueV2_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_SetValueV2_Args) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.Key.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Value == nil {
+		return errors.New("field Value of KeyValue_SetValueV2_Args is required")
+	}
+	fh = stream.FieldHeader{ID: 2, Type: wire.TStruct}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.Value.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_SetValueV2_Args
@@ -3341,6 +3947,21 @@ func (v *KeyValue_SetValueV2_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a KeyValue_SetValueV2_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_SetValueV2_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_SetValueV2_Result) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_SetValueV2_Result
 // struct.
 func (v *KeyValue_SetValueV2_Result) String() string {
@@ -3447,6 +4068,21 @@ func (v *KeyValue_Size_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a KeyValue_Size_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_Size_Args struct could not be generated from the wire
+// representation.
+func (v *KeyValue_Size_Args) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_Size_Args
@@ -3670,6 +4306,44 @@ func (v *KeyValue_Size_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a KeyValue_Size_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a KeyValue_Size_Result struct could not be generated from the wire
+// representation.
+func (v *KeyValue_Size_Result) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Success != nil {
+		fh = stream.FieldHeader{ID: 0, Type: wire.TI64}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteInt64(*(v.Success))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if i != 1 {
+		return fmt.Errorf("KeyValue_Size_Result should have exactly one field: got %v fields", i)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_Size_Result
 // struct.
 func (v *KeyValue_Size_Result) String() string {
@@ -3801,6 +4475,21 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) FromWire(w wire.Va
 	}
 
 	return nil
+}
+
+// Decode deserializes a NonStandardServiceName_NonStandardFunctionName_Args struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a NonStandardServiceName_NonStandardFunctionName_Args struct could not be generated from the wire
+// representation.
+func (v *NonStandardServiceName_NonStandardFunctionName_Args) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a NonStandardServiceName_NonStandardFunctionName_Args
@@ -3978,6 +4667,21 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) FromWire(w wire.
 	}
 
 	return nil
+}
+
+// Decode deserializes a NonStandardServiceName_NonStandardFunctionName_Result struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a NonStandardServiceName_NonStandardFunctionName_Result struct could not be generated from the wire
+// representation.
+func (v *NonStandardServiceName_NonStandardFunctionName_Result) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a NonStandardServiceName_NonStandardFunctionName_Result

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -6,11 +6,13 @@ package set_to_slice
 import (
 	errors "errors"
 	fmt "fmt"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 var ConstListStringList [][]string = [][]string{
@@ -57,6 +59,11 @@ func (v AnotherStringList) ToWire() (wire.Value, error) {
 func (v AnotherStringList) String() string {
 	x := (MyStringList)(v)
 	return fmt.Sprint(x)
+}
+
+func (v AnotherStringList) Encode(sw stream.Writer) error {
+	x := (MyStringList)(v)
+	return x.Encode(sw)
 }
 
 // FromWire deserializes AnotherStringList from its Thrift-level
@@ -557,6 +564,277 @@ func (v *Bar) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _Set_I32_sliceType_Encode(val []int32, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		err = sw.WriteInt32(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Set_String_sliceType_Encode(val []string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Set_Foo_sliceType_Encode(val []*Foo, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Set_Set_String_sliceType_sliceType_Encode(val [][]string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TSet,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		err = _Set_String_sliceType_Encode(v, sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+// Decode deserializes a Bar struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Bar struct could not be generated from the wire
+// representation.
+func (v *Bar) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.RequiredInt32ListField == nil {
+		return errors.New("field RequiredInt32ListField of Bar is required")
+	}
+	fh = stream.FieldHeader{ID: 1, Type: wire.TSet}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _Set_I32_sliceType_Encode(v.RequiredInt32ListField, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.OptionalStringListField != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Set_String_sliceType_Encode(v.OptionalStringListField, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.RequiredTypedefStringListField == nil {
+		return errors.New("field RequiredTypedefStringListField of Bar is required")
+	}
+	fh = stream.FieldHeader{ID: 3, Type: wire.TSet}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.RequiredTypedefStringListField.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.OptionalTypedefStringListField != nil {
+		fh = stream.FieldHeader{ID: 4, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.OptionalTypedefStringListField.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.RequiredFooListField == nil {
+		return errors.New("field RequiredFooListField of Bar is required")
+	}
+	fh = stream.FieldHeader{ID: 5, Type: wire.TSet}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _Set_Foo_sliceType_Encode(v.RequiredFooListField, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.OptionalFooListField != nil {
+		fh = stream.FieldHeader{ID: 6, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Set_Foo_sliceType_Encode(v.OptionalFooListField, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.RequiredTypedefFooListField == nil {
+		return errors.New("field RequiredTypedefFooListField of Bar is required")
+	}
+	fh = stream.FieldHeader{ID: 7, Type: wire.TSet}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.RequiredTypedefFooListField.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.OptionalTypedefFooListField != nil {
+		fh = stream.FieldHeader{ID: 8, Type: wire.TSet}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.OptionalTypedefFooListField.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.RequiredStringListListField == nil {
+		return errors.New("field RequiredStringListListField of Bar is required")
+	}
+	fh = stream.FieldHeader{ID: 9, Type: wire.TSet}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _Set_Set_String_sliceType_sliceType_Encode(v.RequiredStringListListField, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.RequiredTypedefStringListListField == nil {
+		return errors.New("field RequiredTypedefStringListListField of Bar is required")
+	}
+	fh = stream.FieldHeader{ID: 10, Type: wire.TSet}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.RequiredTypedefStringListListField.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Bar
 // struct.
 func (v *Bar) String() string {
@@ -1009,6 +1287,38 @@ func (v *Foo) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a Foo struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Foo struct could not be generated from the wire
+// representation.
+func (v *Foo) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.StringField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Foo
 // struct.
 func (v *Foo) String() string {
@@ -1076,6 +1386,11 @@ func (v FooList) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v FooList) Encode(sw stream.Writer) error {
+	x := ([]*Foo)(v)
+	return _Set_Foo_sliceType_Encode(x, sw)
+}
+
 // FromWire deserializes FooList from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1109,6 +1424,11 @@ func (v MyStringList) ToWire() (wire.Value, error) {
 func (v MyStringList) String() string {
 	x := (StringList)(v)
 	return fmt.Sprint(x)
+}
+
+func (v MyStringList) Encode(sw stream.Writer) error {
+	x := (StringList)(v)
+	return x.Encode(sw)
 }
 
 // FromWire deserializes MyStringList from its Thrift-level
@@ -1146,6 +1466,11 @@ func (v StringList) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v StringList) Encode(sw stream.Writer) error {
+	x := ([]string)(v)
+	return _Set_String_sliceType_Encode(x, sw)
+}
+
 // FromWire deserializes StringList from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1179,6 +1504,11 @@ func (v StringListList) ToWire() (wire.Value, error) {
 func (v StringListList) String() string {
 	x := ([][]string)(v)
 	return fmt.Sprint(x)
+}
+
+func (v StringListList) Encode(sw stream.Writer) error {
+	x := ([][]string)(v)
+	return _Set_Set_String_sliceType_sliceType_Encode(x, sw)
 }
 
 // FromWire deserializes StringListList from its Thrift-level
@@ -1225,6 +1555,30 @@ func (_Set_String_mapType_ValueList) ValueType() wire.Type {
 }
 
 func (_Set_String_mapType_ValueList) Close() {}
+
+func _Set_String_mapType_Encode(val map[string]struct{}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
 
 func _Set_String_mapType_Read(s wire.ValueList) (map[string]struct{}, error) {
 	if s.ValueType() != wire.TBinary {
@@ -1284,6 +1638,11 @@ func (v StringSet) ToWire() (wire.Value, error) {
 func (v StringSet) String() string {
 	x := (map[string]struct{})(v)
 	return fmt.Sprint(x)
+}
+
+func (v StringSet) Encode(sw stream.Writer) error {
+	x := (map[string]struct{})(v)
+	return _Set_String_mapType_Encode(x, sw)
 }
 
 // FromWire deserializes StringSet from its Thrift-level

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -8,13 +8,15 @@ import (
 	base64 "encoding/base64"
 	errors "errors"
 	fmt "fmt"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
 	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	ptr "go.uber.org/thriftrw/ptr"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 type ContactInfo struct {
@@ -94,6 +96,38 @@ func (v *ContactInfo) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a ContactInfo struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ContactInfo struct could not be generated from the wire
+// representation.
+func (v *ContactInfo) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.EmailAddress)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ContactInfo
@@ -725,6 +759,348 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_String_Encode(val []string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_Double_Encode(val []float64, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TDouble,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = sw.WriteDouble(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Decode deserializes a DefaultsStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DefaultsStruct struct could not be generated from the wire
+// representation.
+func (v *DefaultsStruct) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	vRequiredPrimitive := v.RequiredPrimitive
+	if vRequiredPrimitive == nil {
+		vRequiredPrimitive = ptr.Int32(100)
+	}
+	{
+		fh = stream.FieldHeader{ID: 1, Type: wire.TI32}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(*(vRequiredPrimitive)); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalPrimitive := v.OptionalPrimitive
+	if vOptionalPrimitive == nil {
+		vOptionalPrimitive = ptr.Int32(200)
+	}
+	{
+		fh = stream.FieldHeader{ID: 2, Type: wire.TI32}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(*(vOptionalPrimitive)); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredEnum := v.RequiredEnum
+	if vRequiredEnum == nil {
+		vRequiredEnum = _EnumDefault_ptr(enums.EnumDefaultBar)
+	}
+	{
+		fh = stream.FieldHeader{ID: 3, Type: wire.TI32}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := vRequiredEnum.Encode(sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalEnum := v.OptionalEnum
+	if vOptionalEnum == nil {
+		vOptionalEnum = _EnumDefault_ptr(enums.EnumDefaultBaz)
+	}
+	{
+		fh = stream.FieldHeader{ID: 4, Type: wire.TI32}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := vOptionalEnum.Encode(sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredList := v.RequiredList
+	if vRequiredList == nil {
+		vRequiredList = []string{
+			"hello",
+			"world",
+		}
+	}
+	{
+		fh = stream.FieldHeader{ID: 5, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := _List_String_Encode(vRequiredList, sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalList := v.OptionalList
+	if vOptionalList == nil {
+		vOptionalList = []float64{
+			1,
+			2,
+			3,
+		}
+	}
+	{
+		fh = stream.FieldHeader{ID: 6, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := _List_Double_Encode(vOptionalList, sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredStruct := v.RequiredStruct
+	if vRequiredStruct == nil {
+		vRequiredStruct = &Frame{
+			Size: &Size{
+				Height: 200,
+				Width:  100,
+			},
+			TopLeft: &Point{
+				X: 1,
+				Y: 2,
+			},
+		}
+	}
+	{
+		fh = stream.FieldHeader{ID: 7, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := vRequiredStruct.Encode(sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalStruct := v.OptionalStruct
+	if vOptionalStruct == nil {
+		vOptionalStruct = &Edge{
+			EndPoint: &Point{
+				X: 3,
+				Y: 4,
+			},
+			StartPoint: &Point{
+				X: 1,
+				Y: 2,
+			},
+		}
+	}
+	{
+		fh = stream.FieldHeader{ID: 8, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := vOptionalStruct.Encode(sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredBoolDefaultTrue := v.RequiredBoolDefaultTrue
+	if vRequiredBoolDefaultTrue == nil {
+		vRequiredBoolDefaultTrue = ptr.Bool(true)
+	}
+	{
+		fh = stream.FieldHeader{ID: 9, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(vRequiredBoolDefaultTrue)); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalBoolDefaultTrue := v.OptionalBoolDefaultTrue
+	if vOptionalBoolDefaultTrue == nil {
+		vOptionalBoolDefaultTrue = ptr.Bool(true)
+	}
+	{
+		fh = stream.FieldHeader{ID: 10, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(vOptionalBoolDefaultTrue)); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredBoolDefaultFalse := v.RequiredBoolDefaultFalse
+	if vRequiredBoolDefaultFalse == nil {
+		vRequiredBoolDefaultFalse = ptr.Bool(false)
+	}
+	{
+		fh = stream.FieldHeader{ID: 11, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(vRequiredBoolDefaultFalse)); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalBoolDefaultFalse := v.OptionalBoolDefaultFalse
+	if vOptionalBoolDefaultFalse == nil {
+		vOptionalBoolDefaultFalse = ptr.Bool(false)
+	}
+	{
+		fh = stream.FieldHeader{ID: 12, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(vOptionalBoolDefaultFalse)); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a DefaultsStruct
 // struct.
 func (v *DefaultsStruct) String() string {
@@ -1279,6 +1655,57 @@ func (v *Edge) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a Edge struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Edge struct could not be generated from the wire
+// representation.
+func (v *Edge) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.StartPoint == nil {
+		return errors.New("field StartPoint of Edge is required")
+	}
+	fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.StartPoint.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.EndPoint == nil {
+		return errors.New("field EndPoint of Edge is required")
+	}
+	fh = stream.FieldHeader{ID: 2, Type: wire.TStruct}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.EndPoint.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Edge
 // struct.
 func (v *Edge) String() string {
@@ -1407,6 +1834,21 @@ func (v *EmptyStruct) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a EmptyStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a EmptyStruct struct could not be generated from the wire
+// representation.
+func (v *EmptyStruct) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a EmptyStruct
@@ -1554,6 +1996,57 @@ func (v *Frame) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a Frame struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Frame struct could not be generated from the wire
+// representation.
+func (v *Frame) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.TopLeft == nil {
+		return errors.New("field TopLeft of Frame is required")
+	}
+	fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.TopLeft.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Size == nil {
+		return errors.New("field Size of Frame is required")
+	}
+	fh = stream.FieldHeader{ID: 2, Type: wire.TStruct}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.Size.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Frame
@@ -1812,6 +2305,107 @@ func (v *GoTags) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a GoTags struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a GoTags struct could not be generated from the wire
+// representation.
+func (v *GoTags) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Foo)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Bar != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.Bar))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	fh = stream.FieldHeader{ID: 3, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.FooBar)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 4, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.FooBarWithSpace)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.FooBarWithOmitEmpty != nil {
+		fh = stream.FieldHeader{ID: 5, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.FooBarWithOmitEmpty))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	fh = stream.FieldHeader{ID: 6, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.FooBarWithRequired)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a GoTags
@@ -2100,6 +2694,61 @@ func (v *Graph) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_Edge_Encode(val []*Edge, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Decode deserializes a Graph struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Graph struct could not be generated from the wire
+// representation.
+func (v *Graph) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TList}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = _List_Edge_Encode(v.Edges, sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Graph
 // struct.
 func (v *Graph) String() string {
@@ -2196,6 +2845,11 @@ func (v *List) ToWire() (wire.Value, error) {
 func (v *List) String() string {
 	x := (*Node)(v)
 	return fmt.Sprint(x)
+}
+
+func (v *List) Encode(sw stream.Writer) error {
+	x := (*Node)(v)
+	return x.Encode(sw)
 }
 
 // FromWire deserializes List from its Thrift-level
@@ -2317,6 +2971,53 @@ func (v *Node) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a Node struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Node struct could not be generated from the wire
+// representation.
+func (v *Node) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TI32}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt32(v.Value)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Tail != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Tail.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Node
@@ -2658,6 +3359,174 @@ func (v *NotOmitEmpty) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _Map_String_String_Encode(val map[string]string, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteString(k)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteString(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Decode deserializes a NotOmitEmpty struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a NotOmitEmpty struct could not be generated from the wire
+// representation.
+func (v *NotOmitEmpty) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.NotOmitEmptyString != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.NotOmitEmptyString))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyInt != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.NotOmitEmptyInt))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyBool != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.NotOmitEmptyBool))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyList != nil {
+		fh = stream.FieldHeader{ID: 4, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_String_Encode(v.NotOmitEmptyList, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyMap != nil {
+		fh = stream.FieldHeader{ID: 5, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_String_String_Encode(v.NotOmitEmptyMap, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyListMixedWithOmitEmpty != nil {
+		fh = stream.FieldHeader{ID: 6, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_String_Encode(v.NotOmitEmptyListMixedWithOmitEmpty, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
+		fh = stream.FieldHeader{ID: 7, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_String_Encode(v.NotOmitEmptyListMixedWithOmitEmptyV2, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.OmitEmptyString != nil {
+		fh = stream.FieldHeader{ID: 8, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.OmitEmptyString))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a NotOmitEmpty
@@ -3024,6 +3893,51 @@ func (v *Omit) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a Omit struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Omit struct could not be generated from the wire
+// representation.
+func (v *Omit) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Serialized)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Hidden)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Omit
 // struct.
 func (v *Omit) String() string {
@@ -3165,6 +4079,40 @@ func (v *PersonalInfo) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a PersonalInfo struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PersonalInfo struct could not be generated from the wire
+// representation.
+func (v *PersonalInfo) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Age != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TI32}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteInt32(*(v.Age))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a PersonalInfo
@@ -3327,6 +4275,51 @@ func (v *Point) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a Point struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Point struct could not be generated from the wire
+// representation.
+func (v *Point) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TDouble}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteDouble(v.X)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TDouble}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteDouble(v.Y)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Point
@@ -3604,6 +4597,145 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a PrimitiveOptionalStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveOptionalStruct struct could not be generated from the wire
+// representation.
+func (v *PrimitiveOptionalStruct) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.BoolField != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteBool(*(v.BoolField))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ByteField != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TI8}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteInt8(*(v.ByteField))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Int16Field != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TI16}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteInt16(*(v.Int16Field))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Int32Field != nil {
+		fh = stream.FieldHeader{ID: 4, Type: wire.TI32}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteInt32(*(v.Int32Field))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Int64Field != nil {
+		fh = stream.FieldHeader{ID: 5, Type: wire.TI64}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteInt64(*(v.Int64Field))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.DoubleField != nil {
+		fh = stream.FieldHeader{ID: 6, Type: wire.TDouble}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteDouble(*(v.DoubleField))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.StringField != nil {
+		fh = stream.FieldHeader{ID: 7, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.StringField))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.BinaryField != nil {
+		fh = stream.FieldHeader{ID: 8, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteBinary(v.BinaryField)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a PrimitiveOptionalStruct
@@ -4113,6 +5245,132 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a PrimitiveRequiredStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a PrimitiveRequiredStruct struct could not be generated from the wire
+// representation.
+func (v *PrimitiveRequiredStruct) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBool}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteBool(v.BoolField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TI8}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt8(v.ByteField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 3, Type: wire.TI16}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt16(v.Int16Field)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 4, Type: wire.TI32}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt32(v.Int32Field)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 5, Type: wire.TI64}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt64(v.Int64Field)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 6, Type: wire.TDouble}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteDouble(v.DoubleField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 7, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.StringField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.BinaryField == nil {
+		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
+	}
+	fh = stream.FieldHeader{ID: 8, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteBinary(v.BinaryField)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a PrimitiveRequiredStruct
 // struct.
 func (v *PrimitiveRequiredStruct) String() string {
@@ -4374,6 +5632,51 @@ func (v *Rename) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a Rename struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Rename struct could not be generated from the wire
+// representation.
+func (v *Rename) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Default)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.CamelCase)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Rename
 // struct.
 func (v *Rename) String() string {
@@ -4541,6 +5844,51 @@ func (v *Size) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a Size struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Size struct could not be generated from the wire
+// representation.
+func (v *Size) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TDouble}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteDouble(v.Width)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TDouble}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteDouble(v.Height)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Size
@@ -4741,6 +6089,85 @@ func (v *StructLabels) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a StructLabels struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a StructLabels struct could not be generated from the wire
+// representation.
+func (v *StructLabels) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.IsRequired != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteBool(*(v.IsRequired))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Foo != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.Foo))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Qux != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.Qux))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Quux != nil {
+		fh = stream.FieldHeader{ID: 4, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.Quux))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a StructLabels
@@ -5004,6 +6431,68 @@ func (v *User) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a User struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a User struct could not be generated from the wire
+// representation.
+func (v *User) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Name)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Contact != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Contact.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Personal != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TStruct}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Personal.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a User
 // struct.
 func (v *User) String() string {
@@ -5143,6 +6632,35 @@ func (_Map_String_User_MapItemList) ValueType() wire.Type {
 
 func (_Map_String_User_MapItemList) Close() {}
 
+func _Map_String_User_Encode(val map[string]*User, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteString(k)
+		if err != nil {
+			return err
+		}
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
 func _User_Read(w wire.Value) (*User, error) {
 	var v User
 	err := v.FromWire(w)
@@ -5219,6 +6737,11 @@ func (v UserMap) ToWire() (wire.Value, error) {
 func (v UserMap) String() string {
 	x := (map[string]*User)(v)
 	return fmt.Sprint(x)
+}
+
+func (v UserMap) Encode(sw stream.Writer) error {
+	x := (map[string]*User)(v)
+	return _Map_String_User_Encode(x, sw)
 }
 
 // FromWire deserializes UserMap from its Thrift-level
@@ -5338,6 +6861,51 @@ func (v *ZapOptOutStruct) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a ZapOptOutStruct struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ZapOptOutStruct struct could not be generated from the wire
+// representation.
+func (v *ZapOptOutStruct) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Name)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteString(v.Optout)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ZapOptOutStruct

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -8,13 +8,15 @@ import (
 	base64 "encoding/base64"
 	errors "errors"
 	fmt "fmt"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
 	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
 	structs "go.uber.org/thriftrw/gen/internal/tests/structs"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 type _Set_Binary_sliceType_ValueList [][]byte
@@ -45,6 +47,30 @@ func (_Set_Binary_sliceType_ValueList) ValueType() wire.Type {
 }
 
 func (_Set_Binary_sliceType_ValueList) Close() {}
+
+func _Set_Binary_sliceType_Encode(val [][]byte, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		err = sw.WriteBinary(v)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
 
 func _Set_Binary_sliceType_Read(s wire.ValueList) ([][]byte, error) {
 	if s.ValueType() != wire.TBinary {
@@ -111,6 +137,11 @@ func (v BinarySet) ToWire() (wire.Value, error) {
 func (v BinarySet) String() string {
 	x := ([][]byte)(v)
 	return fmt.Sprint(x)
+}
+
+func (v BinarySet) Encode(sw stream.Writer) error {
+	x := ([][]byte)(v)
+	return _Set_Binary_sliceType_Encode(x, sw)
 }
 
 // FromWire deserializes BinarySet from its Thrift-level
@@ -235,6 +266,46 @@ func (v *DefaultPrimitiveTypedef) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a DefaultPrimitiveTypedef struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a DefaultPrimitiveTypedef struct could not be generated from the wire
+// representation.
+func (v *DefaultPrimitiveTypedef) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	vState := v.State
+	if vState == nil {
+		vState = _State_ptr("hello")
+	}
+	{
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		if err := vState.Encode(sw); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a DefaultPrimitiveTypedef
 // struct.
 func (v *DefaultPrimitiveTypedef) String() string {
@@ -351,6 +422,40 @@ func (_Map_Edge_Edge_MapItemList) ValueType() wire.Type {
 }
 
 func (_Map_Edge_Edge_MapItemList) Close() {}
+
+func _Map_Edge_Edge_Encode(val []struct {
+	Key   *structs.Edge
+	Value *structs.Edge
+}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TStruct,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		err = key.Encode(sw)
+		if err != nil {
+			return err
+		}
+		value := v.Value
+		err = value.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
 
 func _Edge_Read(w wire.Value) (*structs.Edge, error) {
 	var v structs.Edge
@@ -480,6 +585,14 @@ func (v EdgeMap) String() string {
 		Value *structs.Edge
 	})(v)
 	return fmt.Sprint(x)
+}
+
+func (v EdgeMap) Encode(sw stream.Writer) error {
+	x := ([]struct {
+		Key   *structs.Edge
+		Value *structs.Edge
+	})(v)
+	return _Map_Edge_Edge_Encode(x, sw)
 }
 
 // FromWire deserializes EdgeMap from its Thrift-level
@@ -623,6 +736,56 @@ func (v *Event) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a Event struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Event struct could not be generated from the wire
+// representation.
+func (v *Event) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.UUID == nil {
+		return errors.New("field UUID of Event is required")
+	}
+	fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.UUID.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Time != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TI64}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Time.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Event
 // struct.
 func (v *Event) String() string {
@@ -743,6 +906,29 @@ func (_List_Event_ValueList) ValueType() wire.Type {
 
 func (_List_Event_ValueList) Close() {}
 
+func _List_Event_Encode(val []*Event, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
 func _Event_Read(w wire.Value) (*Event, error) {
 	var v Event
 	err := v.FromWire(w)
@@ -809,6 +995,11 @@ func (v EventGroup) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v EventGroup) Encode(sw stream.Writer) error {
+	x := ([]*Event)(v)
+	return _List_Event_Encode(x, sw)
+}
+
 // FromWire deserializes EventGroup from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -856,6 +1047,30 @@ func (_Set_Frame_sliceType_ValueList) ValueType() wire.Type {
 }
 
 func (_Set_Frame_sliceType_ValueList) Close() {}
+
+func _Set_Frame_sliceType_Encode(val []*structs.Frame, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	sh := stream.SetHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	err = sw.WriteSetBegin(sh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
 
 func _Frame_Read(w wire.Value) (*structs.Frame, error) {
 	var v structs.Frame
@@ -930,6 +1145,11 @@ func (v FrameGroup) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v FrameGroup) Encode(sw stream.Writer) error {
+	x := ([]*structs.Frame)(v)
+	return _Set_Frame_sliceType_Encode(x, sw)
+}
+
 // FromWire deserializes FrameGroup from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -976,6 +1196,11 @@ func (v MyEnum) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v MyEnum) Encode(sw stream.Writer) error {
+	x := (enums.EnumWithValues)(v)
+	return x.Encode(sw)
+}
+
 // FromWire deserializes MyEnum from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1011,6 +1236,11 @@ func (v *MyUUID) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v *MyUUID) Encode(sw stream.Writer) error {
+	x := (*UUID)(v)
+	return x.Encode(sw)
+}
+
 // FromWire deserializes MyUUID from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1042,6 +1272,11 @@ func (v PDF) ToWire() (wire.Value, error) {
 func (v PDF) String() string {
 	x := ([]byte)(v)
 	return fmt.Sprint(x)
+}
+
+func (v PDF) Encode(sw stream.Writer) error {
+	x := ([]byte)(v)
+	return sw.WriteBinary(x)
 }
 
 // FromWire deserializes PDF from its Thrift-level
@@ -1104,6 +1339,40 @@ func (_Map_Point_Point_MapItemList) ValueType() wire.Type {
 }
 
 func (_Map_Point_Point_MapItemList) Close() {}
+
+func _Map_Point_Point_Encode(val []struct {
+	Key   *structs.Point
+	Value *structs.Point
+}, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TStruct,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		err = key.Encode(sw)
+		if err != nil {
+			return err
+		}
+		value := v.Value
+		err = value.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
 
 func _Point_Read(w wire.Value) (*structs.Point, error) {
 	var v structs.Point
@@ -1235,6 +1504,14 @@ func (v PointMap) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v PointMap) Encode(sw stream.Writer) error {
+	x := ([]struct {
+		Key   *structs.Point
+		Value *structs.Point
+	})(v)
+	return _Map_Point_Point_Encode(x, sw)
+}
+
 // FromWire deserializes PointMap from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1282,6 +1559,11 @@ func (v State) ToWire() (wire.Value, error) {
 func (v State) String() string {
 	x := (string)(v)
 	return fmt.Sprint(x)
+}
+
+func (v State) Encode(sw stream.Writer) error {
+	x := (string)(v)
+	return sw.WriteString(x)
 }
 
 // FromWire deserializes State from its Thrift-level
@@ -1333,6 +1615,35 @@ func (_Map_State_I64_MapItemList) ValueType() wire.Type {
 }
 
 func (_Map_State_I64_MapItemList) Close() {}
+
+func _Map_State_I64_Encode(val map[State]int64, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TI64,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = k.Encode(sw)
+		if err != nil {
+			return err
+		}
+		err = sw.WriteInt64(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
 
 func _Map_State_I64_Read(m wire.MapItemList) (map[State]int64, error) {
 	if m.KeyType() != wire.TBinary {
@@ -1406,6 +1717,11 @@ func (v StateMap) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v StateMap) Encode(sw stream.Writer) error {
+	x := (map[State]int64)(v)
+	return _Map_State_I64_Encode(x, sw)
+}
+
 // FromWire deserializes StateMap from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1447,6 +1763,11 @@ func (v Timestamp) ToWire() (wire.Value, error) {
 func (v Timestamp) String() string {
 	x := (int64)(v)
 	return fmt.Sprint(x)
+}
+
+func (v Timestamp) Encode(sw stream.Writer) error {
+	x := (int64)(v)
+	return sw.WriteInt64(x)
 }
 
 // FromWire deserializes Timestamp from its Thrift-level
@@ -1585,6 +1906,66 @@ func (v *Transition) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a Transition struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Transition struct could not be generated from the wire
+// representation.
+func (v *Transition) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.FromState.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.ToState.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Events != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Events.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Transition
@@ -1766,6 +2147,41 @@ func (v *TransitiveTypedefField) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a TransitiveTypedefField struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a TransitiveTypedefField struct could not be generated from the wire
+// representation.
+func (v *TransitiveTypedefField) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.DefUUID == nil {
+		return errors.New("field DefUUID of TransitiveTypedefField is required")
+	}
+	fh = stream.FieldHeader{ID: 1, Type: wire.TStruct}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = v.DefUUID.Encode(sw)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a TransitiveTypedefField
 // struct.
 func (v *TransitiveTypedefField) String() string {
@@ -1836,6 +2252,11 @@ func (v *UUID) ToWire() (wire.Value, error) {
 func (v *UUID) String() string {
 	x := (*I128)(v)
 	return fmt.Sprint(x)
+}
+
+func (v *UUID) Encode(sw stream.Writer) error {
+	x := (*I128)(v)
+	return x.Encode(sw)
 }
 
 // FromWire deserializes UUID from its Thrift-level
@@ -1953,6 +2374,51 @@ func (v *I128) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a I128 struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a I128 struct could not be generated from the wire
+// representation.
+func (v *I128) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 1, Type: wire.TI64}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt64(v.High)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	fh = stream.FieldHeader{ID: 2, Type: wire.TI64}
+	if err := sw.WriteFieldBegin(fh); err != nil {
+		return err
+	}
+	err = sw.WriteInt64(v.Low)
+	if err != nil {
+		return err
+	}
+	i++
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a I128

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -6,12 +6,14 @@ package unions
 import (
 	base64 "encoding/base64"
 	fmt "fmt"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
 	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	strings "strings"
 )
 
 // ArbitraryValue allows constructing complex values without a schema.
@@ -313,6 +315,156 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _List_ArbitraryValue_Encode(val []*ArbitraryValue, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	err = sw.WriteListBegin(lh)
+	if err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Map_String_ArbitraryValue_Encode(val map[string]*ArbitraryValue, sw stream.Writer) error {
+	var (
+		err error
+	)
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	err = sw.WriteMapBegin(mh)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		err = sw.WriteString(k)
+		if err != nil {
+			return err
+		}
+		err = v.Encode(sw)
+		if err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Decode deserializes a ArbitraryValue struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a ArbitraryValue struct could not be generated from the wire
+// representation.
+func (v *ArbitraryValue) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.BoolValue != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBool}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteBool(*(v.BoolValue))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Int64Value != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TI64}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteInt64(*(v.Int64Value))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.StringValue != nil {
+		fh = stream.FieldHeader{ID: 3, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.StringValue))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ListValue != nil {
+		fh = stream.FieldHeader{ID: 4, Type: wire.TList}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _List_ArbitraryValue_Encode(v.ListValue, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapValue != nil {
+		fh = stream.FieldHeader{ID: 5, Type: wire.TMap}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = _Map_String_ArbitraryValue_Encode(v.MapValue, sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if i != 1 {
+		return fmt.Errorf("ArbitraryValue should have exactly one field: got %v fields", i)
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ArbitraryValue
@@ -675,6 +827,59 @@ func (v *Document) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Decode deserializes a Document struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a Document struct could not be generated from the wire
+// representation.
+func (v *Document) Encode(sw stream.Writer) error {
+	var (
+		i   int = 0
+		err error
+		fh  stream.FieldHeader
+	)
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Pdf != nil {
+		fh = stream.FieldHeader{ID: 1, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = v.Pdf.Encode(sw)
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.PlainText != nil {
+		fh = stream.FieldHeader{ID: 2, Type: wire.TBinary}
+		if err := sw.WriteFieldBegin(fh); err != nil {
+			return err
+		}
+		err = sw.WriteString(*(v.PlainText))
+		if err != nil {
+			return err
+		}
+		i++
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if i != 1 {
+		return fmt.Errorf("Document should have exactly one field: got %v fields", i)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Document
 // struct.
 func (v *Document) String() string {
@@ -813,6 +1018,21 @@ func (v *EmptyUnion) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Decode deserializes a EmptyUnion struct directly from its Thrift-level
+// representation, without going through an intemediary type.
+//
+// An error is returned if a EmptyUnion struct could not be generated from the wire
+// representation.
+func (v *EmptyUnion) Encode(sw stream.Writer) error {
+	var ()
+
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a EmptyUnion

--- a/gen/list_test.go
+++ b/gen/list_test.go
@@ -163,6 +163,7 @@ func TestRoundtripOptionalListFields(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			// assertRoundTrip does more than we need as we only need to test wire.Value FromWire response.
 			assertRoundTrip(t, tt.want, tt.give, tt.desc)
+			testRoundTripCombos(t, tt.want, tt.give, tt.desc)
 		})
 	}
 }

--- a/gen/mock_zap_test.go
+++ b/gen/mock_zap_test.go
@@ -5,10 +5,11 @@
 package gen
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	zapcore "go.uber.org/zap/zapcore"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	zapcore "go.uber.org/zap/zapcore"
 )
 
 // MockObjectEncoder is a mock of ObjectEncoder interface

--- a/gen/set.go
+++ b/gen/set.go
@@ -142,6 +142,54 @@ func (s *setGenerator) Reader(g Generator, spec *compile.SetSpec) (string, error
 	return name, wrapGenerateError(spec.ThriftName(), err)
 }
 
+func (s *setGenerator) Encoder(g Generator, spec *compile.SetSpec) (string, error) {
+	name := encoderFuncName(g, spec)
+	err := g.EnsureDeclared(
+		`
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
+		<$setType := typeReference .Spec>
+		<$sw := newVar "sw">
+		<$sh := newVar "sh">
+		<$o := newVar "o">
+		<$k := newVar "k">
+		<$v := newVar "v">
+		<$val := newVar "val">
+		func <.Name>(<$val> <$setType>, <$sw> <$stream>.Writer) error {
+			var err error
+			
+			<$vt := typeCode .Spec.ValueSpec>
+			<$sh> := <$stream>.SetHeader{
+				Type: <$vt>,
+				Length: len(<$val>),
+			}
+			err = <$sw>.WriteSetBegin(<$sh>)
+			if err != nil {
+				return err
+			}
+
+			<if setUsesMap .Spec>
+				for <$v>, _ := range <$val> {
+			<else>
+				for _, <$v> := range <$val> {
+			<end>
+					err = <encode .Spec.ValueSpec $v $sw>
+					if err != nil {
+						return err
+					}
+				}
+			return <$sw>.WriteSetEnd()
+		}
+		`,
+		struct {
+			Name string
+			Spec *compile.SetSpec
+		}{Name: name, Spec: spec},
+	)
+
+	return name, wrapGenerateError(spec.ThriftName(), err)
+
+}
+
 // Equals generates a function to compare sets of the given type
 //
 // func $name(lhs, rhs $setType) bool {

--- a/gen/stream.go
+++ b/gen/stream.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gen
+
+import (
+	"fmt"
+
+	"go.uber.org/thriftrw/compile"
+)
+
+type StreamGenerator struct {
+	mapG  mapGenerator
+	setG  setGenerator
+	listG listGenerator
+
+	enumG    enumGenerator
+	structG  structGenerator
+	typedefG typedefGenerator
+}
+
+func (sg *StreamGenerator) Encode(g Generator, spec compile.TypeSpec, varName string, sw string) (string, error) {
+	switch s := spec.(type) {
+	case *compile.BoolSpec:
+		return fmt.Sprintf("%s.WriteBool(%s)", sw, varName), nil
+	case *compile.I8Spec:
+		return fmt.Sprintf("%s.WriteInt8(%s)", sw, varName), nil
+	case *compile.I16Spec:
+		return fmt.Sprintf("%s.WriteInt16(%s)", sw, varName), nil
+	case *compile.I32Spec:
+		return fmt.Sprintf("%s.WriteInt32(%s)", sw, varName), nil
+	case *compile.I64Spec:
+		return fmt.Sprintf("%s.WriteInt64(%s)", sw, varName), nil
+	case *compile.DoubleSpec:
+		return fmt.Sprintf("%s.WriteDouble(%s)", sw, varName), nil
+	case *compile.StringSpec:
+		return fmt.Sprintf("%s.WriteString(%s)", sw, varName), nil
+	case *compile.BinarySpec:
+		return fmt.Sprintf("%s.WriteBinary(%s)", sw, varName), nil
+	case *compile.MapSpec:
+		encoder, err := sg.mapG.Encoder(g, s)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s(%s, %s)", encoder, varName, sw), nil
+	case *compile.ListSpec:
+		encoder, err := sg.listG.Encoder(g, s)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s(%s, %s)", encoder, varName, sw), nil
+	case *compile.SetSpec:
+		encoder, err := sg.setG.Encoder(g, s)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s(%s, %s)", encoder, varName, sw), nil
+	default:
+		return fmt.Sprintf("%s.Encode(%s)", varName, sw), nil
+	}
+}
+
+func (sg *StreamGenerator) EncodePtr(g Generator, spec compile.TypeSpec, varName string, sw string) (string, error) {
+	switch spec.(type) {
+	case *compile.BoolSpec, *compile.I8Spec, *compile.I16Spec, *compile.I32Spec,
+		*compile.I64Spec, *compile.DoubleSpec, *compile.StringSpec:
+		return sg.Encode(g, spec, fmt.Sprintf("*(%s)", varName), sw)
+	default:
+		// Everything else is either a reference type or has an Encode method
+		// on it that does automatic dereferencing.
+		return sg.Encode(g, spec, varName, sw)
+	}
+}

--- a/gen/struct.go
+++ b/gen/struct.go
@@ -51,6 +51,27 @@ func (s *structGenerator) Reader(g Generator, spec *compile.StructSpec) (string,
 	return name, wrapGenerateError(spec.ThriftName(), err)
 }
 
+func (s *structGenerator) Encoder(g Generator, spec *compile.StructSpec) (string, error) {
+	name := encoderFuncName(g, spec)
+	err := g.EnsureDeclared(
+		`
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
+		<$val := newVar "val">
+		<$sw := newVar "sw">
+		<$t := typeReference .Spec>
+		func <.Name>(<$val> <$t>, <$sw> <$stream>.Writer) error {
+			return <$val>.Encode(<$sw>)
+		}
+		`,
+		struct {
+			Name string
+			Spec *compile.StructSpec
+		}{Name: name, Spec: spec},
+	)
+
+	return name, wrapGenerateError(spec.ThriftName(), err)
+}
+
 func structure(g Generator, spec *compile.StructSpec) error {
 	name, err := goName(spec)
 	if err != nil {

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -471,6 +471,7 @@ func TestStructRoundTripAndString(t *testing.T) {
 		} else {
 			assert.NotPanics(t, func() { _ = tt.x.String() }, "ToString: %v", tt.desc)
 		}
+		testRoundTripCombos(t, tt.x, tt.v, tt.desc)
 	}
 }
 

--- a/gen/type.go
+++ b/gen/type.go
@@ -208,6 +208,10 @@ func valueListName(g Generator, spec compile.TypeSpec) string {
 	return fmt.Sprintf("_%s_ValueList", g.MangleType(spec))
 }
 
+func encoderFuncName(g Generator, spec compile.TypeSpec) string {
+	return fmt.Sprintf("_%s_Encode", g.MangleType(spec))
+}
+
 // zapperName returns the name that should be used for wrapper types that
 // implement zap.ObjectMarshaler or zap.ArrayMarshaler for the provided
 // Thrift type.

--- a/gen/util_for_test.go
+++ b/gen/util_for_test.go
@@ -23,6 +23,7 @@ package gen
 import (
 	"fmt"
 
+	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/thriftrw/wire"
 )
 
@@ -36,4 +37,14 @@ type thriftType interface {
 
 	ToWire() (wire.Value, error)
 	FromWire(wire.Value) error
+}
+
+// streamingThriftType is implemented by all generated types that know how to
+// write and read themselves to the Thrift Protocol, skipping over the
+// intermediary wire.Type
+type streamingThriftType interface {
+	thriftType
+
+	Encode(stream.Writer) error
+	//Decode(stream.Reader) error
 }

--- a/idl/internal/lex.go
+++ b/idl/internal/lex.go
@@ -20,9 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
-
-
 package internal
 
 import (
@@ -38,7 +35,6 @@ const thrift_first_final int = 19
 const thrift_error int = 0
 
 const thrift_en_main int = 19
-
 
 type lexer struct {
 	line    int
@@ -16591,7 +16587,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		{
 		}
 	}
-
 
 	if lex.cs == thrift_error {
 		lex.AppendError(fmt.Errorf("unknown token at index %d", lex.p))

--- a/internal/envelope/envelopetest/client.go
+++ b/internal/envelope/envelopetest/client.go
@@ -25,9 +25,10 @@
 package envelopetest
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	wire "go.uber.org/thriftrw/wire"
-	reflect "reflect"
 )
 
 // MockTransport is a mock of Transport interface

--- a/internal/envelope/envelopetest/server.go
+++ b/internal/envelope/envelopetest/server.go
@@ -25,9 +25,10 @@
 package envelopetest
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	wire "go.uber.org/thriftrw/wire"
-	reflect "reflect"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -27,13 +27,14 @@ import (
 	bytes "bytes"
 	json "encoding/json"
 	fmt "fmt"
+	math "math"
+	strconv "strconv"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	math "math"
-	strconv "strconv"
-	strings "strings"
 )
 
 type ExceptionType int32

--- a/internal/envelope/mock_protocol_test.go
+++ b/internal/envelope/mock_protocol_test.go
@@ -5,10 +5,11 @@
 package envelope
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	wire "go.uber.org/thriftrw/wire"
 	io "io"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	wire "go.uber.org/thriftrw/wire"
 )
 
 // MockProtocol is a mock of Protocol interface

--- a/internal/frame/mock_reader_test.go
+++ b/internal/frame/mock_reader_test.go
@@ -5,8 +5,9 @@
 package frame
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockReader is a mock of Reader interface

--- a/internal/frame/mock_writer_test.go
+++ b/internal/frame/mock_writer_test.go
@@ -5,8 +5,9 @@
 package frame
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockWriter is a mock of Writer interface

--- a/internal/plugin/handletest/mock.go
+++ b/internal/plugin/handletest/mock.go
@@ -25,10 +25,11 @@
 package handletest
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	plugin "go.uber.org/thriftrw/internal/plugin"
 	api "go.uber.org/thriftrw/plugin/api"
-	reflect "reflect"
 )
 
 // MockHandle is a mock of Handle interface

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -29,13 +29,14 @@ import (
 	json "encoding/json"
 	errors "errors"
 	fmt "fmt"
+	math "math"
+	strconv "strconv"
+	strings "strings"
+
 	multierr "go.uber.org/multierr"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
-	math "math"
-	strconv "strconv"
-	strings "strings"
 )
 
 // API_VERSION is the version of the plugin API.

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -25,9 +25,10 @@
 package plugintest
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	api "go.uber.org/thriftrw/plugin/api"
-	reflect "reflect"
 )
 
 // MockPlugin is a mock of Plugin interface

--- a/protocol/binary/envelope.go
+++ b/protocol/binary/envelope.go
@@ -35,15 +35,15 @@ const (
 func (bw *Writer) WriteEnveloped(e wire.Envelope) error {
 	version := uint32(version1) | uint32(e.Type)
 
-	if err := bw.writeInt32(int32(version)); err != nil {
+	if err := bw.sw.WriteInt32(int32(version)); err != nil {
 		return err
 	}
 
-	if err := bw.writeString(e.Name); err != nil {
+	if err := bw.sw.WriteString(e.Name); err != nil {
 		return err
 	}
 
-	if err := bw.writeInt32(e.SeqID); err != nil {
+	if err := bw.sw.WriteInt32(e.SeqID); err != nil {
 		return err
 	}
 
@@ -53,15 +53,15 @@ func (bw *Writer) WriteEnveloped(e wire.Envelope) error {
 // WriteLegacyEnveloped writes enveloped value using the non-strict envelope
 // (non-strict lacks an envelope version).
 func (bw *Writer) WriteLegacyEnveloped(e wire.Envelope) error {
-	if err := bw.writeString(e.Name); err != nil {
+	if err := bw.sw.WriteString(e.Name); err != nil {
 		return err
 	}
 
-	if err := bw.writeByte(uint8(e.Type)); err != nil {
+	if err := bw.sw.writeByte(uint8(e.Type)); err != nil {
 		return err
 	}
 
-	if err := bw.writeInt32(e.SeqID); err != nil {
+	if err := bw.sw.WriteInt32(e.SeqID); err != nil {
 		return err
 	}
 

--- a/protocol/binary/stream_writer.go
+++ b/protocol/binary/stream_writer.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package binary
+
+import (
+	"io"
+	"math"
+	"sync"
+
+	"go.uber.org/thriftrw/internal/iface"
+	"go.uber.org/thriftrw/protocol/stream"
+)
+
+var streamWriterPool = sync.Pool{
+	New: func() interface{} {
+		return &StreamWriter{}
+	}}
+
+// StreamWriter implements basic logic for writing the Thrift Binary Protocol
+// to an io.Writer.
+type StreamWriter struct {
+	// Private implementation to satisfy the private Writer interface.
+	iface.Impl
+
+	writer io.Writer
+
+	// This buffer is re-used every time we need a slice of up to 8 bytes.
+	buffer [8]byte
+}
+
+// BorrowStreamWriter fetches a StreamWriter from the system that will write
+// its output to the given io.Writer.
+//
+// This StreamWriter must be returned back using ReturnStreamWriter.
+func BorrowStreamWriter(w io.Writer) *StreamWriter {
+	streamWriter := streamWriterPool.Get().(*StreamWriter)
+	streamWriter.writer = w
+	return streamWriter
+}
+
+// ReturnStreamWriter returns a previously borrowed StreamWriter back to the
+// system.
+func ReturnStreamWriter(sw *StreamWriter) {
+	sw.writer = nil
+	streamWriterPool.Put(sw)
+}
+
+func (sw *StreamWriter) write(bs []byte) error {
+	_, err := sw.writer.Write(bs)
+	return err
+}
+
+func (sw *StreamWriter) writeByte(b byte) error {
+	bs := sw.buffer[0:1]
+	bs[0] = b
+	return sw.write(bs)
+}
+
+// WriteBool encodes a boolean
+func (sw *StreamWriter) WriteBool(b bool) error {
+	if b {
+		return sw.writeByte(1)
+	}
+	return sw.writeByte(0)
+}
+
+// WriteInt8 encodes an int8
+func (sw *StreamWriter) WriteInt8(i int8) error {
+	return sw.writeByte(byte(i))
+}
+
+// WriteInt16 encodes an int16
+func (sw *StreamWriter) WriteInt16(i int16) error {
+	bs := sw.buffer[0:2]
+	bigEndian.PutUint16(bs, uint16(i))
+	return sw.write(bs)
+}
+
+// WriteInt32 encodes an int32
+func (sw *StreamWriter) WriteInt32(i int32) error {
+	bs := sw.buffer[0:4]
+	bigEndian.PutUint32(bs, uint32(i))
+	return sw.write(bs)
+}
+
+// WriteInt64 encodes an int64
+func (sw *StreamWriter) WriteInt64(i int64) error {
+	bs := sw.buffer[0:8]
+	bigEndian.PutUint64(bs, uint64(i))
+	return sw.write(bs)
+}
+
+// WriteString encodes a string
+func (sw *StreamWriter) WriteString(s string) error {
+	if err := sw.WriteInt32(int32(len(s))); err != nil {
+		return err
+	}
+
+	_, err := io.WriteString(sw.writer, s)
+	return err
+}
+
+// WriteDouble encodes a double
+func (sw *StreamWriter) WriteDouble(d float64) error {
+	value := math.Float64bits(d)
+	return sw.WriteInt64(int64(value))
+}
+
+// WriteBinary encodes binary
+func (sw *StreamWriter) WriteBinary(b []byte) error {
+	if err := sw.WriteInt32(int32(len(b))); err != nil {
+		return err
+	}
+	return sw.write(b)
+}
+
+// WriteFieldBegin marks the beginning of a new field in a struct. The first
+// byte denotes the type and the next two bytes denote the field id.
+func (sw *StreamWriter) WriteFieldBegin(f stream.FieldHeader) error {
+	// type:1
+	if err := sw.writeByte(byte(f.Type)); err != nil {
+		return err
+	}
+
+	// id:2
+	if err := sw.WriteInt16(f.ID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteFieldEnd denotes the end of a field. No-op.
+func (sw *StreamWriter) WriteFieldEnd() error {
+	return nil
+}
+
+// WriteStructBegin denotes the beginning of a struct. No-op.
+func (sw *StreamWriter) WriteStructBegin() error {
+	return nil
+}
+
+// WriteStructEnd uses the zero byte to mark the end of a struct.
+func (sw *StreamWriter) WriteStructEnd() error {
+	return sw.writeByte(0) // end struct
+}
+
+// WriteListBegin marks the beginning of a new list. The first byte denotes
+// the type of the items and the next four bytes denote the length of the list.
+func (sw *StreamWriter) WriteListBegin(l stream.ListHeader) error {
+	// vtype:1
+	if err := sw.writeByte(byte(l.Type)); err != nil {
+		return err
+	}
+
+	// length:4
+	if err := sw.WriteInt32(int32(l.Length)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteListEnd marks the end of a list. No-op.
+func (sw *StreamWriter) WriteListEnd() error {
+	return nil
+}
+
+// WriteSetBegin marks the beginning of a new set. The first byte denotes
+// the type of the items and the next four bytes denote the length of the set.
+func (sw *StreamWriter) WriteSetBegin(s stream.SetHeader) error {
+	// vtype:1
+	if err := sw.writeByte(byte(s.Type)); err != nil {
+		return err
+	}
+
+	// length:4
+	if err := sw.WriteInt32(int32(s.Length)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteSetEnd marks the end of a set. No-op.
+func (sw *StreamWriter) WriteSetEnd() error {
+	return nil
+}
+
+// WriteMapBegin marks the beginning of a new map. The first byte denotes
+// the type of the keys, the second byte denotes the type of the values,
+// and the next four bytes denote the length of the map.
+func (sw *StreamWriter) WriteMapBegin(m stream.MapHeader) error {
+	// ktype:1
+	if err := sw.writeByte(byte(m.KeyType)); err != nil {
+		return err
+	}
+
+	// vtype:1
+	if err := sw.writeByte(byte(m.ValueType)); err != nil {
+		return err
+	}
+
+	// length:4
+	if err := sw.WriteInt32(int32(m.Length)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteMapEnd marks the end of a map. No-op.
+func (sw *StreamWriter) WriteMapEnd() error {
+	return nil
+}

--- a/thrifttest/mock_protocol.go
+++ b/thrifttest/mock_protocol.go
@@ -25,11 +25,12 @@
 package thrifttest
 
 import (
+	io "io"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	protocol "go.uber.org/thriftrw/protocol"
 	wire "go.uber.org/thriftrw/wire"
-	io "io"
-	reflect "reflect"
 )
 
 // MockProtocol is a mock of Protocol interface


### PR DESCRIPTION
Creates the code generation for all the primitive types, enums, typedefs, structs, and container types. We use the same testing utils as the reader implementation in #496 (hopefully that will reduce rebase conflicts). 