### PR TITLE
Add code generation for all wire types for stream encoding

### DIFF
--- a/gen/container_test.go
+++ b/gen/container_test.go
@@ -180,6 +180,9 @@ func TestCollectionsOfPrimitives(t *testing.T) {
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.p, tt.v, tt.desc)
 		assert.True(t, tt.p.Equals(&tt.p), tt.desc)
+
+		testRoundTripCombos(t, &tt.p, tt.v, tt.desc)
+		assert.True(t, tt.p.Equals(&tt.p), tt.desc)
 	}
 }
 
@@ -351,6 +354,9 @@ func TestEnumContainers(t *testing.T) {
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.r, tt.v, "EnumContainers")
 		assert.True(t, tt.r.Equals(&tt.r), "EnumContainers equal")
+
+		testRoundTripCombos(t, &tt.r, tt.v, "EnumContainers")
+		assert.True(t, tt.r.Equals(&tt.r), "EnumContainers equal")
 	}
 }
 
@@ -505,6 +511,9 @@ func TestListOfStructs(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.r, tt.v, "Graph")
+		assert.True(t, tt.r.Equals(&tt.r), "Graph equal")
+
+		testRoundTripCombos(t, &tt.r, tt.v, "Graph")
 		assert.True(t, tt.r.Equals(&tt.r), "Graph equal")
 	}
 }
@@ -948,6 +957,9 @@ func TestCrazyTown(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, tt.desc)
+		assert.True(t, tt.x.Equals(&tt.x), tt.desc)
+
+		testRoundTripCombos(t, &tt.x, tt.v, tt.desc)
 		assert.True(t, tt.x.Equals(&tt.x), tt.desc)
 	}
 }

--- a/gen/enum.go
+++ b/gen/enum.go
@@ -68,6 +68,7 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		<$math := import "math">
 		<$strconv := import "strconv">
 
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
 		<$wire := import "go.uber.org/thriftrw/wire">
 
 		<$enumName := goName .Spec>
@@ -160,6 +161,17 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		// Ptr returns a pointer to this enum value.
 		func (<$v> <$enumName>) Ptr() *<$enumName> {
 			return &<$v>
+		}
+
+		<$sw := newVar "sw">
+		// Encode encodes <$enumName> directly to bytes.
+		//
+		//   sWriter := BinaryStreamer.Writer(writer)
+		//
+		//   var <$v> <$enumName>
+		//   return <$v>.Encode(sWriter)
+		func (<$v> <$enumName>) Encode(<$sw> <$stream>.Writer) error {
+			return <$sw>.WriteInt32(int32(<$v>))
 		}
 
 		// ToWire translates <$enumName> into a Thrift-level intermediate

--- a/gen/enum_test.go
+++ b/gen/enum_test.go
@@ -108,6 +108,7 @@ func TestEnumDefaultWire(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.e, tt.v, "EnumDefault")
+		testRoundTripCombos(t, &tt.e, tt.v, "EnumDefault")
 	}
 }
 
@@ -154,6 +155,7 @@ func TestEnumWithDuplicateValuesWire(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.e, tt.v, "EnumWithDuplicateValues")
+		testRoundTripCombos(t, &tt.e, tt.v, "EnumWithDuplicateValues")
 	}
 }
 
