### PR TITLE
Support "<" in the templating language

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -215,6 +215,7 @@ func (g *generator) LookupConstantName(c *compile.Constant) (string, error) {
 // TextTemplate renders the given template with the given template context.
 func (g *generator) TextTemplate(s string, data interface{}, opts ...TemplateOption) (string, error) {
 	templateFuncs := template.FuncMap{
+		"lessthan":         lessThanSymbol,
 		"enumItemName":     enumItemName,
 		"formatDoc":        formatDoc,
 		"goCase":           goCase,
@@ -538,4 +539,8 @@ func formatDoc(s string) string {
 		}
 	}
 	return strings.Join(lines, "\n") + "\n"
+}
+
+func lessThanSymbol() string {
+	return "<"
 }


### PR DESCRIPTION
The templating language for code generation uses `<` and `>` as its
delimiters.  This results in syntax errors when trying to use the beginning
delimiter as an actual character , not as invoking a template.  Add an explicit
command (`<lessthan>`) to inject `<` as needed.