### PR TITLE
Define an Enveloper interface type for thrift types that can be stream encoded with an envelope

### DIFF
--- a/envelope/stream/envelope.go
+++ b/envelope/stream/envelope.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package stream
+
+import (
+	"go.uber.org/thriftrw/protocol/stream"
+	"go.uber.org/thriftrw/wire"
+)
+
+// Enveloper is the interface implemented by a type that can be written with
+// an envelope via a stream.Writer.
+type Enveloper interface {
+	MethodName() string
+	EnvelopeType() wire.EnvelopeType
+	Encode(stream.Writer) error
+}


### PR DESCRIPTION
The enveloper/stream Enveloper interface is implemented by a thrift type that can be written with an envelope via streaming (stream.Writer).