@@ -185,6 +187,7 @@ func TestOptionalEnum(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.s, tt.v, "StructWithOptionalEnum")
+		testRoundTripCombos(t, &tt.s, tt.v, "StructWithOptionalEnum")
 	}
 }
 

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -129,6 +129,7 @@ type generator struct {
 	w              WireGenerator
 	e              equalsGenerator
 	z              zapGenerator
+	s              StreamGenerator
 	noZap          bool
 	decls          []ast.Decl
 	thriftImporter ThriftPackageImporter
@@ -233,6 +234,8 @@ func (g *generator) TextTemplate(s string, data interface{}, opts ...TemplateOpt
 		"typeReferencePtr": curryGenerator(typeReferencePtr, g),
 		"fromWire":         curryGenerator(g.w.FromWire, g),
 		"fromWirePtr":      curryGenerator(g.w.FromWirePtr, g),
+		"encode":           curryGenerator(g.s.Encode, g),
+		"encodePtr":        curryGenerator(g.s.EncodePtr, g),
 		"toWire":           curryGenerator(g.w.ToWire, g),
 		"toWirePtr":        curryGenerator(g.w.ToWirePtr, g),
 		"typeCode":         curryGenerator(TypeCode, g),

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -9,6 +9,7 @@ import (
 	errors "errors"
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -135,6 +136,54 @@ func (v *AccessorConflict) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a AccessorConflict struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a AccessorConflict struct could not be encoded.
+func (v *AccessorConflict) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Name != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Name)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.GetName2 != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.GetName2)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.IsSetName2 != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(v.IsSetName2)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a AccessorConflict
@@ -364,6 +413,42 @@ func (v *AccessorNoConflict) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a AccessorNoConflict struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a AccessorNoConflict struct could not be encoded.
+func (v *AccessorNoConflict) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Getname != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Getname)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.GetName != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.GetName)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a AccessorNoConflict
 // struct.
 func (v *AccessorNoConflict) String() string {
@@ -469,6 +554,11 @@ func (v LittlePotatoe) ToWire() (wire.Value, error) {
 func (v LittlePotatoe) String() string {
 	x := (int64)(v)
 	return fmt.Sprint(x)
+}
+
+func (v LittlePotatoe) Encode(sw stream.Writer) error {
+	x := (int64)(v)
+	return sw.WriteInt64(x)
 }
 
 // FromWire deserializes LittlePotatoe from its Thrift-level
@@ -585,6 +675,16 @@ func (v MyEnum) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v MyEnum) Ptr() *MyEnum {
 	return &v
+}
+
+// Encode encodes MyEnum directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v MyEnum
+//   return v.Encode(sWriter)
+func (v MyEnum) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates MyEnum into a Thrift-level intermediate
@@ -957,6 +1057,115 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_String_Encode(val []string, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_String_mapType_Encode(val map[string]struct{}, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_String_String_Encode(val map[string]string, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a PrimitiveContainers struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a PrimitiveContainers struct could not be encoded.
+func (v *PrimitiveContainers) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.A != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_String_Encode(v.A, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.B != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := _Set_String_mapType_Encode(v.B, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.C != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_String_Encode(v.C, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a PrimitiveContainers
 // struct.
 func (v *PrimitiveContainers) String() string {
@@ -1247,6 +1456,38 @@ func (v *StructCollision) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a StructCollision struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a StructCollision struct could not be encoded.
+func (v *StructCollision) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBool}); err != nil {
+		return err
+	}
+	if err := sw.WriteBool(v.CollisionField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.CollisionField2); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a StructCollision
 // struct.
 func (v *StructCollision) String() string {
@@ -1422,6 +1663,54 @@ func (v *UnionCollision) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a UnionCollision struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a UnionCollision struct could not be encoded.
+func (v *UnionCollision) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.CollisionField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(v.CollisionField)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.CollisionField2 != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.CollisionField2)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.CollisionField != nil {
+		count++
+	}
+	if v.CollisionField2 != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("UnionCollision should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a UnionCollision
@@ -1616,6 +1905,37 @@ func (v *WithDefault) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a WithDefault struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a WithDefault struct could not be encoded.
+func (v *WithDefault) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	vPouet := v.Pouet
+	if vPouet == nil {
+		vPouet = &StructCollision2{
+			CollisionField:  false,
+			CollisionField2: "false indeed",
+		}
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := vPouet.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a WithDefault
 // struct.
 func (v *WithDefault) String() string {
@@ -1699,6 +2019,11 @@ func (v LittlePotatoe2) ToWire() (wire.Value, error) {
 func (v LittlePotatoe2) String() string {
 	x := (float64)(v)
 	return fmt.Sprint(x)
+}
+
+func (v LittlePotatoe2) Encode(sw stream.Writer) error {
+	x := (float64)(v)
+	return sw.WriteDouble(x)
 }
 
 // FromWire deserializes LittlePotatoe2 from its Thrift-level
@@ -1797,6 +2122,16 @@ func (v MyEnum2) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v MyEnum2) Ptr() *MyEnum2 {
 	return &v
+}
+
+// Encode encodes MyEnum2 directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v MyEnum2
+//   return v.Encode(sWriter)
+func (v MyEnum2) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates MyEnum2 into a Thrift-level intermediate
@@ -2000,6 +2335,38 @@ func (v *StructCollision2) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a StructCollision2 struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a StructCollision2 struct could not be encoded.
+func (v *StructCollision2) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBool}); err != nil {
+		return err
+	}
+	if err := sw.WriteBool(v.CollisionField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.CollisionField2); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a StructCollision2
 // struct.
 func (v *StructCollision2) String() string {
@@ -2175,6 +2542,54 @@ func (v *UnionCollision2) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a UnionCollision2 struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a UnionCollision2 struct could not be encoded.
+func (v *UnionCollision2) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.CollisionField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(v.CollisionField)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.CollisionField2 != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.CollisionField2)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.CollisionField != nil {
+		count++
+	}
+	if v.CollisionField2 != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("UnionCollision2 should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a UnionCollision2

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -13,6 +13,7 @@ import (
 	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
 	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
 	uuid_conflict "go.uber.org/thriftrw/gen/internal/tests/uuid_conflict"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -1226,6 +1227,507 @@ func (v *ContainersOfContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_I32_Encode(val []int32, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := sw.WriteInt32(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_List_I32_Encode(val [][]int32, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TList,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := _List_I32_Encode(v, sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_I32_mapType_Encode(val map[int32]struct{}, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		if err := sw.WriteInt32(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _List_Set_I32_mapType_Encode(val []map[int32]struct{}, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TSet,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := _Set_I32_mapType_Encode(v, sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Map_I32_I32_Encode(val map[int32]int32, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI32,
+		ValueType: wire.TI32,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteInt32(k); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _List_Map_I32_I32_Encode(val []map[int32]int32, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TMap,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := _Map_I32_I32_Encode(v, sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_String_mapType_Encode(val map[string]struct{}, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Set_Set_String_mapType_sliceType_Encode(val []map[string]struct{}, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TSet,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		if err := _Set_String_mapType_Encode(v, sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _List_String_Encode(val []string, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_List_String_sliceType_Encode(val [][]string, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TList,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		if err := _List_String_Encode(v, sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_String_String_Encode(val map[string]string, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Set_Map_String_String_sliceType_Encode(val []map[string]string, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TMap,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		if err := _Map_String_String_Encode(v, sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_String_I32_Encode(val map[string]int32, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TI32,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Map_Map_String_I32_I64_Encode(val []struct {
+	Key   map[string]int32
+	Value int64
+}, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TMap,
+		ValueType: wire.TI64,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		if err := _Map_String_I32_Encode(key, sw); err != nil {
+			return err
+		}
+		value := v.Value
+		if err := sw.WriteInt64(value); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Set_I64_mapType_Encode(val map[int64]struct{}, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TI64,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		if err := sw.WriteInt64(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_List_I32_Set_I64_mapType_Encode(val []struct {
+	Key   []int32
+	Value map[int64]struct{}
+}, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TList,
+		ValueType: wire.TSet,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		if err := _List_I32_Encode(key, sw); err != nil {
+			return err
+		}
+		value := v.Value
+		if err := _Set_I64_mapType_Encode(value, sw); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _List_Double_Encode(val []float64, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TDouble,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := sw.WriteDouble(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Map_Set_I32_mapType_List_Double_Encode(val []struct {
+	Key   map[int32]struct{}
+	Value []float64
+}, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TSet,
+		ValueType: wire.TList,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		if err := _Set_I32_mapType_Encode(key, sw); err != nil {
+			return err
+		}
+		value := v.Value
+		if err := _List_Double_Encode(value, sw); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a ContainersOfContainers struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ContainersOfContainers struct could not be encoded.
+func (v *ContainersOfContainers) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.ListOfLists != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_List_I32_Encode(v.ListOfLists, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ListOfSets != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_Set_I32_mapType_Encode(v.ListOfSets, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ListOfMaps != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_Map_I32_I32_Encode(v.ListOfMaps, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfSets != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := _Set_Set_String_mapType_sliceType_Encode(v.SetOfSets, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfLists != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := _Set_List_String_sliceType_Encode(v.SetOfLists, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfMaps != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := _Set_Map_String_String_sliceType_Encode(v.SetOfMaps, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfMapToInt != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 7, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_Map_String_I32_I64_Encode(v.MapOfMapToInt, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfListToSet != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 8, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_List_I32_Set_I64_mapType_Encode(v.MapOfListToSet, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfSetToListOfDouble != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 9, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_Set_I32_mapType_List_Double_Encode(v.MapOfSetToListOfDouble, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ContainersOfContainers
 // struct.
 func (v *ContainersOfContainers) String() string {
@@ -2385,6 +2887,115 @@ func (v *EnumContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_EnumDefault_Encode(val []enums.EnumDefault, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_EnumWithValues_mapType_Encode(val map[enums.EnumWithValues]struct{}, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_EnumWithDuplicateValues_I32_Encode(val map[enums.EnumWithDuplicateValues]int32, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI32,
+		ValueType: wire.TI32,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := k.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a EnumContainers struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a EnumContainers struct could not be encoded.
+func (v *EnumContainers) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.ListOfEnums != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_EnumDefault_Encode(v.ListOfEnums, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfEnums != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := _Set_EnumWithValues_mapType_Encode(v.SetOfEnums, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfEnums != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_EnumWithDuplicateValues_I32_Encode(v.MapOfEnums, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a EnumContainers
 // struct.
 func (v *EnumContainers) String() string {
@@ -2788,6 +3399,74 @@ func (v *ListOfConflictingEnums) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_RecordType_Encode(val []enum_conflict.RecordType, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_RecordType_1_Encode(val []enums.RecordType, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a ListOfConflictingEnums struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ListOfConflictingEnums struct could not be encoded.
+func (v *ListOfConflictingEnums) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_RecordType_Encode(v.Records, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_RecordType_1_Encode(v.OtherRecords, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ListOfConflictingEnums
 // struct.
 func (v *ListOfConflictingEnums) String() string {
@@ -3119,6 +3798,74 @@ func (v *ListOfConflictingUUIDs) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_UUID_Encode(val []*typedefs.UUID, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_UUID_1_Encode(val []uuid_conflict.UUID, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a ListOfConflictingUUIDs struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ListOfConflictingUUIDs struct could not be encoded.
+func (v *ListOfConflictingUUIDs) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_UUID_Encode(v.Uuids, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_UUID_1_Encode(v.OtherUUIDs, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ListOfConflictingUUIDs
 // struct.
 func (v *ListOfConflictingUUIDs) String() string {
@@ -3322,6 +4069,30 @@ func (v *ListOfOptionalPrimitives) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a ListOfOptionalPrimitives struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ListOfOptionalPrimitives struct could not be encoded.
+func (v *ListOfOptionalPrimitives) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.ListOfStrings != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_String_Encode(v.ListOfStrings, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ListOfOptionalPrimitives
 // struct.
 func (v *ListOfOptionalPrimitives) String() string {
@@ -3460,6 +4231,28 @@ func (v *ListOfRequiredPrimitives) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a ListOfRequiredPrimitives struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ListOfRequiredPrimitives struct could not be encoded.
+func (v *ListOfRequiredPrimitives) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_String_Encode(v.ListOfStrings, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ListOfRequiredPrimitives
@@ -3757,6 +4550,93 @@ func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _Map_Binary_String_Encode(val []struct {
+	Key   []byte
+	Value string
+}, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		if err := sw.WriteBinary(key); err != nil {
+			return err
+		}
+		value := v.Value
+		if err := sw.WriteString(value); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Map_String_Binary_Encode(val map[string][]byte, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := sw.WriteBinary(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a MapOfBinaryAndString struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a MapOfBinaryAndString struct could not be encoded.
+func (v *MapOfBinaryAndString) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.BinaryToString != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_Binary_String_Encode(v.BinaryToString, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.StringToBinary != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_Binary_Encode(v.StringToBinary, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a MapOfBinaryAndString
@@ -4360,6 +5240,192 @@ func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_Binary_Encode(val [][]byte, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := sw.WriteBinary(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_I64_Encode(val []int64, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TI64,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := sw.WriteInt64(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_Byte_mapType_Encode(val map[int8]struct{}, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TI8,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		if err := sw.WriteInt8(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_I32_String_Encode(val map[int32]string, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI32,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteInt32(k); err != nil {
+			return err
+		}
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Map_String_Bool_Encode(val map[string]bool, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBool,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a PrimitiveContainers struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a PrimitiveContainers struct could not be encoded.
+func (v *PrimitiveContainers) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.ListOfBinary != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_Binary_Encode(v.ListOfBinary, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ListOfInts != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_I64_Encode(v.ListOfInts, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfStrings != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := _Set_String_mapType_Encode(v.SetOfStrings, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SetOfBytes != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := _Set_Byte_mapType_Encode(v.SetOfBytes, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfIntToString != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_I32_String_Encode(v.MapOfIntToString, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapOfStringToBool != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_Bool_Encode(v.MapOfStringToBool, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a PrimitiveContainers
 // struct.
 func (v *PrimitiveContainers) String() string {
@@ -4878,6 +5944,77 @@ func (v *PrimitiveContainersRequired) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _Map_I64_Double_Encode(val map[int64]float64, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI64,
+		ValueType: wire.TDouble,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteInt64(k); err != nil {
+			return err
+		}
+		if err := sw.WriteDouble(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a PrimitiveContainersRequired struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a PrimitiveContainersRequired struct could not be encoded.
+func (v *PrimitiveContainersRequired) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_String_Encode(v.ListOfStrings, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.SetOfInts == nil {
+		return errors.New("field SetOfInts of PrimitiveContainersRequired is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TSet}); err != nil {
+		return err
+	}
+	if err := _Set_I32_mapType_Encode(v.SetOfInts, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.MapOfIntsToDoubles == nil {
+		return errors.New("field MapOfIntsToDoubles of PrimitiveContainersRequired is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TMap}); err != nil {
+		return err
+	}
+	if err := _Map_I64_Double_Encode(v.MapOfIntsToDoubles, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a PrimitiveContainersRequired

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -9,6 +9,7 @@ import (
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
 	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -93,6 +94,16 @@ func (v RecordType) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v RecordType) Ptr() *RecordType {
 	return &v
+}
+
+// Encode encodes RecordType directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v RecordType
+//   return v.Encode(sWriter)
+func (v RecordType) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates RecordType into a Thrift-level intermediate
@@ -331,6 +342,50 @@ func (v *Records) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Records struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Records struct could not be encoded.
+func (v *Records) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	vRecordType := v.RecordType
+	if vRecordType == nil {
+		vRecordType = _RecordType_ptr(DefaultRecordType)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := vRecordType.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOtherRecordType := v.OtherRecordType
+	if vOtherRecordType == nil {
+		vOtherRecordType = _RecordType_1_ptr(DefaultOtherRecordType)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := vOtherRecordType.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Records

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -8,6 +8,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -59,6 +60,16 @@ func (v EmptyEnum) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v EmptyEnum) Ptr() *EmptyEnum {
 	return &v
+}
+
+// Encode encodes EmptyEnum directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EmptyEnum
+//   return v.Encode(sWriter)
+func (v EmptyEnum) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates EmptyEnum into a Thrift-level intermediate
@@ -227,6 +238,16 @@ func (v EnumDefault) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v EnumDefault) Ptr() *EnumDefault {
 	return &v
+}
+
+// Encode encodes EnumDefault directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumDefault
+//   return v.Encode(sWriter)
+func (v EnumDefault) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates EnumDefault into a Thrift-level intermediate
@@ -467,6 +488,16 @@ func (v EnumWithDuplicateName) Ptr() *EnumWithDuplicateName {
 	return &v
 }
 
+// Encode encodes EnumWithDuplicateName directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumWithDuplicateName
+//   return v.Encode(sWriter)
+func (v EnumWithDuplicateName) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
+}
+
 // ToWire translates EnumWithDuplicateName into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -669,6 +700,16 @@ func (v EnumWithDuplicateValues) MarshalLogObject(enc zapcore.ObjectEncoder) err
 // Ptr returns a pointer to this enum value.
 func (v EnumWithDuplicateValues) Ptr() *EnumWithDuplicateValues {
 	return &v
+}
+
+// Encode encodes EnumWithDuplicateValues directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumWithDuplicateValues
+//   return v.Encode(sWriter)
+func (v EnumWithDuplicateValues) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates EnumWithDuplicateValues into a Thrift-level intermediate
@@ -878,6 +919,16 @@ func (v EnumWithLabel) Ptr() *EnumWithLabel {
 	return &v
 }
 
+// Encode encodes EnumWithLabel directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumWithLabel
+//   return v.Encode(sWriter)
+func (v EnumWithLabel) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
+}
+
 // ToWire translates EnumWithLabel into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1074,6 +1125,16 @@ func (v EnumWithValues) Ptr() *EnumWithValues {
 	return &v
 }
 
+// Encode encodes EnumWithValues directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumWithValues
+//   return v.Encode(sWriter)
+func (v EnumWithValues) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
+}
+
 // ToWire translates EnumWithValues into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1266,6 +1327,16 @@ func (v RecordType) Ptr() *RecordType {
 	return &v
 }
 
+// Encode encodes RecordType directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v RecordType
+//   return v.Encode(sWriter)
+func (v RecordType) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
+}
+
 // ToWire translates RecordType into a Thrift-level intermediate
 // representation. This intermediate representation may be serialized
 // into bytes using a ThriftRW protocol implementation.
@@ -1439,6 +1510,16 @@ func (v RecordTypeValues) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v RecordTypeValues) Ptr() *RecordTypeValues {
 	return &v
+}
+
+// Encode encodes RecordTypeValues directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v RecordTypeValues
+//   return v.Encode(sWriter)
+func (v RecordTypeValues) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates RecordTypeValues into a Thrift-level intermediate
@@ -1621,6 +1702,30 @@ func (v *StructWithOptionalEnum) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a StructWithOptionalEnum struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a StructWithOptionalEnum struct could not be encoded.
+func (v *StructWithOptionalEnum) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.E != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := v.E.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a StructWithOptionalEnum
 // struct.
 func (v *StructWithOptionalEnum) String() string {
@@ -1773,6 +1878,16 @@ func (v LowerCaseEnum) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v LowerCaseEnum) Ptr() *LowerCaseEnum {
 	return &v
+}
+
+// Encode encodes LowerCaseEnum directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v LowerCaseEnum
+//   return v.Encode(sWriter)
+func (v LowerCaseEnum) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates LowerCaseEnum into a Thrift-level intermediate

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -6,6 +6,7 @@ package exceptions
 import (
 	errors "errors"
 	fmt "fmt"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -110,6 +111,40 @@ func (v *DoesNotExistException) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a DoesNotExistException struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a DoesNotExistException struct could not be encoded.
+func (v *DoesNotExistException) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Key); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Error2 != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Error2)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a DoesNotExistException
@@ -307,6 +342,40 @@ func (v *DoesNotExistException2) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a DoesNotExistException2 struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a DoesNotExistException2 struct could not be encoded.
+func (v *DoesNotExistException2) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Key); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Error2 != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Error2)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a DoesNotExistException2
 // struct.
 func (v *DoesNotExistException2) String() string {
@@ -445,6 +514,18 @@ func (v *EmptyException) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a EmptyException struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a EmptyException struct could not be encoded.
+func (v *EmptyException) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a EmptyException

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -8,6 +8,7 @@ import (
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
 	non_hyphenated "go.uber.org/thriftrw/gen/internal/tests/non_hyphenated"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -100,6 +101,31 @@ func (v *DocumentStruct) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a DocumentStruct struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a DocumentStruct struct could not be encoded.
+func (v *DocumentStruct) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Second == nil {
+		return errors.New("field Second of DocumentStruct is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.Second.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a DocumentStruct

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -8,6 +8,7 @@ import (
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
 	non_hyphenated "go.uber.org/thriftrw/gen/internal/tests/non_hyphenated"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -100,6 +101,31 @@ func (v *DocumentStructure) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a DocumentStructure struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a DocumentStructure struct could not be encoded.
+func (v *DocumentStructure) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.R2 == nil {
+		return errors.New("field R2 of DocumentStructure is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.R2.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a DocumentStructure

--- a/gen/internal/tests/non_hyphenated/non_hyphenated.go
+++ b/gen/internal/tests/non_hyphenated/non_hyphenated.go
@@ -5,6 +5,7 @@ package non_hyphenated
 
 import (
 	fmt "fmt"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -63,6 +64,18 @@ func (v *First) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a First struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a First struct could not be encoded.
+func (v *First) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a First
@@ -153,6 +166,18 @@ func (v *Second) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Second struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Second struct could not be encoded.
+func (v *Second) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Second

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -8,6 +8,7 @@ import (
 	json "encoding/json"
 	errors "errors"
 	fmt "fmt"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	math "math"
@@ -79,6 +80,16 @@ func (v EnumDefault) MarshalText() ([]byte, error) {
 // Ptr returns a pointer to this enum value.
 func (v EnumDefault) Ptr() *EnumDefault {
 	return &v
+}
+
+// Encode encodes EnumDefault directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v EnumDefault
+//   return v.Encode(sWriter)
+func (v EnumDefault) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates EnumDefault into a Thrift-level intermediate
@@ -629,6 +640,198 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_String_Encode(val []string, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Set_I32_mapType_Encode(val map[int32]struct{}, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		if err := sw.WriteInt32(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Map_I64_Double_Encode(val map[int64]float64, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI64,
+		ValueType: wire.TDouble,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteInt64(k); err != nil {
+			return err
+		}
+		if err := sw.WriteDouble(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a PrimitiveRequiredStruct struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a PrimitiveRequiredStruct struct could not be encoded.
+func (v *PrimitiveRequiredStruct) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBool}); err != nil {
+		return err
+	}
+	if err := sw.WriteBool(v.BoolField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI8}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt8(v.ByteField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TI16}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt16(v.Int16Field); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TI32}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt32(v.Int32Field); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TI64}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt64(v.Int64Field); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TDouble}); err != nil {
+		return err
+	}
+	if err := sw.WriteDouble(v.DoubleField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 7, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.StringField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.BinaryField == nil {
+		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 8, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteBinary(v.BinaryField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 9, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_String_Encode(v.ListOfStrings, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.SetOfInts == nil {
+		return errors.New("field SetOfInts of PrimitiveRequiredStruct is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 10, Type: wire.TSet}); err != nil {
+		return err
+	}
+	if err := _Set_I32_mapType_Encode(v.SetOfInts, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.MapOfIntsToDoubles == nil {
+		return errors.New("field MapOfIntsToDoubles of PrimitiveRequiredStruct is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 11, Type: wire.TMap}); err != nil {
+		return err
+	}
+	if err := _Map_I64_Double_Encode(v.MapOfIntsToDoubles, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a PrimitiveRequiredStruct
 // struct.
 func (v *PrimitiveRequiredStruct) String() string {
@@ -892,6 +1095,11 @@ func (v *Primitives) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v *Primitives) Encode(sw stream.Writer) error {
+	x := (*PrimitiveRequiredStruct)(v)
+	return x.Encode(sw)
+}
+
 // FromWire deserializes Primitives from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -919,6 +1127,11 @@ func (v StringList) ToWire() (wire.Value, error) {
 func (v StringList) String() string {
 	x := ([]string)(v)
 	return fmt.Sprint(x)
+}
+
+func (v StringList) Encode(sw stream.Writer) error {
+	x := ([]string)(v)
+	return _List_String_Encode(x, sw)
 }
 
 // FromWire deserializes StringList from its Thrift-level
@@ -970,6 +1183,29 @@ func (_Map_String_String_MapItemList) ValueType() wire.Type {
 }
 
 func (_Map_String_String_MapItemList) Close() {}
+
+func _Map_String_String_Encode(val map[string]string, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
 
 func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 	if m.KeyType() != wire.TBinary {
@@ -1030,6 +1266,11 @@ func (v StringMap) ToWire() (wire.Value, error) {
 func (v StringMap) String() string {
 	x := (map[string]string)(v)
 	return fmt.Sprint(x)
+}
+
+func (v StringMap) Encode(sw stream.Writer) error {
+	x := (map[string]string)(v)
+	return _Map_String_String_Encode(x, sw)
 }
 
 // FromWire deserializes StringMap from its Thrift-level

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -11,6 +11,7 @@ import (
 	multierr "go.uber.org/multierr"
 	exceptions "go.uber.org/thriftrw/gen/internal/tests/exceptions"
 	unions "go.uber.org/thriftrw/gen/internal/tests/unions"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -117,6 +118,41 @@ func (v *ConflictingNamesSetValueArgs) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a ConflictingNamesSetValueArgs struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ConflictingNamesSetValueArgs struct could not be encoded.
+func (v *ConflictingNamesSetValueArgs) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Key); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Value == nil {
+		return errors.New("field Value of ConflictingNamesSetValueArgs is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteBinary(v.Value); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ConflictingNamesSetValueArgs
@@ -267,6 +303,30 @@ func (v *InternalError) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a InternalError struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a InternalError struct could not be encoded.
+func (v *InternalError) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Message != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Message)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a InternalError
 // struct.
 func (v *InternalError) String() string {
@@ -369,6 +429,11 @@ func (v Key) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v Key) Encode(sw stream.Writer) error {
+	x := (string)(v)
+	return sw.WriteString(x)
+}
+
 // FromWire deserializes Key from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -454,6 +519,18 @@ func (v *Cache_Clear_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Cache_Clear_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Cache_Clear_Args struct could not be encoded.
+func (v *Cache_Clear_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Cache_Clear_Args
@@ -601,6 +678,30 @@ func (v *Cache_ClearAfter_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Cache_ClearAfter_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Cache_ClearAfter_Args struct could not be encoded.
+func (v *Cache_ClearAfter_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.DurationMS != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TI64}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt64(*(v.DurationMS)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Cache_ClearAfter_Args
@@ -793,6 +894,30 @@ func (v *ConflictingNames_SetValue_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a ConflictingNames_SetValue_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ConflictingNames_SetValue_Args struct could not be encoded.
+func (v *ConflictingNames_SetValue_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Request != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Request.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ConflictingNames_SetValue_Args
@@ -1003,6 +1128,18 @@ func (v *ConflictingNames_SetValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a ConflictingNames_SetValue_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ConflictingNames_SetValue_Result struct could not be encoded.
+func (v *ConflictingNames_SetValue_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a ConflictingNames_SetValue_Result
 // struct.
 func (v *ConflictingNames_SetValue_Result) String() string {
@@ -1138,6 +1275,30 @@ func (v *KeyValue_DeleteValue_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a KeyValue_DeleteValue_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_DeleteValue_Args struct could not be encoded.
+func (v *KeyValue_DeleteValue_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Key != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := v.Key.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_DeleteValue_Args
@@ -1449,6 +1610,54 @@ func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a KeyValue_DeleteValue_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_DeleteValue_Result struct could not be encoded.
+func (v *KeyValue_DeleteValue_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.DoesNotExist != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.DoesNotExist.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.InternalError != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.InternalError.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.DoesNotExist != nil {
+		count++
+	}
+	if v.InternalError != nil {
+		count++
+	}
+
+	if count > 1 {
+		return fmt.Errorf("KeyValue_DeleteValue_Result should have at most one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_DeleteValue_Result
 // struct.
 func (v *KeyValue_DeleteValue_Result) String() string {
@@ -1670,6 +1879,48 @@ func (v *KeyValue_GetManyValues_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _List_Key_Encode(val []Key, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a KeyValue_GetManyValues_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_GetManyValues_Args struct could not be encoded.
+func (v *KeyValue_GetManyValues_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Range != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_Key_Encode(v.Range, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_GetManyValues_Args
@@ -2035,6 +2286,72 @@ func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_ArbitraryValue_Encode(val []*unions.ArbitraryValue, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a KeyValue_GetManyValues_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_GetManyValues_Result struct could not be encoded.
+func (v *KeyValue_GetManyValues_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Success != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 0, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_ArbitraryValue_Encode(v.Success, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.DoesNotExist != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.DoesNotExist.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+	if v.DoesNotExist != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("KeyValue_GetManyValues_Result should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_GetManyValues_Result
 // struct.
 func (v *KeyValue_GetManyValues_Result) String() string {
@@ -2240,6 +2557,30 @@ func (v *KeyValue_GetValue_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a KeyValue_GetValue_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_GetValue_Args struct could not be encoded.
+func (v *KeyValue_GetValue_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Key != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := v.Key.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_GetValue_Args
@@ -2526,6 +2867,54 @@ func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a KeyValue_GetValue_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_GetValue_Result struct could not be encoded.
+func (v *KeyValue_GetValue_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Success != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 0, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Success.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.DoesNotExist != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.DoesNotExist.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+	if v.DoesNotExist != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("KeyValue_GetValue_Result should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_GetValue_Result
 // struct.
 func (v *KeyValue_GetValue_Result) String() string {
@@ -2722,6 +3111,42 @@ func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a KeyValue_SetValue_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_SetValue_Args struct could not be encoded.
+func (v *KeyValue_SetValue_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Key != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := v.Key.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Value != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Value.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_SetValue_Args
@@ -2960,6 +3385,18 @@ func (v *KeyValue_SetValue_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a KeyValue_SetValue_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_SetValue_Result struct could not be encoded.
+func (v *KeyValue_SetValue_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_SetValue_Result
 // struct.
 func (v *KeyValue_SetValue_Result) String() string {
@@ -3118,6 +3555,41 @@ func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a KeyValue_SetValueV2_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_SetValueV2_Args struct could not be encoded.
+func (v *KeyValue_SetValueV2_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := v.Key.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Value == nil {
+		return errors.New("field Value of KeyValue_SetValueV2_Args is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.Value.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_SetValueV2_Args
@@ -3341,6 +3813,18 @@ func (v *KeyValue_SetValueV2_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a KeyValue_SetValueV2_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_SetValueV2_Result struct could not be encoded.
+func (v *KeyValue_SetValueV2_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_SetValueV2_Result
 // struct.
 func (v *KeyValue_SetValueV2_Result) String() string {
@@ -3447,6 +3931,18 @@ func (v *KeyValue_Size_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a KeyValue_Size_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_Size_Args struct could not be encoded.
+func (v *KeyValue_Size_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a KeyValue_Size_Args
@@ -3670,6 +4166,39 @@ func (v *KeyValue_Size_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a KeyValue_Size_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a KeyValue_Size_Result struct could not be encoded.
+func (v *KeyValue_Size_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Success != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 0, Type: wire.TI64}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt64(*(v.Success)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("KeyValue_Size_Result should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a KeyValue_Size_Result
 // struct.
 func (v *KeyValue_Size_Result) String() string {
@@ -3801,6 +4330,18 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) FromWire(w wire.Va
 	}
 
 	return nil
+}
+
+// Encode serializes a NonStandardServiceName_NonStandardFunctionName_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a NonStandardServiceName_NonStandardFunctionName_Args struct could not be encoded.
+func (v *NonStandardServiceName_NonStandardFunctionName_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a NonStandardServiceName_NonStandardFunctionName_Args
@@ -3978,6 +4519,18 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) FromWire(w wire.
 	}
 
 	return nil
+}
+
+// Encode serializes a NonStandardServiceName_NonStandardFunctionName_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a NonStandardServiceName_NonStandardFunctionName_Result struct could not be encoded.
+func (v *NonStandardServiceName_NonStandardFunctionName_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a NonStandardServiceName_NonStandardFunctionName_Result

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -7,6 +7,7 @@ import (
 	errors "errors"
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -57,6 +58,11 @@ func (v AnotherStringList) ToWire() (wire.Value, error) {
 func (v AnotherStringList) String() string {
 	x := (MyStringList)(v)
 	return fmt.Sprint(x)
+}
+
+func (v AnotherStringList) Encode(sw stream.Writer) error {
+	x := (MyStringList)(v)
+	return x.Encode(sw)
 }
 
 // FromWire deserializes AnotherStringList from its Thrift-level
@@ -557,6 +563,224 @@ func (v *Bar) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _Set_I32_sliceType_Encode(val []int32, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		if err := sw.WriteInt32(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Set_String_sliceType_Encode(val []string, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Set_Foo_sliceType_Encode(val []*Foo, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+func _Set_Set_String_sliceType_sliceType_Encode(val [][]string, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TSet,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		if err := _Set_String_sliceType_Encode(v, sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
+
+// Encode serializes a Bar struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Bar struct could not be encoded.
+func (v *Bar) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.RequiredInt32ListField == nil {
+		return errors.New("field RequiredInt32ListField of Bar is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TSet}); err != nil {
+		return err
+	}
+	if err := _Set_I32_sliceType_Encode(v.RequiredInt32ListField, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.OptionalStringListField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := _Set_String_sliceType_Encode(v.OptionalStringListField, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.RequiredTypedefStringListField == nil {
+		return errors.New("field RequiredTypedefStringListField of Bar is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TSet}); err != nil {
+		return err
+	}
+	if err := v.RequiredTypedefStringListField.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.OptionalTypedefStringListField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := v.OptionalTypedefStringListField.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.RequiredFooListField == nil {
+		return errors.New("field RequiredFooListField of Bar is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TSet}); err != nil {
+		return err
+	}
+	if err := _Set_Foo_sliceType_Encode(v.RequiredFooListField, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.OptionalFooListField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := _Set_Foo_sliceType_Encode(v.OptionalFooListField, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.RequiredTypedefFooListField == nil {
+		return errors.New("field RequiredTypedefFooListField of Bar is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 7, Type: wire.TSet}); err != nil {
+		return err
+	}
+	if err := v.RequiredTypedefFooListField.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.OptionalTypedefFooListField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 8, Type: wire.TSet}); err != nil {
+			return err
+		}
+		if err := v.OptionalTypedefFooListField.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.RequiredStringListListField == nil {
+		return errors.New("field RequiredStringListListField of Bar is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 9, Type: wire.TSet}); err != nil {
+		return err
+	}
+	if err := _Set_Set_String_sliceType_sliceType_Encode(v.RequiredStringListListField, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.RequiredTypedefStringListListField == nil {
+		return errors.New("field RequiredTypedefStringListListField of Bar is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 10, Type: wire.TSet}); err != nil {
+		return err
+	}
+	if err := v.RequiredTypedefStringListListField.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Bar
 // struct.
 func (v *Bar) String() string {
@@ -1009,6 +1233,28 @@ func (v *Foo) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Foo struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Foo struct could not be encoded.
+func (v *Foo) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.StringField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Foo
 // struct.
 func (v *Foo) String() string {
@@ -1076,6 +1322,11 @@ func (v FooList) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v FooList) Encode(sw stream.Writer) error {
+	x := ([]*Foo)(v)
+	return _Set_Foo_sliceType_Encode(x, sw)
+}
+
 // FromWire deserializes FooList from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1109,6 +1360,11 @@ func (v MyStringList) ToWire() (wire.Value, error) {
 func (v MyStringList) String() string {
 	x := (StringList)(v)
 	return fmt.Sprint(x)
+}
+
+func (v MyStringList) Encode(sw stream.Writer) error {
+	x := (StringList)(v)
+	return x.Encode(sw)
 }
 
 // FromWire deserializes MyStringList from its Thrift-level
@@ -1146,6 +1402,11 @@ func (v StringList) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v StringList) Encode(sw stream.Writer) error {
+	x := ([]string)(v)
+	return _Set_String_sliceType_Encode(x, sw)
+}
+
 // FromWire deserializes StringList from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1179,6 +1440,11 @@ func (v StringListList) ToWire() (wire.Value, error) {
 func (v StringListList) String() string {
 	x := ([][]string)(v)
 	return fmt.Sprint(x)
+}
+
+func (v StringListList) Encode(sw stream.Writer) error {
+	x := ([][]string)(v)
+	return _Set_Set_String_sliceType_sliceType_Encode(x, sw)
 }
 
 // FromWire deserializes StringListList from its Thrift-level
@@ -1225,6 +1491,26 @@ func (_Set_String_mapType_ValueList) ValueType() wire.Type {
 }
 
 func (_Set_String_mapType_ValueList) Close() {}
+
+func _Set_String_mapType_Encode(val map[string]struct{}, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for v, _ := range val {
+
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
 
 func _Set_String_mapType_Read(s wire.ValueList) (map[string]struct{}, error) {
 	if s.ValueType() != wire.TBinary {
@@ -1284,6 +1570,11 @@ func (v StringSet) ToWire() (wire.Value, error) {
 func (v StringSet) String() string {
 	x := (map[string]struct{})(v)
 	return fmt.Sprint(x)
+}
+
+func (v StringSet) Encode(sw stream.Writer) error {
+	x := (map[string]struct{})(v)
+	return _Set_String_mapType_Encode(x, sw)
 }
 
 // FromWire deserializes StringSet from its Thrift-level

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -10,6 +10,7 @@ import (
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
 	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	ptr "go.uber.org/thriftrw/ptr"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
@@ -94,6 +95,28 @@ func (v *ContactInfo) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a ContactInfo struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ContactInfo struct could not be encoded.
+func (v *ContactInfo) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.EmailAddress); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ContactInfo
@@ -725,6 +748,271 @@ func (v *DefaultsStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_String_Encode(val []string, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _List_Double_Encode(val []float64, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TDouble,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := sw.WriteDouble(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a DefaultsStruct struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a DefaultsStruct struct could not be encoded.
+func (v *DefaultsStruct) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	vRequiredPrimitive := v.RequiredPrimitive
+	if vRequiredPrimitive == nil {
+		vRequiredPrimitive = ptr.Int32(100)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(*(vRequiredPrimitive)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalPrimitive := v.OptionalPrimitive
+	if vOptionalPrimitive == nil {
+		vOptionalPrimitive = ptr.Int32(200)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(*(vOptionalPrimitive)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredEnum := v.RequiredEnum
+	if vRequiredEnum == nil {
+		vRequiredEnum = _EnumDefault_ptr(enums.EnumDefaultBar)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := vRequiredEnum.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalEnum := v.OptionalEnum
+	if vOptionalEnum == nil {
+		vOptionalEnum = _EnumDefault_ptr(enums.EnumDefaultBaz)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := vOptionalEnum.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredList := v.RequiredList
+	if vRequiredList == nil {
+		vRequiredList = []string{
+			"hello",
+			"world",
+		}
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_String_Encode(vRequiredList, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalList := v.OptionalList
+	if vOptionalList == nil {
+		vOptionalList = []float64{
+			1,
+			2,
+			3,
+		}
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_Double_Encode(vOptionalList, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredStruct := v.RequiredStruct
+	if vRequiredStruct == nil {
+		vRequiredStruct = &Frame{
+			Size: &Size{
+				Height: 200,
+				Width:  100,
+			},
+			TopLeft: &Point{
+				X: 1,
+				Y: 2,
+			},
+		}
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 7, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := vRequiredStruct.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalStruct := v.OptionalStruct
+	if vOptionalStruct == nil {
+		vOptionalStruct = &Edge{
+			EndPoint: &Point{
+				X: 3,
+				Y: 4,
+			},
+			StartPoint: &Point{
+				X: 1,
+				Y: 2,
+			},
+		}
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 8, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := vOptionalStruct.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredBoolDefaultTrue := v.RequiredBoolDefaultTrue
+	if vRequiredBoolDefaultTrue == nil {
+		vRequiredBoolDefaultTrue = ptr.Bool(true)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 9, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(vRequiredBoolDefaultTrue)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalBoolDefaultTrue := v.OptionalBoolDefaultTrue
+	if vOptionalBoolDefaultTrue == nil {
+		vOptionalBoolDefaultTrue = ptr.Bool(true)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 10, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(vOptionalBoolDefaultTrue)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vRequiredBoolDefaultFalse := v.RequiredBoolDefaultFalse
+	if vRequiredBoolDefaultFalse == nil {
+		vRequiredBoolDefaultFalse = ptr.Bool(false)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 11, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(vRequiredBoolDefaultFalse)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	vOptionalBoolDefaultFalse := v.OptionalBoolDefaultFalse
+	if vOptionalBoolDefaultFalse == nil {
+		vOptionalBoolDefaultFalse = ptr.Bool(false)
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 12, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(vOptionalBoolDefaultFalse)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a DefaultsStruct
 // struct.
 func (v *DefaultsStruct) String() string {
@@ -1279,6 +1567,44 @@ func (v *Edge) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Edge struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Edge struct could not be encoded.
+func (v *Edge) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.StartPoint == nil {
+		return errors.New("field StartPoint of Edge is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.StartPoint.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.EndPoint == nil {
+		return errors.New("field EndPoint of Edge is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.EndPoint.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Edge
 // struct.
 func (v *Edge) String() string {
@@ -1407,6 +1733,18 @@ func (v *EmptyStruct) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a EmptyStruct struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a EmptyStruct struct could not be encoded.
+func (v *EmptyStruct) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a EmptyStruct
@@ -1554,6 +1892,44 @@ func (v *Frame) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Frame struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Frame struct could not be encoded.
+func (v *Frame) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.TopLeft == nil {
+		return errors.New("field TopLeft of Frame is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.TopLeft.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Size == nil {
+		return errors.New("field Size of Frame is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.Size.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Frame
@@ -1812,6 +2188,82 @@ func (v *GoTags) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a GoTags struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a GoTags struct could not be encoded.
+func (v *GoTags) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Foo); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Bar != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Bar)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.FooBar); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.FooBarWithSpace); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.FooBarWithOmitEmpty != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.FooBarWithOmitEmpty)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.FooBarWithRequired); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a GoTags
@@ -2100,6 +2552,46 @@ func (v *Graph) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_Edge_Encode(val []*Edge, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a Graph struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Graph struct could not be encoded.
+func (v *Graph) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_Edge_Encode(v.Edges, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Graph
 // struct.
 func (v *Graph) String() string {
@@ -2196,6 +2688,11 @@ func (v *List) ToWire() (wire.Value, error) {
 func (v *List) String() string {
 	x := (*Node)(v)
 	return fmt.Sprint(x)
+}
+
+func (v *List) Encode(sw stream.Writer) error {
+	x := (*Node)(v)
+	return x.Encode(sw)
 }
 
 // FromWire deserializes List from its Thrift-level
@@ -2317,6 +2814,40 @@ func (v *Node) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Node struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Node struct could not be encoded.
+func (v *Node) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TI32}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt32(v.Value); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Tail != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Tail.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Node
@@ -2658,6 +3189,137 @@ func (v *NotOmitEmpty) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _Map_String_String_Encode(val map[string]string, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a NotOmitEmpty struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a NotOmitEmpty struct could not be encoded.
+func (v *NotOmitEmpty) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.NotOmitEmptyString != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.NotOmitEmptyString)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyInt != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.NotOmitEmptyInt)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyBool != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.NotOmitEmptyBool)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyList != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_String_Encode(v.NotOmitEmptyList, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyMap != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_String_Encode(v.NotOmitEmptyMap, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyListMixedWithOmitEmpty != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_String_Encode(v.NotOmitEmptyListMixedWithOmitEmpty, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.NotOmitEmptyListMixedWithOmitEmptyV2 != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 7, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_String_Encode(v.NotOmitEmptyListMixedWithOmitEmptyV2, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.OmitEmptyString != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 8, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.OmitEmptyString)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a NotOmitEmpty
@@ -3024,6 +3686,38 @@ func (v *Omit) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Omit struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Omit struct could not be encoded.
+func (v *Omit) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Serialized); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Hidden); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Omit
 // struct.
 func (v *Omit) String() string {
@@ -3165,6 +3859,30 @@ func (v *PersonalInfo) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a PersonalInfo struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a PersonalInfo struct could not be encoded.
+func (v *PersonalInfo) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Age != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(*(v.Age)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a PersonalInfo
@@ -3327,6 +4045,38 @@ func (v *Point) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Point struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Point struct could not be encoded.
+func (v *Point) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TDouble}); err != nil {
+		return err
+	}
+	if err := sw.WriteDouble(v.X); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TDouble}); err != nil {
+		return err
+	}
+	if err := sw.WriteDouble(v.Y); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Point
@@ -3604,6 +4354,114 @@ func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a PrimitiveOptionalStruct struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a PrimitiveOptionalStruct struct could not be encoded.
+func (v *PrimitiveOptionalStruct) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.BoolField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(v.BoolField)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ByteField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI8}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt8(*(v.ByteField)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Int16Field != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TI16}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt16(*(v.Int16Field)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Int32Field != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt32(*(v.Int32Field)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Int64Field != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TI64}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt64(*(v.Int64Field)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.DoubleField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TDouble}); err != nil {
+			return err
+		}
+		if err := sw.WriteDouble(*(v.DoubleField)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.StringField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 7, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.StringField)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.BinaryField != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 8, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteBinary(v.BinaryField); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a PrimitiveOptionalStruct
@@ -4113,6 +4971,101 @@ func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a PrimitiveRequiredStruct struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a PrimitiveRequiredStruct struct could not be encoded.
+func (v *PrimitiveRequiredStruct) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBool}); err != nil {
+		return err
+	}
+	if err := sw.WriteBool(v.BoolField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI8}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt8(v.ByteField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TI16}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt16(v.Int16Field); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TI32}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt32(v.Int32Field); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TI64}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt64(v.Int64Field); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TDouble}); err != nil {
+		return err
+	}
+	if err := sw.WriteDouble(v.DoubleField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 7, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.StringField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.BinaryField == nil {
+		return errors.New("field BinaryField of PrimitiveRequiredStruct is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 8, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteBinary(v.BinaryField); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a PrimitiveRequiredStruct
 // struct.
 func (v *PrimitiveRequiredStruct) String() string {
@@ -4374,6 +5327,38 @@ func (v *Rename) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Rename struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Rename struct could not be encoded.
+func (v *Rename) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Default); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.CamelCase); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Rename
 // struct.
 func (v *Rename) String() string {
@@ -4541,6 +5526,38 @@ func (v *Size) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Size struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Size struct could not be encoded.
+func (v *Size) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TDouble}); err != nil {
+		return err
+	}
+	if err := sw.WriteDouble(v.Width); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TDouble}); err != nil {
+		return err
+	}
+	if err := sw.WriteDouble(v.Height); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Size
@@ -4741,6 +5758,66 @@ func (v *StructLabels) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a StructLabels struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a StructLabels struct could not be encoded.
+func (v *StructLabels) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.IsRequired != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(v.IsRequired)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Foo != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Foo)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Qux != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Qux)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Quux != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Quux)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a StructLabels
@@ -5004,6 +6081,52 @@ func (v *User) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a User struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a User struct could not be encoded.
+func (v *User) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Name); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Contact != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Contact.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Personal != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Personal.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a User
 // struct.
 func (v *User) String() string {
@@ -5143,6 +6266,29 @@ func (_Map_String_User_MapItemList) ValueType() wire.Type {
 
 func (_Map_String_User_MapItemList) Close() {}
 
+func _Map_String_User_Encode(val map[string]*User, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
 func _User_Read(w wire.Value) (*User, error) {
 	var v User
 	err := v.FromWire(w)
@@ -5219,6 +6365,11 @@ func (v UserMap) ToWire() (wire.Value, error) {
 func (v UserMap) String() string {
 	x := (map[string]*User)(v)
 	return fmt.Sprint(x)
+}
+
+func (v UserMap) Encode(sw stream.Writer) error {
+	x := (map[string]*User)(v)
+	return _Map_String_User_Encode(x, sw)
 }
 
 // FromWire deserializes UserMap from its Thrift-level
@@ -5338,6 +6489,38 @@ func (v *ZapOptOutStruct) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a ZapOptOutStruct struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ZapOptOutStruct struct could not be encoded.
+func (v *ZapOptOutStruct) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Name); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Optout); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ZapOptOutStruct

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -11,6 +11,7 @@ import (
 	multierr "go.uber.org/multierr"
 	enums "go.uber.org/thriftrw/gen/internal/tests/enums"
 	structs "go.uber.org/thriftrw/gen/internal/tests/structs"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -45,6 +46,26 @@ func (_Set_Binary_sliceType_ValueList) ValueType() wire.Type {
 }
 
 func (_Set_Binary_sliceType_ValueList) Close() {}
+
+func _Set_Binary_sliceType_Encode(val [][]byte, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TBinary,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		if err := sw.WriteBinary(v); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
 
 func _Set_Binary_sliceType_Read(s wire.ValueList) ([][]byte, error) {
 	if s.ValueType() != wire.TBinary {
@@ -111,6 +132,11 @@ func (v BinarySet) ToWire() (wire.Value, error) {
 func (v BinarySet) String() string {
 	x := ([][]byte)(v)
 	return fmt.Sprint(x)
+}
+
+func (v BinarySet) Encode(sw stream.Writer) error {
+	x := ([][]byte)(v)
+	return _Set_Binary_sliceType_Encode(x, sw)
 }
 
 // FromWire deserializes BinarySet from its Thrift-level
@@ -235,6 +261,34 @@ func (v *DefaultPrimitiveTypedef) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a DefaultPrimitiveTypedef struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a DefaultPrimitiveTypedef struct could not be encoded.
+func (v *DefaultPrimitiveTypedef) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	vState := v.State
+	if vState == nil {
+		vState = _State_ptr("hello")
+	}
+	{
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := vState.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a DefaultPrimitiveTypedef
 // struct.
 func (v *DefaultPrimitiveTypedef) String() string {
@@ -351,6 +405,34 @@ func (_Map_Edge_Edge_MapItemList) ValueType() wire.Type {
 }
 
 func (_Map_Edge_Edge_MapItemList) Close() {}
+
+func _Map_Edge_Edge_Encode(val []struct {
+	Key   *structs.Edge
+	Value *structs.Edge
+}, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TStruct,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		if err := key.Encode(sw); err != nil {
+			return err
+		}
+		value := v.Value
+		if err := value.Encode(sw); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
 
 func _Edge_Read(w wire.Value) (*structs.Edge, error) {
 	var v structs.Edge
@@ -480,6 +562,14 @@ func (v EdgeMap) String() string {
 		Value *structs.Edge
 	})(v)
 	return fmt.Sprint(x)
+}
+
+func (v EdgeMap) Encode(sw stream.Writer) error {
+	x := ([]struct {
+		Key   *structs.Edge
+		Value *structs.Edge
+	})(v)
+	return _Map_Edge_Edge_Encode(x, sw)
 }
 
 // FromWire deserializes EdgeMap from its Thrift-level
@@ -623,6 +713,43 @@ func (v *Event) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Event struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Event struct could not be encoded.
+func (v *Event) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.UUID == nil {
+		return errors.New("field UUID of Event is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.UUID.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Time != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI64}); err != nil {
+			return err
+		}
+		if err := v.Time.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Event
 // struct.
 func (v *Event) String() string {
@@ -743,6 +870,24 @@ func (_List_Event_ValueList) ValueType() wire.Type {
 
 func (_List_Event_ValueList) Close() {}
 
+func _List_Event_Encode(val []*Event, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
 func _Event_Read(w wire.Value) (*Event, error) {
 	var v Event
 	err := v.FromWire(w)
@@ -809,6 +954,11 @@ func (v EventGroup) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v EventGroup) Encode(sw stream.Writer) error {
+	x := ([]*Event)(v)
+	return _List_Event_Encode(x, sw)
+}
+
 // FromWire deserializes EventGroup from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -856,6 +1006,26 @@ func (_Set_Frame_sliceType_ValueList) ValueType() wire.Type {
 }
 
 func (_Set_Frame_sliceType_ValueList) Close() {}
+
+func _Set_Frame_sliceType_Encode(val []*structs.Frame, sw stream.Writer) error {
+
+	sh := stream.SetHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+
+	if err := sw.WriteSetBegin(sh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteSetEnd()
+}
 
 func _Frame_Read(w wire.Value) (*structs.Frame, error) {
 	var v structs.Frame
@@ -930,6 +1100,11 @@ func (v FrameGroup) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v FrameGroup) Encode(sw stream.Writer) error {
+	x := ([]*structs.Frame)(v)
+	return _Set_Frame_sliceType_Encode(x, sw)
+}
+
 // FromWire deserializes FrameGroup from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -976,6 +1151,11 @@ func (v MyEnum) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v MyEnum) Encode(sw stream.Writer) error {
+	x := (enums.EnumWithValues)(v)
+	return x.Encode(sw)
+}
+
 // FromWire deserializes MyEnum from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1011,6 +1191,11 @@ func (v *MyUUID) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v *MyUUID) Encode(sw stream.Writer) error {
+	x := (*UUID)(v)
+	return x.Encode(sw)
+}
+
 // FromWire deserializes MyUUID from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1042,6 +1227,11 @@ func (v PDF) ToWire() (wire.Value, error) {
 func (v PDF) String() string {
 	x := ([]byte)(v)
 	return fmt.Sprint(x)
+}
+
+func (v PDF) Encode(sw stream.Writer) error {
+	x := ([]byte)(v)
+	return sw.WriteBinary(x)
 }
 
 // FromWire deserializes PDF from its Thrift-level
@@ -1104,6 +1294,34 @@ func (_Map_Point_Point_MapItemList) ValueType() wire.Type {
 }
 
 func (_Map_Point_Point_MapItemList) Close() {}
+
+func _Map_Point_Point_Encode(val []struct {
+	Key   *structs.Point
+	Value *structs.Point
+}, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TStruct,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		key := v.Key
+		if err := key.Encode(sw); err != nil {
+			return err
+		}
+		value := v.Value
+		if err := value.Encode(sw); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
 
 func _Point_Read(w wire.Value) (*structs.Point, error) {
 	var v structs.Point
@@ -1235,6 +1453,14 @@ func (v PointMap) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v PointMap) Encode(sw stream.Writer) error {
+	x := ([]struct {
+		Key   *structs.Point
+		Value *structs.Point
+	})(v)
+	return _Map_Point_Point_Encode(x, sw)
+}
+
 // FromWire deserializes PointMap from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1282,6 +1508,11 @@ func (v State) ToWire() (wire.Value, error) {
 func (v State) String() string {
 	x := (string)(v)
 	return fmt.Sprint(x)
+}
+
+func (v State) Encode(sw stream.Writer) error {
+	x := (string)(v)
+	return sw.WriteString(x)
 }
 
 // FromWire deserializes State from its Thrift-level
@@ -1333,6 +1564,29 @@ func (_Map_State_I64_MapItemList) ValueType() wire.Type {
 }
 
 func (_Map_State_I64_MapItemList) Close() {}
+
+func _Map_State_I64_Encode(val map[State]int64, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TI64,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := k.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteInt64(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
 
 func _Map_State_I64_Read(m wire.MapItemList) (map[State]int64, error) {
 	if m.KeyType() != wire.TBinary {
@@ -1406,6 +1660,11 @@ func (v StateMap) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v StateMap) Encode(sw stream.Writer) error {
+	x := (map[State]int64)(v)
+	return _Map_State_I64_Encode(x, sw)
+}
+
 // FromWire deserializes StateMap from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -1447,6 +1706,11 @@ func (v Timestamp) ToWire() (wire.Value, error) {
 func (v Timestamp) String() string {
 	x := (int64)(v)
 	return fmt.Sprint(x)
+}
+
+func (v Timestamp) Encode(sw stream.Writer) error {
+	x := (int64)(v)
+	return sw.WriteInt64(x)
 }
 
 // FromWire deserializes Timestamp from its Thrift-level
@@ -1585,6 +1849,50 @@ func (v *Transition) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Transition struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Transition struct could not be encoded.
+func (v *Transition) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := v.FromState.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := v.ToState.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Events != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := v.Events.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Transition
@@ -1766,6 +2074,31 @@ func (v *TransitiveTypedefField) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a TransitiveTypedefField struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a TransitiveTypedefField struct could not be encoded.
+func (v *TransitiveTypedefField) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.DefUUID == nil {
+		return errors.New("field DefUUID of TransitiveTypedefField is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.DefUUID.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a TransitiveTypedefField
 // struct.
 func (v *TransitiveTypedefField) String() string {
@@ -1836,6 +2169,11 @@ func (v *UUID) ToWire() (wire.Value, error) {
 func (v *UUID) String() string {
 	x := (*I128)(v)
 	return fmt.Sprint(x)
+}
+
+func (v *UUID) Encode(sw stream.Writer) error {
+	x := (*I128)(v)
+	return x.Encode(sw)
 }
 
 // FromWire deserializes UUID from its Thrift-level
@@ -1953,6 +2291,38 @@ func (v *I128) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a I128 struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a I128 struct could not be encoded.
+func (v *I128) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TI64}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt64(v.High); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI64}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt64(v.Low); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a I128

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -8,6 +8,7 @@ import (
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
 	typedefs "go.uber.org/thriftrw/gen/internal/tests/typedefs"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -313,6 +314,140 @@ func (v *ArbitraryValue) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _List_ArbitraryValue_Encode(val []*ArbitraryValue, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Map_String_ArbitraryValue_Encode(val map[string]*ArbitraryValue, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a ArbitraryValue struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ArbitraryValue struct could not be encoded.
+func (v *ArbitraryValue) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.BoolValue != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(v.BoolValue)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Int64Value != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI64}); err != nil {
+			return err
+		}
+		if err := sw.WriteInt64(*(v.Int64Value)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.StringValue != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.StringValue)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ListValue != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_ArbitraryValue_Encode(v.ListValue, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapValue != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_ArbitraryValue_Encode(v.MapValue, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.BoolValue != nil {
+		count++
+	}
+	if v.Int64Value != nil {
+		count++
+	}
+	if v.StringValue != nil {
+		count++
+	}
+	if v.ListValue != nil {
+		count++
+	}
+	if v.MapValue != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("ArbitraryValue should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ArbitraryValue
@@ -675,6 +810,54 @@ func (v *Document) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Document struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Document struct could not be encoded.
+func (v *Document) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Pdf != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := v.Pdf.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.PlainText != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.PlainText)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.Pdf != nil {
+		count++
+	}
+	if v.PlainText != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("Document should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Document
 // struct.
 func (v *Document) String() string {
@@ -813,6 +996,18 @@ func (v *EmptyUnion) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a EmptyUnion struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a EmptyUnion struct could not be encoded.
+func (v *EmptyUnion) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a EmptyUnion

--- a/gen/list.go
+++ b/gen/list.go
@@ -140,6 +140,53 @@ func (l *listGenerator) Reader(g Generator, spec *compile.ListSpec) (string, err
 	return name, wrapGenerateError(spec.ThriftName(), err)
 }
 
+// Encoder generates a function to encode a list given a stream.Writer
+//
+//     func $name(val []listType, sr *stream.Writer) error {
+//             ...
+//     }
+//
+// And returns its name.
+func (l *listGenerator) Encode(g Generator, spec *compile.ListSpec) (string, error) {
+	name := encoderFuncName(g, spec)
+	err := g.EnsureDeclared(
+		`
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
+
+		<$listType := typeReference .Spec>
+		<$sw := newVar "sw">
+		<$lh := newVar "lh">
+		<$o := newVar "o">
+		<$k := newVar "k">
+		<$v := newVar "v">
+		<$val := newVar "val">
+		func <.Name>(<$val> <$listType>, <$sw> <$stream>.Writer) error {	
+			<$vt := typeCode .Spec.ValueSpec>
+			<$lh> := <$stream>.ListHeader{
+				Type: <$vt>,
+				Length: len(<$val>),
+			}
+			if err := <$sw>.WriteListBegin(<$lh>); err != nil {
+				return err
+			}
+
+			for _, <$v> := range <$val> {
+				if err := <encode .Spec.ValueSpec $v $sw>; err != nil {
+					return err
+				}
+			}
+			return <$sw>.WriteListEnd()
+		}
+		`,
+		struct {
+			Name string
+			Spec *compile.ListSpec
+		}{Name: name, Spec: spec},
+	)
+
+	return name, wrapGenerateError(spec.ThriftName(), err)
+}
+
 // Equals generates a function to compare lists of the given type
 //
 // 	func $name(lhs, rhs $listType) bool {

--- a/gen/list_test.go
+++ b/gen/list_test.go
@@ -163,6 +163,7 @@ func TestRoundtripOptionalListFields(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			// assertRoundTrip does more than we need as we only need to test wire.Value FromWire response.
 			assertRoundTrip(t, tt.want, tt.give, tt.desc)
+			testRoundTripCombos(t, tt.want, tt.give, tt.desc)
 		})
 	}
 }

--- a/gen/map.go
+++ b/gen/map.go
@@ -179,6 +179,66 @@ func (m *mapGenerator) Reader(g Generator, spec *compile.MapSpec) (string, error
 	return name, wrapGenerateError(spec.ThriftName(), err)
 }
 
+func (m *mapGenerator) Encode(g Generator, spec *compile.MapSpec) (string, error) {
+	name := encoderFuncName(g, spec)
+	err := g.EnsureDeclared(
+		`
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
+
+		<$mapType := typeReference .Spec>
+		<$sw := newVar "sw">
+		<$mh := newVar "mh">
+		<$o := newVar "o">
+		<$k := newVar "k">
+		<$v := newVar "v">
+		<$val := newVar "val">
+		<$key := newVar "key">
+		<$value := newVar "value">
+		func <.Name>(<$val> <$mapType>, <$sw> <$stream>.Writer) error {
+			<$kt := typeCode .Spec.KeySpec>
+			<$vt := typeCode .Spec.ValueSpec>	
+			<$mh> := <$stream>.MapHeader{
+				KeyType: <$kt>,
+				ValueType: <$vt>,
+				Length: len(<$val>),
+			}
+			if err := <$sw>.WriteMapBegin(<$mh>); err != nil {
+				return err
+			}
+
+			<if isHashable .Spec.KeySpec>
+				for <$k>, <$v> := range <$val> {
+					if err := <encode .Spec.KeySpec $k $sw>; err != nil {
+						return err
+					}
+					if err := <encode .Spec.ValueSpec $v $sw>; err != nil {
+						return err
+					}
+				}		
+			<else>
+				for _, <$v> := range <$val> {
+					<$key> := <printf "%s.Key" $v>
+					if err := <encode .Spec.KeySpec $key $sw>; err != nil {
+						return err
+					}
+					<$value> := <printf "%s.Value" $v>
+					if err := <encode .Spec.ValueSpec $value $sw>; err != nil {
+						return err
+					}
+				}
+			<end>
+			return <$sw>.WriteMapEnd()
+		}
+		`,
+		struct {
+			Name string
+			Spec *compile.MapSpec
+		}{Name: name, Spec: spec},
+	)
+
+	return name, wrapGenerateError(spec.ThriftName(), err)
+}
+
 // Equals generates a function to compare maps of the given type
 //
 // 	func $name(lhs, rhs $mapType) bool {

--- a/gen/roundtrip_test.go
+++ b/gen/roundtrip_test.go
@@ -26,10 +26,11 @@ import (
 	"reflect"
 	"testing"
 
-	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/protocol/binary"
+	"go.uber.org/thriftrw/wire"
 )
 
 // assertRoundTrip checks if x.ToWire() results in the given Value and whether
@@ -80,4 +81,56 @@ func assertBinaryRoundTrip(t *testing.T, w wire.Value, message string) (wire.Val
 	}
 
 	return newV, true
+}
+
+func testRoundTripCombos(t *testing.T, x thriftType, v wire.Value, msg string) {
+	t.Helper()
+
+	useStreaming := []struct {
+		encode bool
+		decode bool
+	}{
+		{false, false},
+		//{false, true},
+		{true, false},
+		//{true, true},
+	}
+
+	for _, streaming := range useStreaming {
+		name := fmt.Sprintf("%s: stream-encode: %v, stream-decode: %v", msg, streaming.encode, streaming.decode)
+		t.Run(name, func(t *testing.T) {
+			var buff bytes.Buffer
+
+			xType := reflect.TypeOf(x)
+			if xType.Kind() == reflect.Ptr {
+				xType = xType.Elem()
+			}
+
+			if streaming.encode {
+				w := binary.BorrowStreamWriter(&buff)
+				give, ok := x.(streamingThriftType)
+				require.True(t, ok)
+				require.NoError(t, give.Encode(w), "%v: failed to stream encode", msg)
+				binary.ReturnStreamWriter(w)
+			} else {
+				w, err := x.ToWire()
+				require.NoError(t, err, "failed to serialize: %v", x)
+				require.True(t, wire.ValuesAreEqual(v, w), "%v: %v.ToWire() != %v", msg, x, v)
+				require.NoError(t, protocol.Binary.Encode(w, &buff), "%v: failed to binary.Encode", msg)
+			}
+
+			if streaming.decode {
+				// TODO: Fill in with streaming decode implementation
+				t.Skip()
+			} else {
+				newV, err := protocol.Binary.Decode(bytes.NewReader(buff.Bytes()), v.Type())
+				require.NoError(t, err, "failed to deserialize")
+
+				gotX := reflect.New(xType).Interface().(thriftType)
+				require.NoError(t, gotX.FromWire(newV), "FromWire")
+				assert.Equal(t, x, gotX)
+			}
+		})
+	}
+
 }

--- a/gen/stream.go
+++ b/gen/stream.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gen
+
+import (
+	"fmt"
+
+	"go.uber.org/thriftrw/compile"
+)
+
+// StreamGenerator generates code that knows how to encode and decode Thrift
+// objects in a streaming fashion.
+type StreamGenerator struct {
+	mapG  mapGenerator
+	setG  setGenerator
+	listG listGenerator
+}
+
+// Encode generates code that knows how to serialize Thrift types into bytes.
+func (sg *StreamGenerator) Encode(g Generator, spec compile.TypeSpec, varName string, sw string) (string, error) {
+	switch s := spec.(type) {
+	case *compile.BoolSpec:
+		return fmt.Sprintf("%s.WriteBool(%s)", sw, varName), nil
+	case *compile.I8Spec:
+		return fmt.Sprintf("%s.WriteInt8(%s)", sw, varName), nil
+	case *compile.I16Spec:
+		return fmt.Sprintf("%s.WriteInt16(%s)", sw, varName), nil
+	case *compile.I32Spec:
+		return fmt.Sprintf("%s.WriteInt32(%s)", sw, varName), nil
+	case *compile.I64Spec:
+		return fmt.Sprintf("%s.WriteInt64(%s)", sw, varName), nil
+	case *compile.DoubleSpec:
+		return fmt.Sprintf("%s.WriteDouble(%s)", sw, varName), nil
+	case *compile.StringSpec:
+		return fmt.Sprintf("%s.WriteString(%s)", sw, varName), nil
+	case *compile.BinarySpec:
+		return fmt.Sprintf("%s.WriteBinary(%s)", sw, varName), nil
+	case *compile.MapSpec:
+		encoder, err := sg.mapG.Encode(g, s)
+		return fmt.Sprintf("%s(%s, %s)", encoder, varName, sw), err
+	case *compile.ListSpec:
+		encoder, err := sg.listG.Encode(g, s)
+		return fmt.Sprintf("%s(%s, %s)", encoder, varName, sw), err
+	case *compile.SetSpec:
+		encoder, err := sg.setG.Encode(g, s)
+		return fmt.Sprintf("%s(%s, %s)", encoder, varName, sw), err
+	default:
+		return fmt.Sprintf("%s.Encode(%s)", varName, sw), nil
+	}
+}
+
+// EncodePtr is the same as Encode except varName is expected to be a reference
+// to a value of the given type.
+func (sg *StreamGenerator) EncodePtr(g Generator, spec compile.TypeSpec, varName string, sw string) (string, error) {
+	switch spec.(type) {
+	case *compile.BoolSpec, *compile.I8Spec, *compile.I16Spec, *compile.I32Spec,
+		*compile.I64Spec, *compile.DoubleSpec, *compile.StringSpec:
+		return sg.Encode(g, spec, fmt.Sprintf("*(%s)", varName), sw)
+	default:
+		// Everything else is either a reference type or has an Encode method
+		// on it that does automatic dereferencing.
+		return sg.Encode(g, spec, varName, sw)
+	}
+}

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -471,6 +471,7 @@ func TestStructRoundTripAndString(t *testing.T) {
 		} else {
 			assert.NotPanics(t, func() { _ = tt.x.String() }, "ToString: %v", tt.desc)
 		}
+		testRoundTripCombos(t, tt.x, tt.v, tt.desc)
 	}
 }
 
@@ -651,7 +652,7 @@ func TestBasicException(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.s, tt.v, "DoesNotExistException")
-
+		testRoundTripCombos(t, &tt.s, tt.v, "DoesNotExistException")
 		err := error(&tt.s) // should implement the error interface
 		assert.Equal(t, "DoesNotExistException{Key: foo}", err.Error())
 	}
@@ -672,7 +673,7 @@ func TestCollisionException(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.s, tt.v, "DoesNotExistException2")
-
+		testRoundTripCombos(t, &tt.s, tt.v, "DoesNotExistException2")
 		assert.Equal(t, "Does_Not_Exist_Exception_Collision", tt.s.ErrorName(),
 			"Thrift name of exception incorrect")
 

--- a/gen/type.go
+++ b/gen/type.go
@@ -208,6 +208,10 @@ func valueListName(g Generator, spec compile.TypeSpec) string {
 	return fmt.Sprintf("_%s_ValueList", g.MangleType(spec))
 }
 
+func encoderFuncName(g Generator, spec compile.TypeSpec) string {
+	return fmt.Sprintf("_%s_Encode", g.MangleType(spec))
+}
+
 // zapperName returns the name that should be used for wrapper types that
 // implement zap.ObjectMarshaler or zap.ArrayMarshaler for the provided
 // Thrift type.

--- a/gen/typedef.go
+++ b/gen/typedef.go
@@ -57,6 +57,7 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 	err := g.DeclareFromTemplate(
 		`
 		<$fmt := import "fmt">
+		<$stream := import "go.uber.org/thriftrw/protocol/stream">
 		<$wire := import "go.uber.org/thriftrw/wire">
 		<$typedefType := typeReference .>
 
@@ -64,6 +65,7 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 
 		<$v := newVar "v">
 		<$x := newVar "x">
+		<$sw := newVar "sw">
 
 		<- if isPrimitiveType .>
 		// <typeName .>Ptr returns a pointer to a <$typedefType>
@@ -84,6 +86,11 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 		func (<$v> <$typedefType>) String() string {
 			<$x> := (<typeReference .Target>)(<$v>)
 			return <$fmt>.Sprint(<$x>)
+		}
+
+		func (<$v> <$typedefType>) Encode(<$sw> <$stream>.Writer) error {
+			<$x> := (<typeReference .Target>)(<$v>)
+			return <encode .Target $x $sw>
 		}
 
 		<$w := newVar "w">

--- a/gen/typedef_test.go
+++ b/gen/typedef_test.go
@@ -89,6 +89,7 @@ func TestTypedefString(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "State")
+		testRoundTripCombos(t, &tt.x, tt.v, "State")
 		assert.True(t, tt.x.Equals(tt.x), "State equal")
 	}
 }
@@ -126,6 +127,7 @@ func TestTypedefBinary(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "PDF")
+		testRoundTripCombos(t, &tt.x, tt.v, "PDF")
 		assert.True(t, tt.x.Equals(tt.x))
 	}
 }
@@ -162,6 +164,7 @@ func TestTypedefStruct(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, tt.x, tt.v, "UUID")
+		testRoundTripCombos(t, tt.x, tt.v, "UUID")
 		assert.True(t, tt.x.Equals(tt.x), "UUID equal")
 	}
 }
@@ -221,6 +224,7 @@ func TestTypedefContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "EventGroup")
+		testRoundTripCombos(t, &tt.x, tt.v, "EventGroup")
 		assert.True(t, tt.x.Equals(tt.x), "EventGroup equal")
 	}
 }
@@ -304,6 +308,7 @@ func TestUnhashableSetAlias(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "FrameGroup")
+		testRoundTripCombos(t, &tt.x, tt.v, "FrameGroup")
 		assert.True(t, tt.x.Equals(tt.x), "FrameGroup equal")
 	}
 }
@@ -401,6 +406,7 @@ func TestUnhashableMapKeyAlias(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "PointMap")
+		testRoundTripCombos(t, &tt.x, tt.v, "PointMap")
 		assert.True(t, tt.x.Equals(tt.x), "PointMap equal")
 	}
 }
@@ -483,6 +489,7 @@ func TestBinarySet(t *testing.T) {
 
 	for _, tt := range tests {
 		assertRoundTrip(t, &tt.x, tt.v, "BinarySet")
+		testRoundTripCombos(t, &tt.x, tt.v, "BinarySet")
 		assert.True(t, tt.x.Equals(tt.x), "BinarySet equal")
 	}
 }
@@ -563,17 +570,21 @@ func TestTypedefAnnotatedSetToSlice(t *testing.T) {
 	s := "[foo]"
 
 	assertRoundTrip(t, &a, l, "StringList")
+	testRoundTripCombos(t, &a, l, "StringList")
 	assert.True(t, a.Equals(b))
 	assert.Equal(t, s, a.String())
 
 	assertRoundTrip(t, &c, l, "MyStringList")
+	testRoundTripCombos(t, &c, l, "MyStringList")
 	assert.True(t, c.Equals(d))
 	assert.Equal(t, s, c.String())
 
 	assertRoundTrip(t, &e, l, "AnotherStringList")
+	testRoundTripCombos(t, &e, l, "AnotherStringList")
 	assert.True(t, e.Equals(f))
 	assert.Equal(t, s, e.String())
 
 	assertRoundTrip(t, &g, ll, "StringListList")
+	testRoundTripCombos(t, &g, ll, "StringListList")
 	assert.Equal(t, "[[foo]]", g.String())
 }

--- a/gen/util_for_test.go
+++ b/gen/util_for_test.go
@@ -23,6 +23,7 @@ package gen
 import (
 	"fmt"
 
+	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/thriftrw/wire"
 )
 
@@ -36,4 +37,14 @@ type thriftType interface {
 
 	ToWire() (wire.Value, error)
 	FromWire(wire.Value) error
+}
+
+// streamingThriftType is implemented by all generated types that know how to
+// write and read themselves to the Thrift Protocol, skipping over the
+// intermediary wire.Type
+type streamingThriftType interface {
+	thriftType
+
+	Encode(stream.Writer) error
+	//Decode(stream.Reader) error
 }

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -28,6 +28,7 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -189,6 +190,16 @@ func (v ExceptionType) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v ExceptionType) Ptr() *ExceptionType {
 	return &v
+}
+
+// Encode encodes ExceptionType directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v ExceptionType
+//   return v.Encode(sWriter)
+func (v ExceptionType) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates ExceptionType into a Thrift-level intermediate
@@ -424,6 +435,42 @@ func (v *TApplicationException) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a TApplicationException struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a TApplicationException struct could not be encoded.
+func (v *TApplicationException) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Message != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.Message)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Type != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := v.Type.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a TApplicationException

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -30,6 +30,7 @@ import (
 	errors "errors"
 	fmt "fmt"
 	multierr "go.uber.org/multierr"
+	stream "go.uber.org/thriftrw/protocol/stream"
 	thriftreflect "go.uber.org/thriftrw/thriftreflect"
 	wire "go.uber.org/thriftrw/wire"
 	zapcore "go.uber.org/zap/zapcore"
@@ -259,6 +260,76 @@ func (v *Argument) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _Map_String_String_Encode(val map[string]string, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := sw.WriteString(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a Argument struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Argument struct could not be encoded.
+func (v *Argument) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Name); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Type == nil {
+		return errors.New("field Type of Argument is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.Type.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Annotations != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_String_Encode(v.Annotations, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Argument
 // struct.
 func (v *Argument) String() string {
@@ -452,6 +523,16 @@ func (v Feature) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v Feature) Ptr() *Feature {
 	return &v
+}
+
+// Encode encodes Feature directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v Feature
+//   return v.Encode(sWriter)
+func (v Feature) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates Feature into a Thrift-level intermediate
@@ -814,6 +895,114 @@ func (v *Function) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _List_Argument_Encode(val []*Argument, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a Function struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Function struct could not be encoded.
+func (v *Function) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Name); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.ThriftName); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_Argument_Encode(v.Arguments, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.ReturnType != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.ReturnType.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Exceptions != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_Argument_Encode(v.Exceptions, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.OneWay != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TBool}); err != nil {
+			return err
+		}
+		if err := sw.WriteBool(*(v.OneWay)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.Annotations != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 7, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_String_Encode(v.Annotations, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Function
@@ -1493,6 +1682,168 @@ func (v *GenerateServiceRequest) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_ServiceID_Encode(val []ServiceID, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+func _Map_ServiceID_Service_Encode(val map[ServiceID]*Service, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI32,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := k.Encode(sw); err != nil {
+			return err
+		}
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _Map_ModuleID_Module_Encode(val map[ModuleID]*Module, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TI32,
+		ValueType: wire.TStruct,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := k.Encode(sw); err != nil {
+			return err
+		}
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+func _List_ModuleID_Encode(val []ModuleID, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a GenerateServiceRequest struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a GenerateServiceRequest struct could not be encoded.
+func (v *GenerateServiceRequest) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_ServiceID_Encode(v.RootServices, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Services == nil {
+		return errors.New("field Services of GenerateServiceRequest is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TMap}); err != nil {
+		return err
+	}
+	if err := _Map_ServiceID_Service_Encode(v.Services, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Modules == nil {
+		return errors.New("field Modules of GenerateServiceRequest is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TMap}); err != nil {
+		return err
+	}
+	if err := _Map_ModuleID_Module_Encode(v.Modules, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.PackagePrefix); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.ThriftRoot); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.RootModules != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TList}); err != nil {
+			return err
+		}
+		if err := _List_ModuleID_Encode(v.RootModules, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a GenerateServiceRequest
 // struct.
 func (v *GenerateServiceRequest) String() string {
@@ -1927,6 +2278,53 @@ func (v *GenerateServiceResponse) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _Map_String_Binary_Encode(val map[string][]byte, sw stream.Writer) error {
+
+	mh := stream.MapHeader{
+		KeyType:   wire.TBinary,
+		ValueType: wire.TBinary,
+		Length:    len(val),
+	}
+	if err := sw.WriteMapBegin(mh); err != nil {
+		return err
+	}
+
+	for k, v := range val {
+		if err := sw.WriteString(k); err != nil {
+			return err
+		}
+		if err := sw.WriteBinary(v); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteMapEnd()
+}
+
+// Encode serializes a GenerateServiceResponse struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a GenerateServiceResponse struct could not be encoded.
+func (v *GenerateServiceResponse) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Files != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_Binary_Encode(v.Files, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a GenerateServiceResponse
 // struct.
 func (v *GenerateServiceResponse) String() string {
@@ -2070,6 +2468,18 @@ func (v *HandshakeRequest) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a HandshakeRequest struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a HandshakeRequest struct could not be encoded.
+func (v *HandshakeRequest) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a HandshakeRequest
@@ -2307,6 +2717,78 @@ func (v *HandshakeResponse) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+func _List_Feature_Encode(val []Feature, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TI32,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a HandshakeResponse struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a HandshakeResponse struct could not be encoded.
+func (v *HandshakeResponse) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Name); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TI32}); err != nil {
+		return err
+	}
+	if err := sw.WriteInt32(v.APIVersion); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_Feature_Encode(v.Features, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.LibraryVersion != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.LibraryVersion)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a HandshakeResponse
@@ -2587,6 +3069,48 @@ func (v *Module) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Module struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Module struct could not be encoded.
+func (v *Module) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.ImportPath); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Directory); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.ThriftFilePath); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Module
 // struct.
 func (v *Module) String() string {
@@ -2689,6 +3213,11 @@ func (v ModuleID) ToWire() (wire.Value, error) {
 func (v ModuleID) String() string {
 	x := (int32)(v)
 	return fmt.Sprint(x)
+}
+
+func (v ModuleID) Encode(sw stream.Writer) error {
+	x := (int32)(v)
+	return sw.WriteInt32(x)
 }
 
 // FromWire deserializes ModuleID from its Thrift-level
@@ -2956,6 +3485,100 @@ func (v *Service) FromWire(w wire.Value) error {
 	return nil
 }
 
+func _List_Function_Encode(val []*Function, sw stream.Writer) error {
+
+	lh := stream.ListHeader{
+		Type:   wire.TStruct,
+		Length: len(val),
+	}
+	if err := sw.WriteListBegin(lh); err != nil {
+		return err
+	}
+
+	for _, v := range val {
+		if err := v.Encode(sw); err != nil {
+			return err
+		}
+	}
+	return sw.WriteListEnd()
+}
+
+// Encode serializes a Service struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Service struct could not be encoded.
+func (v *Service) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 7, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Name); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.ThriftName); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.ParentID != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := v.ParentID.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TList}); err != nil {
+		return err
+	}
+	if err := _List_Function_Encode(v.Functions, sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TI32}); err != nil {
+		return err
+	}
+	if err := v.ModuleID.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Annotations != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 8, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_String_Encode(v.Annotations, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Service
 // struct.
 func (v *Service) String() string {
@@ -3166,6 +3789,11 @@ func (v ServiceID) String() string {
 	return fmt.Sprint(x)
 }
 
+func (v ServiceID) Encode(sw stream.Writer) error {
+	x := (int32)(v)
+	return sw.WriteInt32(x)
+}
+
 // FromWire deserializes ServiceID from its Thrift-level
 // representation. The Thrift-level representation may be obtained
 // from a ThriftRW protocol implementation.
@@ -3317,6 +3945,16 @@ func (v SimpleType) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Ptr returns a pointer to this enum value.
 func (v SimpleType) Ptr() *SimpleType {
 	return &v
+}
+
+// Encode encodes SimpleType directly to bytes.
+//
+//   sWriter := BinaryStreamer.Writer(writer)
+//
+//   var v SimpleType
+//   return v.Encode(sWriter)
+func (v SimpleType) Encode(sw stream.Writer) error {
+	return sw.WriteInt32(int32(v))
 }
 
 // ToWire translates SimpleType into a Thrift-level intermediate
@@ -3663,6 +4301,114 @@ func (v *Type) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Type struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Type struct could not be encoded.
+func (v *Type) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.SimpleType != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TI32}); err != nil {
+			return err
+		}
+		if err := v.SimpleType.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.SliceType != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.SliceType.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.KeyValueSliceType != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.KeyValueSliceType.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.MapType != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 4, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.MapType.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.ReferenceType != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 5, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.ReferenceType.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.PointerType != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 6, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.PointerType.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.SimpleType != nil {
+		count++
+	}
+	if v.SliceType != nil {
+		count++
+	}
+	if v.KeyValueSliceType != nil {
+		count++
+	}
+	if v.MapType != nil {
+		count++
+	}
+	if v.ReferenceType != nil {
+		count++
+	}
+	if v.PointerType != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("Type should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Type
 // struct.
 func (v *Type) String() string {
@@ -3965,6 +4711,44 @@ func (v *TypePair) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a TypePair struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a TypePair struct could not be encoded.
+func (v *TypePair) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Left == nil {
+		return errors.New("field Left of TypePair is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.Left.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Right == nil {
+		return errors.New("field Right of TypePair is required")
+	}
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
+		return err
+	}
+	if err := v.Right.Encode(sw); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a TypePair
 // struct.
 func (v *TypePair) String() string {
@@ -4178,6 +4962,50 @@ func (v *TypeReference) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a TypeReference struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a TypeReference struct could not be encoded.
+func (v *TypeReference) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.Name); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TBinary}); err != nil {
+		return err
+	}
+	if err := sw.WriteString(v.ImportPath); err != nil {
+		return err
+	}
+	if err := sw.WriteFieldEnd(); err != nil {
+		return err
+	}
+
+	if v.Annotations != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 3, Type: wire.TMap}); err != nil {
+			return err
+		}
+		if err := _Map_String_String_Encode(v.Annotations, sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a TypeReference
 // struct.
 func (v *TypeReference) String() string {
@@ -4335,6 +5163,18 @@ func (v *Plugin_Goodbye_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Plugin_Goodbye_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Plugin_Goodbye_Args struct could not be encoded.
+func (v *Plugin_Goodbye_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Plugin_Goodbye_Args
@@ -4514,6 +5354,18 @@ func (v *Plugin_Goodbye_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Plugin_Goodbye_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Plugin_Goodbye_Result struct could not be encoded.
+func (v *Plugin_Goodbye_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Plugin_Goodbye_Result
 // struct.
 func (v *Plugin_Goodbye_Result) String() string {
@@ -4647,6 +5499,30 @@ func (v *Plugin_Handshake_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a Plugin_Handshake_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Plugin_Handshake_Args struct could not be encoded.
+func (v *Plugin_Handshake_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Request != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Request.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a Plugin_Handshake_Args
@@ -4905,6 +5781,39 @@ func (v *Plugin_Handshake_Result) FromWire(w wire.Value) error {
 	return nil
 }
 
+// Encode serializes a Plugin_Handshake_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a Plugin_Handshake_Result struct could not be encoded.
+func (v *Plugin_Handshake_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Success != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 0, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Success.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("Plugin_Handshake_Result should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
+}
+
 // String returns a readable string representation of a Plugin_Handshake_Result
 // struct.
 func (v *Plugin_Handshake_Result) String() string {
@@ -5063,6 +5972,30 @@ func (v *ServiceGenerator_Generate_Args) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a ServiceGenerator_Generate_Args struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ServiceGenerator_Generate_Args struct could not be encoded.
+func (v *ServiceGenerator_Generate_Args) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Request != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Request.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ServiceGenerator_Generate_Args
@@ -5319,6 +6252,39 @@ func (v *ServiceGenerator_Generate_Result) FromWire(w wire.Value) error {
 	}
 
 	return nil
+}
+
+// Encode serializes a ServiceGenerator_Generate_Result struct directly into bytes, without going
+// through an intermediary type.
+//
+// An error is returned if a ServiceGenerator_Generate_Result struct could not be encoded.
+func (v *ServiceGenerator_Generate_Result) Encode(sw stream.Writer) error {
+	if err := sw.WriteStructBegin(); err != nil {
+		return err
+	}
+
+	if v.Success != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 0, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.Success.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+
+	if count != 1 {
+		return fmt.Errorf("ServiceGenerator_Generate_Result should have exactly one field: got %v fields", count)
+	}
+
+	return sw.WriteStructEnd()
 }
 
 // String returns a readable string representation of a ServiceGenerator_Generate_Result


### PR DESCRIPTION
Creates the code generation for all the primitive types, enums, typedefs, structs, and container types. We use the same testing utils as the reader implementation in #496 (hopefully that will reduce rebase conflicts).