### PR TITLE
Rename 'BorrowStreamWriter' to 'NewStreamWriter'; unexport 'ReturnStreamWriter'

### DIFF
--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -762,9 +762,9 @@ func (q *quickSuite) testThriftRoundTripStreaming(t *testing.T, give, defaults t
 	sWant, ok := want.(streamingThriftType)
 	require.True(t, ok, "default thrift type must satisfy streaming requirements")
 
-	sw := binary.BorrowStreamWriter(&buf)
+	sw := binary.NewStreamWriter(&buf)
 	require.NoError(t, sGive.Encode(sw), "failed to streaming encode %v", sGive)
-	binary.ReturnStreamWriter(sw)
+	require.NoError(t, sw.Close())
 
 	gType := reflect.TypeOf(sGive)
 	if gType.Kind() == reflect.Ptr {

--- a/gen/roundtrip_test.go
+++ b/gen/roundtrip_test.go
@@ -109,11 +109,11 @@ func testRoundTripCombos(t *testing.T, x thriftType, v wire.Value, msg string) {
 			streamer := protocol.BinaryStreamer
 
 			if streaming.encode {
-				w := binary.BorrowStreamWriter(&buff)
+				w := binary.NewStreamWriter(&buff)
 				give, ok := x.(streamingThriftType)
 				require.True(t, ok)
 				require.NoError(t, give.Encode(w), "%v: failed to stream encode", msg)
-				binary.ReturnStreamWriter(w)
+				require.NoError(t, w.Close())
 			} else {
 				w, err := x.ToWire()
 				require.NoError(t, err, "failed to serialize: %v", x)

--- a/protocol/binary.go
+++ b/protocol/binary.go
@@ -144,7 +144,7 @@ func (binaryProtocol) DecodeEnveloped(r io.ReaderAt) (wire.Envelope, error) {
 }
 
 func (binaryProtocol) Writer(w io.Writer) stream.Writer {
-	return binary.BorrowStreamWriter(w)
+	return binary.NewStreamWriter(w)
 }
 
 func (binaryProtocol) Reader(r io.Reader) stream.Reader {

--- a/protocol/binary/stream_writer.go
+++ b/protocol/binary/stream_writer.go
@@ -46,19 +46,19 @@ type StreamWriter struct {
 	buffer [8]byte
 }
 
-// BorrowStreamWriter fetches a StreamWriter from the system that will write
+// NewStreamWriter fetches a StreamWriter from the system that will write
 // its output to the given io.Writer.
 //
 // This StreamWriter must be returned back using ReturnStreamWriter.
-func BorrowStreamWriter(w io.Writer) *StreamWriter {
+func NewStreamWriter(w io.Writer) *StreamWriter {
 	streamWriter := streamWriterPool.Get().(*StreamWriter)
 	streamWriter.writer = w
 	return streamWriter
 }
 
-// ReturnStreamWriter returns a previously borrowed StreamWriter back to the
+// returnStreamWriter returns a previously borrowed StreamWriter back to the
 // system.
-func ReturnStreamWriter(sw *StreamWriter) {
+func returnStreamWriter(sw *StreamWriter) {
 	sw.writer = nil
 	streamWriterPool.Put(sw)
 }
@@ -235,6 +235,6 @@ func (sw *StreamWriter) WriteMapEnd() error {
 // Close frees up the resources used by the StreamWriter and returns it back
 // to the pool.
 func (sw *StreamWriter) Close() error {
-	ReturnStreamWriter(sw)
+	returnStreamWriter(sw)
 	return nil
 }

--- a/protocol/binary/writer.go
+++ b/protocol/binary/writer.go
@@ -57,7 +57,7 @@ type Writer struct {
 //
 // This Writer must be returned back using ReturnWriter.
 func BorrowWriter(w io.Writer) *Writer {
-	streamWriter := BorrowStreamWriter(w)
+	streamWriter := NewStreamWriter(w)
 	writer := writerPool.Get().(*Writer)
 	writer.sw = streamWriter
 	return writer
@@ -67,7 +67,7 @@ func BorrowWriter(w io.Writer) *Writer {
 func ReturnWriter(w *Writer) {
 	sw := w.sw
 	w.sw = nil
-	ReturnStreamWriter(sw)
+	returnStreamWriter(sw)
 	writerPool.Put(w)
 }
 

--- a/protocol/binary_test.go
+++ b/protocol/binary_test.go
@@ -584,10 +584,10 @@ func TestStructBeginAndEndEncode(t *testing.T) {
 	var streamBuff bytes.Buffer
 
 	// Encode with Streaming protocol
-	w := binary.BorrowStreamWriter(&streamBuff)
+	w := binary.NewStreamWriter(&streamBuff)
 	require.NoError(t, w.WriteStructBegin())
 	require.NoError(t, w.WriteStructEnd())
-	binary.ReturnStreamWriter(w)
+	require.NoError(t, w.Close())
 
 	// Assert that encoded bytes are equivalent
 	assert.Equal(t, []byte{0x0}, streamBuff.Bytes())
@@ -720,14 +720,14 @@ func TestMapBeginEncode(t *testing.T) {
 	)
 
 	// Encode with Streaming protocol
-	w := binary.BorrowStreamWriter(&streamBuff)
+	w := binary.NewStreamWriter(&streamBuff)
 	err = w.WriteMapBegin(stream.MapHeader{
 		KeyType:   wire.TBinary,
 		ValueType: wire.TBool,
 		Length:    1,
 	})
 	require.NoError(t, err)
-	binary.ReturnStreamWriter(w)
+	require.NoError(t, w.Close())
 
 	// Assert that encoded bytes are equivalent
 	assert.Equal(t, []byte{0xb, 0x2, 0x0, 0x0, 0x0, 0x1}, streamBuff.Bytes())
@@ -844,13 +844,13 @@ func TestSetBeginEncode(t *testing.T) {
 	)
 
 	// Encode with Streaming protocol
-	w := binary.BorrowStreamWriter(&streamBuff)
+	w := binary.NewStreamWriter(&streamBuff)
 	err = w.WriteSetBegin(stream.SetHeader{
 		Type:   wire.TList,
 		Length: 1,
 	})
 	require.NoError(t, err)
-	binary.ReturnStreamWriter(w)
+	require.NoError(t, w.Close())
 
 	// Assert that encoded bytes are equivalent
 	assert.Equal(t, []byte{0xf, 0x0, 0x0, 0x0, 0x1}, streamBuff.Bytes())
@@ -999,13 +999,13 @@ func TestListBeginEncode(t *testing.T) {
 	)
 
 	// Encode with Streaming protocol
-	w := binary.BorrowStreamWriter(&streamBuff)
+	w := binary.NewStreamWriter(&streamBuff)
 	err = w.WriteListBegin(stream.ListHeader{
 		Type:   wire.TMap,
 		Length: 5,
 	})
 	require.NoError(t, err)
-	binary.ReturnStreamWriter(w)
+	require.NoError(t, w.Close())
 
 	// Assert that encoded bytes are equivalent
 	assert.Equal(t, []byte{0xd, 0x0, 0x0, 0x0, 0x5}, streamBuff.Bytes())


### PR DESCRIPTION
With #506 implementing a `Close()` for the `StreamWriter`, change the concepts
around the {con,de}structors to not use 'borrow'ing - hide these behind New and Close.