### PR TITLE
Add pooling to the stream reader so that resources can be returned to the system

### DIFF
--- a/gen/benchmark_test.go
+++ b/gen/benchmark_test.go
@@ -177,6 +177,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 
 			reader := protocol.BinaryStreamer.Reader(r)
 			require.NoError(b, give.Decode(reader), "Decode")
+			require.NoError(b, reader.Close(), "Close StreamReader")
 		}
 	}
 

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -773,9 +773,9 @@ func (q *quickSuite) testThriftRoundTripStreaming(t *testing.T, give, defaults t
 
 	got := reflect.New(gType).Interface().(streamingThriftType)
 
-	sr := binary.BorrowStreamReader(&buf)
+	sr := binary.NewStreamReader(&buf)
 	require.NoError(t, got.Decode(sr), "failed to streaming decode from %v", buf)
-	binary.ReturnStreamReader(sr)
+	require.NoError(t, sr.Close())
 
 	assert.Equal(t, want, got)
 	if shouldCheckForMutation {

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -773,8 +773,9 @@ func (q *quickSuite) testThriftRoundTripStreaming(t *testing.T, give, defaults t
 
 	got := reflect.New(gType).Interface().(streamingThriftType)
 
-	sr := binary.NewStreamReader(&buf)
-	require.NoError(t, got.Decode(&sr), "failed to streaming decode from %v", buf)
+	sr := binary.BorrowStreamReader(&buf)
+	require.NoError(t, got.Decode(sr), "failed to streaming decode from %v", buf)
+	binary.ReturnStreamReader(sr)
 
 	assert.Equal(t, want, got)
 	if shouldCheckForMutation {

--- a/protocol/binary.go
+++ b/protocol/binary.go
@@ -148,7 +148,7 @@ func (binaryProtocol) Writer(w io.Writer) stream.Writer {
 }
 
 func (binaryProtocol) Reader(r io.Reader) stream.Reader {
-	return binary.BorrowStreamReader(r)
+	return binary.NewStreamReader(r)
 }
 
 // DecodeRequest specializes Decode and replaces DecodeEnveloped for the

--- a/protocol/binary.go
+++ b/protocol/binary.go
@@ -148,8 +148,7 @@ func (binaryProtocol) Writer(w io.Writer) stream.Writer {
 }
 
 func (binaryProtocol) Reader(r io.Reader) stream.Reader {
-	sReader := binary.NewStreamReader(r)
-	return &sReader
+	return binary.BorrowStreamReader(r)
 }
 
 // DecodeRequest specializes Decode and replaces DecodeEnveloped for the

--- a/protocol/binary/lazy_list.go
+++ b/protocol/binary/lazy_list.go
@@ -21,6 +21,7 @@
 package binary
 
 import (
+	"io"
 	"sync"
 
 	"go.uber.org/thriftrw/wire"
@@ -48,7 +49,7 @@ func borrowLazyMapItemList() *lazyMapItemList {
 type lazyValueList struct {
 	count       int32
 	typ         wire.Type
-	reader      *reader
+	readerAt    io.ReaderAt
 	startOffset int64
 }
 
@@ -62,6 +63,8 @@ func (ll *lazyValueList) Size() int {
 
 func (ll *lazyValueList) ForEach(f func(wire.Value) error) error {
 	off := ll.startOffset
+	reader := newReader(ll.readerAt, off)
+	defer reader.close()
 
 	for i := int32(0); i < ll.count; i++ {
 		var (
@@ -69,7 +72,7 @@ func (ll *lazyValueList) ForEach(f func(wire.Value) error) error {
 			err error
 		)
 
-		val, off, err = ll.reader.ReadValue(ll.typ, off)
+		val, off, err = reader.ReadValue(ll.typ, off)
 		if err != nil {
 			return err
 		}
@@ -82,7 +85,7 @@ func (ll *lazyValueList) ForEach(f func(wire.Value) error) error {
 }
 
 func (ll *lazyValueList) Close() {
-	ll.reader = nil
+	ll.readerAt = nil
 	lazyValueListPool.Put(ll)
 }
 
@@ -91,7 +94,7 @@ func (ll *lazyValueList) Close() {
 type lazyMapItemList struct {
 	ktype, vtype wire.Type
 	count        int32
-	reader       *reader
+	readerAt     io.ReaderAt
 	startOffset  int64
 }
 
@@ -109,6 +112,8 @@ func (lm *lazyMapItemList) Size() int {
 
 func (lm *lazyMapItemList) ForEach(f func(wire.MapItem) error) error {
 	off := lm.startOffset
+	reader := newReader(lm.readerAt, off)
+	defer reader.close()
 
 	for i := int32(0); i < lm.count; i++ {
 		var (
@@ -116,12 +121,12 @@ func (lm *lazyMapItemList) ForEach(f func(wire.MapItem) error) error {
 			err  error
 		)
 
-		k, off, err = lm.reader.ReadValue(lm.ktype, off)
+		k, off, err = reader.ReadValue(lm.ktype, off)
 		if err != nil {
 			return err
 		}
 
-		v, off, err = lm.reader.ReadValue(lm.vtype, off)
+		v, off, err = reader.ReadValue(lm.vtype, off)
 		if err != nil {
 			return err
 		}
@@ -135,6 +140,6 @@ func (lm *lazyMapItemList) ForEach(f func(wire.MapItem) error) error {
 }
 
 func (lm *lazyMapItemList) Close() {
-	lm.reader = nil
+	lm.readerAt = nil
 	lazyMapItemListPool.Put(lm)
 }

--- a/protocol/binary/reader.go
+++ b/protocol/binary/reader.go
@@ -54,7 +54,7 @@ func newReader(r io.ReaderAt) reader {
 
 	return reader{
 		or: &or,
-		sr: NewStreamReader(&or),
+		sr: newStreamReader(&or),
 	}
 }
 

--- a/protocol/binary/stream_reader.go
+++ b/protocol/binary/stream_reader.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"sync"
 
 	"go.uber.org/thriftrw/internal/iface"
 	"go.uber.org/thriftrw/protocol/stream"
@@ -67,9 +68,31 @@ type StreamReader struct {
 	buffer [8]byte
 }
 
-// NewStreamReader returns a new StreamReader.
-func NewStreamReader(r io.Reader) StreamReader {
+// newStreamReader returns a new StreamReader.
+func newStreamReader(r io.Reader) StreamReader {
 	return StreamReader{reader: r}
+}
+
+var streamReaderPool = sync.Pool{
+	New: func() interface{} {
+		return &StreamReader{}
+	}}
+
+// BorrowStreamReader fetches a StreamReader from the system that will write
+// its output to the given io.Reader.
+//
+// This StreamReader must be returned back using ReturnStreamReader.
+func BorrowStreamReader(r io.Reader) *StreamReader {
+	streamReader := streamReaderPool.Get().(*StreamReader)
+	streamReader.reader = r
+	return streamReader
+}
+
+// ReturnStreamReader returns a previously borrowed StreamReader back to the
+// system.
+func ReturnStreamReader(sr *StreamReader) {
+	sr.reader = nil
+	streamReaderPool.Put(sr)
 }
 
 func (sr *StreamReader) read(bs []byte) (int, error) {
@@ -343,6 +366,13 @@ func (sr *StreamReader) Skip(t wire.Type) error {
 	default:
 		return decodeErrorf("unknown ttype %v", t)
 	}
+}
+
+// Close frees up the resources used by the StreamReader and returns it back
+// to the pool.
+func (sr *StreamReader) Close() error {
+	ReturnStreamReader(sr)
+	return nil
 }
 
 func (sr *StreamReader) skipStruct() error {

--- a/protocol/stream/stream.go
+++ b/protocol/stream/stream.go
@@ -121,6 +121,7 @@ type Reader interface {
 	ReadSetEnd() error
 	ReadMapBegin() (MapHeader, error)
 	ReadMapEnd() error
+	Close() error
 
 	// Skip skips over the bytes of the wire type and any applicable headers.
 	Skip(w wire.Type) error


### PR DESCRIPTION
Adds a sync.Pool to the StreamReader implementation to allow callers to borrow a StreamReader and return it after finishing work. 

The binary.Reader implementation continues to instantiate the StreamReader because the binary.Reader.ReadValue method cannot return a StreamReader to the system since methods on container types like ForEach need access to the StreamReader to iterate through items. `newStreamReader` is unexported to make it only usable by internal ThriftRW callers. External callers of the StreamReader should use protocol.BinaryStreamer.Reader(io.Reader) and the StreamReader.Close() method.

Based off of #510 