### PR TITLE
Expose stream protocol method to close Writer

### DIFF
--- a/gen/benchmark_test.go
+++ b/gen/benchmark_test.go
@@ -137,6 +137,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 			give, ok := bb.give.(streamingThriftType)
 			require.True(b, ok)
 			require.NoError(b, give.Encode(writer), "StreamEncode")
+			require.NoError(b, writer.Close(), "Close StreamWriter")
 		}
 	}
 

--- a/protocol/binary/stream_writer.go
+++ b/protocol/binary/stream_writer.go
@@ -231,3 +231,10 @@ func (sw *StreamWriter) WriteMapBegin(m stream.MapHeader) error {
 func (sw *StreamWriter) WriteMapEnd() error {
 	return nil
 }
+
+// Close frees up the resources used by the StreamWriter and returns it back
+// to the pool.
+func (sw *StreamWriter) Close() error {
+	ReturnStreamWriter(sw)
+	return nil
+}

--- a/protocol/stream/stream.go
+++ b/protocol/stream/stream.go
@@ -95,6 +95,7 @@ type Writer interface {
 	WriteSetEnd() error
 	WriteListBegin(l ListHeader) error
 	WriteListEnd() error
+	Close() error
 }
 
 // Reader defines an decoder for a Thrift value, implemented in a streaming


### PR DESCRIPTION
Provides a stream protocol method to close out the resources of the given Writer. 

The corresponding Close() method on Reader will be implemented in a follow-up PR.