### PR TITLE
Implement enveloping for Thrift streaming protocol

### DIFF
--- a/protocol/binary.go
+++ b/protocol/binary.go
@@ -21,6 +21,7 @@
 package protocol
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -101,6 +102,10 @@ var BinaryStreamer stream.Protocol
 //      an invalid request.
 var EnvelopeAgnosticBinary EnvelopeAgnosticProtocol
 
+// EnvelopeAgnosticBinaryStreamer is the streaming equivalent of an
+// EnvelopeAgnosticBinary.
+var EnvelopeAgnosticBinaryStreamer stream.EnvelopeAgnosticProtocol
+
 type errUnexpectedEnvelopeType wire.EnvelopeType
 
 func (e errUnexpectedEnvelopeType) Error() string {
@@ -111,6 +116,7 @@ func init() {
 	Binary = binaryProtocol{}
 	BinaryStreamer = binaryProtocol{}
 	EnvelopeAgnosticBinary = binaryProtocol{}
+	EnvelopeAgnosticBinaryStreamer = binaryProtocol{}
 }
 
 type binaryProtocol struct {
@@ -229,6 +235,72 @@ func (b binaryProtocol) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire
 	// identifiers, outside the 0-15 range.
 	val, err := b.Decode(r, wire.TStruct)
 	return val, NoEnvelopeResponder, err
+}
+
+// ReadRequestEnvelope reads off the request envelope (if present) from the Reader and
+// returns a stream.Reader for the caller to read off the remaining un-enveloped request struct.
+// Additionally, the method returns a stream.Responder for writing a response with
+// an envelope style of the request.
+//
+// The method allows a Thrift request handler to transparently
+// accept requests regardless of whether the caller is configured to submit envelopes.
+// The caller specifies the expected envelope type, one of OneWay or Unary,
+// on which the decoder asserts if the envelope is present.
+func (b binaryProtocol) ReadRequestEnvelope(et wire.EnvelopeType, r io.Reader) (stream.Reader, stream.Responder, error) {
+	var buf [2]byte
+
+	if count, _ := r.Read(buf[0:2]); count < 2 {
+		return b.Reader(bytes.NewReader(buf[:])), binary.NoEnvelopeStreamResponder, nil
+	}
+
+	// reset the Reader to properly read out the enveloping, if it exists;
+	// also, use a TeeReader to make sure that if there is no enveloping, we can
+	// reset it again.
+	var teeBuf bytes.Buffer
+	resetReader := io.MultiReader(bytes.NewReader(buf[:]), r)
+	teeReader := io.TeeReader(resetReader, &teeBuf)
+	sr := b.Reader(teeReader)
+
+	if buf[0] == 0x00 {
+		eh, err := b.readEnvelopeHeader(sr, et)
+		if err != nil {
+			return sr, binary.NoEnvelopeStreamResponder, err
+		}
+		return sr, &binary.EnvelopeV0StreamResponder{
+			Name:  eh.Name,
+			SeqID: eh.SeqID,
+		}, nil
+	}
+
+	if buf[0]&0x80 > 0 {
+		eh, err := b.readEnvelopeHeader(sr, et)
+		if err != nil {
+			return sr, binary.NoEnvelopeStreamResponder, err
+		}
+		return sr, &binary.EnvelopeV1StreamResponder{
+			Name:  eh.Name,
+			SeqID: eh.SeqID,
+		}, nil
+	}
+
+	// For anything else, the request is either not-enveloped or invalid, let the
+	// caller manage that data
+	noEnvReader := io.MultiReader(&teeBuf, resetReader)
+	noEnvSr := b.Reader(noEnvReader)
+	return noEnvSr, binary.NoEnvelopeStreamResponder, nil
+}
+
+func (b binaryProtocol) readEnvelopeHeader(sr stream.Reader, et wire.EnvelopeType) (stream.EnvelopeHeader, error) {
+	eh, err := sr.ReadEnvelopeBegin()
+	if err != nil {
+		return eh, err
+	}
+	if eh.Type != et {
+		return eh, errUnexpectedEnvelopeType(eh.Type)
+	}
+	err = sr.ReadEnvelopeEnd()
+	return eh, err
+
 }
 
 // noEnvelopeResponder responds to a request without an envelope.

--- a/protocol/binary/envelope.go
+++ b/protocol/binary/envelope.go
@@ -23,6 +23,7 @@ package binary
 import (
 	"fmt"
 
+	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/thriftrw/wire"
 )
 
@@ -33,17 +34,13 @@ const (
 
 // WriteEnveloped writes enveloped value using the strict envelope.
 func (bw *Writer) WriteEnveloped(e wire.Envelope) error {
-	version := uint32(version1) | uint32(e.Type)
-
-	if err := bw.sw.WriteInt32(int32(version)); err != nil {
-		return err
-	}
-
-	if err := bw.sw.WriteString(e.Name); err != nil {
-		return err
-	}
-
-	if err := bw.sw.WriteInt32(e.SeqID); err != nil {
+	if err := bw.sw.WriteEnvelopeBegin(
+		stream.EnvelopeHeader{
+			Name:  e.Name,
+			Type:  e.Type,
+			SeqID: e.SeqID,
+		},
+	); err != nil {
 		return err
 	}
 
@@ -53,15 +50,13 @@ func (bw *Writer) WriteEnveloped(e wire.Envelope) error {
 // WriteLegacyEnveloped writes enveloped value using the non-strict envelope
 // (non-strict lacks an envelope version).
 func (bw *Writer) WriteLegacyEnveloped(e wire.Envelope) error {
-	if err := bw.sw.WriteString(e.Name); err != nil {
-		return err
-	}
-
-	if err := bw.sw.writeByte(uint8(e.Type)); err != nil {
-		return err
-	}
-
-	if err := bw.sw.WriteInt32(e.SeqID); err != nil {
+	if err := bw.sw.WriteLegacyEnvelopeBegin(
+		stream.EnvelopeHeader{
+			Name:  e.Name,
+			Type:  e.Type,
+			SeqID: e.SeqID,
+		},
+	); err != nil {
 		return err
 	}
 

--- a/protocol/binary/stream_envelope.go
+++ b/protocol/binary/stream_envelope.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package binary
+
+import (
+	"fmt"
+	"io"
+
+	"go.uber.org/thriftrw/protocol/stream"
+	"go.uber.org/thriftrw/wire"
+)
+
+// WriteEnvelopeBegin writes the start of a strict envelope (contains an envelope version).
+func (sw *StreamWriter) WriteEnvelopeBegin(eh stream.EnvelopeHeader) error {
+	version := uint32(version1) | uint32(eh.Type)
+
+	if err := sw.WriteInt32(int32(version)); err != nil {
+		return err
+	}
+
+	if err := sw.WriteString(eh.Name); err != nil {
+		return err
+	}
+
+	return sw.WriteInt32(eh.SeqID)
+}
+
+// WriteEnvelopeEnd writes the "end" of an envelope. Since there is no ending
+// to an envelope, this is a no-op.
+func (sw *StreamWriter) WriteEnvelopeEnd() error {
+	return nil
+}
+
+// WriteLegacyEnvelopeBegin writes the start of a non-strict envelope (lacks an envelope version).
+func (sw *StreamWriter) WriteLegacyEnvelopeBegin(eh stream.EnvelopeHeader) error {
+	if err := sw.WriteString(eh.Name); err != nil {
+		return err
+	}
+
+	if err := sw.writeByte(uint8(eh.Type)); err != nil {
+		return err
+	}
+
+	return sw.WriteInt32(eh.SeqID)
+}
+
+// WriteLegacyEnvelopeEnd writes the "end" of a legacy envelope. Since there is
+// no ending to a legacy envelope, this is a no-op.
+func (sw *StreamWriter) WriteLegacyEnvelopeEnd() error {
+	return nil
+}
+
+// ReadEnvelopeBegin reads the start of an Apache Thrift envelope. Thrift supports
+// two kinds of envelopes: strict, and non-strict. See ReadEnveloped method
+// for more information on enveloping.
+func (sw *StreamReader) ReadEnvelopeBegin() (stream.EnvelopeHeader, error) {
+	var eh stream.EnvelopeHeader
+
+	val, err := sw.ReadInt32()
+	if err != nil {
+		return eh, err
+	}
+
+	if val > 0 {
+		if eh, err = sw.readNonStrictEnvelope(val); err != nil {
+			return eh, err
+		}
+	} else {
+		if eh, err = sw.readStrictEnvelope(val); err != nil {
+			return eh, err
+		}
+	}
+
+	seqID, err := sw.ReadInt32()
+	if err != nil {
+		return eh, err
+	}
+
+	eh.SeqID = seqID
+	return eh, nil
+}
+
+// readNonStrictEnvelope reads off a non-strict envelope as described by protocol.EnvelopeAgnosticProtocol.
+func (sw *StreamReader) readNonStrictEnvelope(length int32) (stream.EnvelopeHeader, error) {
+	var eh stream.EnvelopeHeader
+
+	buf := make([]byte, length)
+	for i := int32(0); i < length; i++ {
+		i8, err := sw.ReadInt8()
+		if err != nil {
+			return eh, err
+		}
+		buf[i] = byte(i8)
+	}
+
+	typ, err := sw.ReadInt8()
+	if err != nil {
+		return eh, err
+	}
+
+	eh.Name = string(buf)
+	eh.Type = wire.EnvelopeType(typ)
+	return eh, nil
+}
+
+func (sw *StreamReader) readStrictEnvelope(ver int32) (stream.EnvelopeHeader, error) {
+	var eh stream.EnvelopeHeader
+
+	if v := uint32(ver) & versionMask; v != version1 {
+		return eh, fmt.Errorf("cannot decode envelope of version: %v", v)
+	}
+
+	name, err := sw.ReadString()
+	if err != nil {
+		return eh, err
+	}
+
+	// Casting automatically truncates to the lowest 8 bits.
+	eh.Type = wire.EnvelopeType(ver)
+	eh.Name = name
+	return eh, nil
+}
+
+// ReadEnvelopeEnd reads the "end" of an envelope.  Since there is no real
+// envelope end, this is a no-op.
+func (sw *StreamReader) ReadEnvelopeEnd() error {
+	return nil
+}
+
+type noEnvelopeStreamResponder struct{}
+
+// NoEnvelopeStreamResponder responds to a request without an envelope.
+var NoEnvelopeStreamResponder stream.Responder = &noEnvelopeStreamResponder{}
+
+func (r noEnvelopeStreamResponder) WriteResponseEnvelope(et wire.EnvelopeType, w io.Writer) (stream.Writer, error) {
+	writer := BorrowStreamWriter(w)
+	return writer, nil
+}
+
+// EnvelopeV0StreamResponder responds to requests with a non-strict (un-versioned) envelope.
+type EnvelopeV0StreamResponder struct {
+	Name  string
+	SeqID int32
+}
+
+// WriteResponseEnvelope writes an envelope to the writer (non-strict envelope) and
+// returns a borrowed stream.Writer. Callers must call Close() on stream.Writer once finished.
+func (r EnvelopeV0StreamResponder) WriteResponseEnvelope(et wire.EnvelopeType, w io.Writer) (stream.Writer, error) {
+	writer := BorrowStreamWriter(w)
+	err := writer.WriteLegacyEnvelopeBegin(stream.EnvelopeHeader{
+		Name:  r.Name,
+		Type:  et,
+		SeqID: r.SeqID,
+	})
+	return writer, err
+}
+
+// EnvelopeV1StreamResponder responds to requests with a strict, version 1 envelope.
+type EnvelopeV1StreamResponder struct {
+	Name  string
+	SeqID int32
+}
+
+// WriteResponseEnvelope writes an envelope to the writer (strict envelope) and returns a
+// borrowed stream.Writer. Callers must call Close() on stream.Writer once finished.
+func (r EnvelopeV1StreamResponder) WriteResponseEnvelope(et wire.EnvelopeType, w io.Writer) (stream.Writer, error) {
+	writer := BorrowStreamWriter(w)
+	err := writer.WriteEnvelopeBegin(stream.EnvelopeHeader{
+		Name:  r.Name,
+		Type:  et,
+		SeqID: r.SeqID,
+	})
+	return writer, err
+}

--- a/protocol/stream/envelope.go
+++ b/protocol/stream/envelope.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package stream
+
+import (
+	"io"
+
+	"go.uber.org/thriftrw/wire"
+)
+
+// EnvelopeHeader represents the envelope of a response or a request which includes
+// metadata about the method, the type of data in the envelope, and the value.
+// It is equivalent of `wire.Envelope`, but for streaming purposes.
+type EnvelopeHeader struct {
+	Name  string
+	Type  wire.EnvelopeType
+	SeqID int32
+}
+
+// EnvelopeAgnosticProtocol is the streaming equivalent of protocol.EnvelopeAgnosticProtocol
+type EnvelopeAgnosticProtocol interface {
+	Protocol
+
+	// ReadRequestEnvelope reads off the request envelope (if present) from a Reader
+	// and returns a stream.Reader to read the remaining un-enveloped request struct.
+	// This allows a Thrift request handler to transparently read requests
+	// regardless of whether the caller is configured to submit envelopes.
+	// The caller specifies the expected EnvelopeType, either OneWay or Unary,
+	// on which the read asserts the specified envelope is present.
+	ReadRequestEnvelope(et wire.EnvelopeType, r io.Reader) (Reader, Responder, error)
+}
+
+// Responder captures how to respond to a request, concerning whether and what
+// kind of envelope style to use
+type Responder interface {
+	// WriteResponseEnvelope writes a response envelope to the Writer with the envelope
+	// style of the corresponding request, and returns a stream.Writer to write
+	// remaining un-enveloped response bytes. Once writing of the response is complete,
+	// whether successful or not (error), users must call Close() on the stream.Writer.
+	//
+	// The EnvelopeType should be either wire.Reply or wire.Exception.
+	WriteResponseEnvelope(et wire.EnvelopeType, w io.Writer) (Writer, error)
+}

--- a/protocol/stream/stream.go
+++ b/protocol/stream/stream.go
@@ -95,6 +95,12 @@ type Writer interface {
 	WriteSetEnd() error
 	WriteListBegin(l ListHeader) error
 	WriteListEnd() error
+
+	WriteEnvelopeBegin(eh EnvelopeHeader) error
+	WriteEnvelopeEnd() error
+	WriteLegacyEnvelopeBegin(eh EnvelopeHeader) error
+	WriteLegacyEnvelopeEnd() error
+
 	Close() error
 }
 
@@ -124,4 +130,7 @@ type Reader interface {
 
 	// Skip skips over the bytes of the wire type and any applicable headers.
 	Skip(w wire.Type) error
+
+	ReadEnvelopeBegin() (EnvelopeHeader, error)
+	ReadEnvelopeEnd() error
 }


### PR DESCRIPTION
Implements "EnvelopeAgnosticProtocol" interface method, "ReadRequestEnvelope", on the Thrift binary protocol. The ReadRequestEnvelope method reads off the request envelope (if present) from a reader and returns a stream.Reader for the caller to read off the remaining un-enveloped request struct. Additionally, the method returns a stream.Responder to provide a seamless way for the caller to write the response without having to manage the envelope.

Implements "stream.Responder" for protocol/stream package via three responder types. The Responder types are "NoEnvelopeStreamResponder" for no response envelopes, "EnvelopeV0StreamResponder" for  non-versioned response envelopes (legacy), and "EnvelopeV1StreamResponder" for versioned response envelopes.

Implements "stream.Writer" methods to write a legacy or versioned response envelope.