### PR TITLE
binary: Move Responders and Protocol into package

### DIFF
--- a/envelope/envelope_test.go
+++ b/envelope/envelope_test.go
@@ -29,7 +29,7 @@ import (
 	// without causing a circular dependency.
 	. "go.uber.org/thriftrw/envelope"
 
-	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/wire"
 
 	"github.com/golang/mock/gomock"
@@ -75,7 +75,7 @@ func TestWrite(t *testing.T) {
 		defer ctrl.Finish()
 
 		var buff bytes.Buffer
-		require.NoError(t, Write(protocol.Binary, &buff, 1234, enveloper))
+		require.NoError(t, Write(binary.Default, &buff, 1234, enveloper))
 		assert.Equal(t,
 			[]byte{
 				0x80, 0x01, 0x00, 0x01, // version|type:4 = 1 | call
@@ -97,7 +97,7 @@ func TestWrite(t *testing.T) {
 		errEnveloper.Err = fmt.Errorf("great sadness")
 
 		var buff bytes.Buffer
-		require.Error(t, Write(protocol.Binary, &buff, 1234, errEnveloper))
+		require.Error(t, Write(binary.Default, &buff, 1234, errEnveloper))
 	})
 }
 
@@ -197,7 +197,7 @@ func TestReadReply(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result, seqID, err := ReadReply(protocol.Binary, bytes.NewReader(tt.bs))
+		result, seqID, err := ReadReply(binary.Default, bytes.NewReader(tt.bs))
 		if tt.wantErr != "" {
 			if assert.Error(t, err, tt.desc) {
 				assert.Contains(t, err.Error(), tt.wantErr, "%v: error mismatch", tt.desc)

--- a/gen/benchmark_test.go
+++ b/gen/benchmark_test.go
@@ -9,6 +9,7 @@ import (
 	tc "go.uber.org/thriftrw/gen/internal/tests/containers"
 	ts "go.uber.org/thriftrw/gen/internal/tests/structs"
 	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/wire"
@@ -123,7 +124,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 
 			w, err := bb.give.ToWire()
 			require.NoError(b, err, "ToWire")
-			require.NoError(b, protocol.Binary.Encode(w, &buff), "Encode")
+			require.NoError(b, binary.Default.Encode(w, &buff), "Encode")
 		}
 	}
 
@@ -146,7 +147,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 		var buff bytes.Buffer
 		w, err := bb.give.ToWire()
 		require.NoError(b, err, "ToWire")
-		require.NoError(b, protocol.Binary.Encode(w, &buff), "Encode")
+		require.NoError(b, binary.Default.Encode(w, &buff), "Encode")
 
 		r := bytes.NewReader(buff.Bytes())
 
@@ -154,7 +155,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			r.Seek(0, 0)
 
-			wval, err := protocol.Binary.Decode(r, wire.TStruct)
+			wval, err := binary.Default.Decode(r, wire.TStruct)
 			require.NoError(b, err, "Decode")
 
 			require.NoError(b, bb.give.FromWire(wval), "FromWire")

--- a/gen/collision_test.go
+++ b/gen/collision_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	tc "go.uber.org/thriftrw/gen/internal/tests/collision"
-	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/wire"
 
@@ -539,11 +539,11 @@ func roundTrip(t *testing.T, give thriftType, want thriftType, msg string) thrif
 	}
 
 	var buff bytes.Buffer
-	if !assert.NoError(t, protocol.Binary.Encode(v, &buff), "%v: failed to serialize", msg) {
+	if !assert.NoError(t, binary.Default.Encode(v, &buff), "%v: failed to serialize", msg) {
 		return nil
 	}
 
-	newV, err := protocol.Binary.Decode(bytes.NewReader(buff.Bytes()), v.Type())
+	newV, err := binary.Default.Decode(bytes.NewReader(buff.Bytes()), v.Type())
 	if !assert.NoError(t, err, "%v: failed to deserialize", msg) {
 		return nil
 	}

--- a/gen/roundtrip_test.go
+++ b/gen/roundtrip_test.go
@@ -67,11 +67,11 @@ func assertRoundTrip(t *testing.T, x thriftType, v wire.Value, msg string, args 
 // assertBinaryRoundTrip checks that De/Encode returns the same value.
 func assertBinaryRoundTrip(t *testing.T, w wire.Value, message string) (wire.Value, bool) {
 	var buff bytes.Buffer
-	if !assert.NoError(t, protocol.Binary.Encode(w, &buff), "%v: failed to serialize", message) {
+	if !assert.NoError(t, binary.Default.Encode(w, &buff), "%v: failed to serialize", message) {
 		return w, false
 	}
 
-	newV, err := protocol.Binary.Decode(bytes.NewReader(buff.Bytes()), w.Type())
+	newV, err := binary.Default.Decode(bytes.NewReader(buff.Bytes()), w.Type())
 	if !assert.NoError(t, err, "%v: failed to deserialize", message) {
 		return newV, false
 	}

--- a/gen/service_test.go
+++ b/gen/service_test.go
@@ -31,7 +31,7 @@ import (
 	tx "go.uber.org/thriftrw/gen/internal/tests/exceptions"
 	tv "go.uber.org/thriftrw/gen/internal/tests/services"
 	tu "go.uber.org/thriftrw/gen/internal/tests/unions"
-	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/wire"
 
@@ -542,12 +542,12 @@ func TestServiceTypesEnveloper(t *testing.T) {
 
 	for _, tt := range tests {
 		buf := &bytes.Buffer{}
-		err := envelope.Write(protocol.Binary, buf, 1234, tt.s)
+		err := envelope.Write(binary.Default, buf, 1234, tt.s)
 		require.NoError(t, err, "envelope.Write for %v failed", tt)
 
 		// Decode the payload and validate the payload.
 		reader := bytes.NewReader(buf.Bytes())
-		envelope, err := protocol.Binary.DecodeEnveloped(reader)
+		envelope, err := binary.Default.DecodeEnveloped(reader)
 		require.NoError(t, err, "Failed to read enveloped data for %v", tt)
 
 		expected := tt.wantEnvelope

--- a/internal/plugin/transport.go
+++ b/internal/plugin/transport.go
@@ -25,16 +25,15 @@ import (
 	"io"
 	"strings"
 
+	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 	"go.uber.org/thriftrw/internal/envelope"
 	"go.uber.org/thriftrw/internal/multiplex"
 	"go.uber.org/thriftrw/plugin/api"
-	"go.uber.org/thriftrw/protocol"
-
-	"go.uber.org/atomic"
-	"go.uber.org/multierr"
+	"go.uber.org/thriftrw/protocol/binary"
 )
 
-var _proto = protocol.Binary
+var _proto = binary.Default
 
 // transportHandle is a Handle to a plugin which is behind an envelope.Transport.
 type transportHandle struct {

--- a/internal/plugin/transport_test.go
+++ b/internal/plugin/transport_test.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/thriftrw/internal/multiplex"
 	"go.uber.org/thriftrw/plugin/api"
 	"go.uber.org/thriftrw/plugin/plugintest"
-	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/version"
 
@@ -46,7 +46,7 @@ func newFakePluginServer(mockCtrl *gomock.Controller) *fakePluginServer {
 
 	done := make(chan error)
 	go func() {
-		err := server.Serve(envelope.NewServer(protocol.Binary, handler))
+		err := server.Serve(envelope.NewServer(binary.Default, handler))
 		if err != nil {
 			done <- err
 		}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -29,12 +29,12 @@ import (
 	"go.uber.org/thriftrw/internal/frame"
 	"go.uber.org/thriftrw/internal/multiplex"
 	"go.uber.org/thriftrw/plugin/api"
-	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/version"
 )
 
-var _proto = protocol.Binary
+var _proto = binary.Default
 
 // Plugin defines a ThriftRW plugin.
 //

--- a/protocol/binary.go
+++ b/protocol/binary.go
@@ -31,7 +31,7 @@ import (
 // Binary implements the Thrift Binary Protocol.
 // Binary can be cast up to EnvelopeAgnosticProtocol to support DecodeRequest.
 //
-// Deprecated: binary.Default.
+// Deprecated: Don't use this directly. Use binary.Default.
 var Binary Protocol
 
 // BinaryStreamer implements a streaming version of the Thrift Binary Protocol.

--- a/protocol/binary.go
+++ b/protocol/binary.go
@@ -21,10 +21,8 @@
 package protocol
 
 import (
-	"fmt"
 	"io"
 
-	"go.uber.org/thriftrw/internal/iface"
 	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/thriftrw/wire"
@@ -32,6 +30,8 @@ import (
 
 // Binary implements the Thrift Binary Protocol.
 // Binary can be cast up to EnvelopeAgnosticProtocol to support DecodeRequest.
+//
+// Deprecated: binary.Default.
 var Binary Protocol
 
 // BinaryStreamer implements a streaming version of the Thrift Binary Protocol.
@@ -101,181 +101,32 @@ var BinaryStreamer stream.Protocol
 //      an invalid request.
 var EnvelopeAgnosticBinary EnvelopeAgnosticProtocol
 
-type errUnexpectedEnvelopeType wire.EnvelopeType
-
-func (e errUnexpectedEnvelopeType) Error() string {
-	return fmt.Sprintf("unexpected envelope type: %v", wire.EnvelopeType(e))
-}
-
 func init() {
-	Binary = binaryProtocol{}
-	BinaryStreamer = binaryProtocol{}
-	EnvelopeAgnosticBinary = binaryProtocol{}
+	Binary = binary.Default
+	BinaryStreamer = binary.Default
+	EnvelopeAgnosticBinary = binaryAdapter{binary.Default}
 }
 
-type binaryProtocol struct {
-	iface.Private
-}
+// adapts binary.Protocol (which returns a binary.Responder) into
+// protocol.Protocol (which returns a protocol.Responder).
+type binaryAdapter struct{ *binary.Protocol }
 
-func (binaryProtocol) Encode(v wire.Value, w io.Writer) error {
-	writer := binary.BorrowWriter(w)
-	err := writer.WriteValue(v)
-	binary.ReturnWriter(writer)
-	return err
-}
-
-func (binaryProtocol) Decode(r io.ReaderAt, t wire.Type) (wire.Value, error) {
-	reader := binary.NewReader(r)
-	value, _, err := reader.ReadValue(t, 0)
-	return value, err
-}
-
-func (binaryProtocol) EncodeEnveloped(e wire.Envelope, w io.Writer) error {
-	writer := binary.BorrowWriter(w)
-	err := writer.WriteEnveloped(e)
-	binary.ReturnWriter(writer)
-	return err
-}
-
-func (binaryProtocol) DecodeEnveloped(r io.ReaderAt) (wire.Envelope, error) {
-	reader := binary.NewReader(r)
-	e, err := reader.ReadEnveloped()
-	return e, err
-}
-
-func (binaryProtocol) Writer(w io.Writer) stream.Writer {
-	return binary.NewStreamWriter(w)
-}
-
-func (binaryProtocol) Reader(r io.Reader) stream.Reader {
-	return binary.NewStreamReader(r)
-}
-
-// DecodeRequest specializes Decode and replaces DecodeEnveloped for the
-// specific purpose of decoding request structs that may or may not have an
-// envelope.
-// This allows a Thrift request handler to transparently accept requests
-// regardless of whether the caller submits an envelope.
-// The caller specifies the expected envelope type, one of OneWay or Unary, on
-// which the decoder asserts if the envelope is present.
-//
-// This is possible because we can distinguish an envelope from a bare request
-// struct by looking at the first byte and the length of the message.
-//
-// 1. A message of length 1 containing only 0x00 can only be an empty struct.
-// 0x00 is the type ID for STOP, indicating the end of the struct.
-//
-// 2. A message of length >1 starting with 0x00 can only be a non-strict
-// envelope (not versioned), assuming the message name is less than 16MB long.
-// In this case, the first four bytes indicate the length of the method name,
-// which is unlikely to overflow into the high byte.
-//
-// 3. A message of length >1, where the first byte is <0 can only be a strict envelope.
-// The MSB indicates that the message is versioned. Reading the first two bytes
-// and masking out the MSB indicates the version number.
-// At this time, there is only one version.
-//
-// 4. A message of length >1, where the first byte is >=0 can only be a bare
-// struct starting with that field identifier. Valid field identifiers today
-// are in the range 0x00-0x0f. There is some chance that a future version of
-// the protocol will add more field types, but it is very unlikely that the
-// field type will flow into the MSB (128 type identifiers, starting with the
-// 15 valid types today).
-func (b binaryProtocol) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Value, Responder, error) {
-	var buf [2]byte
-
-	// If we fail to read two bytes, the only possible valid value is the empty struct.
-	if count, _ := r.ReadAt(buf[0:2], 0); count < 2 {
-		val, err := b.Decode(r, wire.TStruct)
-		return val, NoEnvelopeResponder, err
-	}
-
-	// If length > 1, 0x00 is only a valid preamble for a non-strict enveloped request.
-	if buf[0] == 0x00 {
-		e, err := b.DecodeEnveloped(r)
-		if err != nil {
-			return wire.Value{}, NoEnvelopeResponder, err
-		}
-		if e.Type != et {
-			return wire.Value{}, NoEnvelopeResponder, errUnexpectedEnvelopeType(e.Type)
-		}
-		return e.Value, &EnvelopeV0Responder{
-			Name:  e.Name,
-			SeqID: e.SeqID,
-		}, nil
-	}
-
-	// Only strict (versioned) envelopes begin with the most significant bit set.
-	// This could only be confused for a type identifier greater than 127
-	// (beyond the 15 Thrift has at time of writing), or a message name longer
-	// than 16MB.
-	if buf[0]&0x80 > 0 {
-		e, err := b.DecodeEnveloped(r)
-		if err != nil {
-			return wire.Value{}, NoEnvelopeResponder, err
-		}
-		if e.Type != et {
-			return wire.Value{}, NoEnvelopeResponder, errUnexpectedEnvelopeType(e.Type)
-		}
-		return e.Value, &EnvelopeV1Responder{
-			Name:  e.Name,
-			SeqID: e.SeqID,
-		}, nil
-	}
-
-	// All other patterns are either bare structs or invalid.
-	// We delegate to the struct decoder to distinguish invalid type
-	// identifiers, outside the 0-15 range.
-	val, err := b.Decode(r, wire.TStruct)
-	return val, NoEnvelopeResponder, err
-}
-
-// noEnvelopeResponder responds to a request without an envelope.
-type noEnvelopeResponder struct{}
-
-func (noEnvelopeResponder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
-	return Binary.Encode(v, w)
+func (b binaryAdapter) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Value, Responder, error) {
+	v, res, err := b.Protocol.DecodeRequest(et, r)
+	return v, res, err
 }
 
 // NoEnvelopeResponder responds to a request without an envelope.
-var NoEnvelopeResponder Responder = &noEnvelopeResponder{}
+//
+// Deprecated: Don't use this directly. Use DecodeRequest.
+var NoEnvelopeResponder Responder = binary.NoEnvelopeResponder
 
 // EnvelopeV0Responder responds to requests with a non-strict (unversioned) envelope.
-type EnvelopeV0Responder struct {
-	Name  string
-	SeqID int32
-}
-
-// EncodeResponse writes the response to the writer using a non-strict
-// envelope.
-func (r EnvelopeV0Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
-	writer := binary.BorrowWriter(w)
-	err := writer.WriteLegacyEnveloped(wire.Envelope{
-		Name:  r.Name,
-		Type:  t,
-		SeqID: r.SeqID,
-		Value: v,
-	})
-	binary.ReturnWriter(writer)
-	return err
-}
+//
+// Deprecated: Don't use this directly. Use DecodeRequest.
+type EnvelopeV0Responder = binary.EnvelopeV0Responder
 
 // EnvelopeV1Responder responds to requests with a strict, version 1 envelope.
-type EnvelopeV1Responder struct {
-	Name  string
-	SeqID int32
-}
-
-// EncodeResponse writes the response to the writer using a strict, version 1
-// envelope.
-func (r EnvelopeV1Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
-	writer := binary.BorrowWriter(w)
-	err := writer.WriteEnveloped(wire.Envelope{
-		Name:  r.Name,
-		Type:  t,
-		SeqID: r.SeqID,
-		Value: v,
-	})
-	binary.ReturnWriter(writer)
-	return err
-}
+//
+// Deprecated: Don't use this directly. Use DecodeRequest.
+type EnvelopeV1Responder = binary.EnvelopeV1Responder

--- a/protocol/binary/protocol.go
+++ b/protocol/binary/protocol.go
@@ -52,10 +52,14 @@ func (*Protocol) Decode(r io.ReaderAt, t wire.Type) (wire.Value, error) {
 	return value, err
 }
 
+// Writer builds a stream writer that writes to the provided stream using the
+// Thrift Binary Protocol.
 func (*Protocol) Writer(w io.Writer) stream.Writer {
 	return NewStreamWriter(w)
 }
 
+// Reader builds a stream reader that reads from the provided stream using the
+// Thrift Binary Protocol.
 func (*Protocol) Reader(r io.Reader) stream.Reader {
 	return NewStreamReader(r)
 }

--- a/protocol/binary/protocol.go
+++ b/protocol/binary/protocol.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package binary
+
+import (
+	"fmt"
+	"io"
+
+	"go.uber.org/thriftrw/internal/iface"
+	"go.uber.org/thriftrw/protocol/stream"
+	"go.uber.org/thriftrw/wire"
+)
+
+// Default is the default implementation of the Thrift Binary Protocol.
+var Default = new(Protocol)
+
+// Protocol implements the Thrift Binary Protocol.
+type Protocol struct {
+	iface.Private
+}
+
+// Encode the given Value and write the result to the given Writer.
+func (*Protocol) Encode(v wire.Value, w io.Writer) error {
+	writer := BorrowWriter(w)
+	err := writer.WriteValue(v)
+	ReturnWriter(writer)
+	return err
+}
+
+// Decode reads a Value of the given type from the given Reader.
+func (*Protocol) Decode(r io.ReaderAt, t wire.Type) (wire.Value, error) {
+	reader := NewReader(r)
+	value, _, err := reader.ReadValue(t, 0)
+	return value, err
+}
+
+func (*Protocol) Writer(w io.Writer) stream.Writer {
+	return NewStreamWriter(w)
+}
+
+func (*Protocol) Reader(r io.Reader) stream.Reader {
+	return NewStreamReader(r)
+}
+
+// EncodeEnveloped encodes the enveloped value and writes the result
+// to the given Writer.
+func (*Protocol) EncodeEnveloped(e wire.Envelope, w io.Writer) error {
+	writer := BorrowWriter(w)
+	err := writer.WriteEnveloped(e)
+	ReturnWriter(writer)
+	return err
+}
+
+// DecodeEnveloped reads an enveloped value from the given Reader.
+// Enveloped values are assumed to be TStructs.
+func (*Protocol) DecodeEnveloped(r io.ReaderAt) (wire.Envelope, error) {
+	reader := NewReader(r)
+	e, err := reader.ReadEnveloped()
+	return e, err
+}
+
+// DecodeRequest specializes Decode and replaces DecodeEnveloped for the
+// specific purpose of decoding request structs that may or may not have an
+// envelope.
+// This allows a Thrift request handler to transparently accept requests
+// regardless of whether the caller submits an envelope.
+// The caller specifies the expected envelope type, one of OneWay or Unary, on
+// which the decoder asserts if the envelope is present.
+//
+// This is possible because we can distinguish an envelope from a bare request
+// struct by looking at the first byte and the length of the message.
+//
+// 1. A message of length 1 containing only 0x00 can only be an empty struct.
+// 0x00 is the type ID for STOP, indicating the end of the struct.
+//
+// 2. A message of length >1 starting with 0x00 can only be a non-strict
+// envelope (not versioned), assuming the message name is less than 16MB long.
+// In this case, the first four bytes indicate the length of the method name,
+// which is unlikely to overflow into the high byte.
+//
+// 3. A message of length >1, where the first byte is <0 can only be a strict envelope.
+// The MSB indicates that the message is versioned. Reading the first two bytes
+// and masking out the MSB indicates the version number.
+// At this time, there is only one version.
+//
+// 4. A message of length >1, where the first byte is >=0 can only be a bare
+// struct starting with that field identifier. Valid field identifiers today
+// are in the range 0x00-0x0f. There is some chance that a future version of
+// the protocol will add more field types, but it is very unlikely that the
+// field type will flow into the MSB (128 type identifiers, starting with the
+// 15 valid types today).
+func (p *Protocol) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Value, Responder, error) {
+	var buf [2]byte
+
+	// If we fail to read two bytes, the only possible valid value is the empty struct.
+	if count, _ := r.ReadAt(buf[0:2], 0); count < 2 {
+		val, err := p.Decode(r, wire.TStruct)
+		return val, NoEnvelopeResponder, err
+	}
+
+	// If length > 1, 0x00 is only a valid preamble for a non-strict enveloped request.
+	if buf[0] == 0x00 {
+		e, err := p.DecodeEnveloped(r)
+		if err != nil {
+			return wire.Value{}, NoEnvelopeResponder, err
+		}
+		if e.Type != et {
+			return wire.Value{}, NoEnvelopeResponder, errUnexpectedEnvelopeType(e.Type)
+		}
+		return e.Value, &EnvelopeV0Responder{
+			Name:  e.Name,
+			SeqID: e.SeqID,
+		}, nil
+	}
+
+	// Only strict (versioned) envelopes begin with the most significant bit set.
+	// This could only be confused for a type identifier greater than 127
+	// (beyond the 15 Thrift has at time of writing), or a message name longer
+	// than 16MB.
+	if buf[0]&0x80 > 0 {
+		e, err := p.DecodeEnveloped(r)
+		if err != nil {
+			return wire.Value{}, NoEnvelopeResponder, err
+		}
+		if e.Type != et {
+			return wire.Value{}, NoEnvelopeResponder, errUnexpectedEnvelopeType(e.Type)
+		}
+		return e.Value, &EnvelopeV1Responder{
+			Name:  e.Name,
+			SeqID: e.SeqID,
+		}, nil
+	}
+
+	// All other patterns are either bare structs or invalid.
+	// We delegate to the struct decoder to distinguish invalid type
+	// identifiers, outside the 0-15 range.
+	val, err := p.Decode(r, wire.TStruct)
+	return val, NoEnvelopeResponder, err
+}
+
+// Responder captures how to respond to a request, concerning whether and what
+// kind of envelope to use, how to match the sequence identifier of the
+// corresponding request.
+type Responder interface {
+	EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error
+}
+
+// noEnvelopeResponder responds to a request without an envelope.
+type noEnvelopeResponder struct{}
+
+func (noEnvelopeResponder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
+	return Default.Encode(v, w)
+}
+
+// NoEnvelopeResponder responds to a request without an envelope.
+var NoEnvelopeResponder = &noEnvelopeResponder{}
+
+// EnvelopeV0Responder responds to requests with a non-strict (unversioned) envelope.
+type EnvelopeV0Responder struct {
+	Name  string
+	SeqID int32
+}
+
+// EncodeResponse writes the response to the writer using a non-strict
+// envelope.
+func (r EnvelopeV0Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
+	writer := BorrowWriter(w)
+	err := writer.WriteLegacyEnveloped(wire.Envelope{
+		Name:  r.Name,
+		Type:  t,
+		SeqID: r.SeqID,
+		Value: v,
+	})
+	ReturnWriter(writer)
+	return err
+}
+
+// EnvelopeV1Responder responds to requests with a strict, version 1 envelope.
+type EnvelopeV1Responder struct {
+	Name  string
+	SeqID int32
+}
+
+// EncodeResponse writes the response to the writer using a strict, version 1
+// envelope.
+func (r EnvelopeV1Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
+	writer := BorrowWriter(w)
+	err := writer.WriteEnveloped(wire.Envelope{
+		Name:  r.Name,
+		Type:  t,
+		SeqID: r.SeqID,
+		Value: v,
+	})
+	ReturnWriter(writer)
+	return err
+}
+
+type errUnexpectedEnvelopeType wire.EnvelopeType
+
+func (e errUnexpectedEnvelopeType) Error() string {
+	return fmt.Sprintf("unexpected envelope type: %v", wire.EnvelopeType(e))
+}


### PR DESCRIPTION
In #512 it came up that the `*Responder` types in the protocol package
belong in the protocol/binary package because they're binary-specific.
We found that we cannot move the types into the `binary` package because
`EnvelopeAgnosticProtocol.DecodeRequest` returns a `protocol.Responder`,
which causes an import cycle between protocol and protocol/binary.

This change moves the implementation of the binary protocol, all its
methods, and all responder implementations into a binary/protocol.go
file, including the DecodeRequest method and exposes the raw Protocol
type so that we're not limited by an interface.

To get around the import cycle, we redeclare the Responder interface in
the binary package, and adapt the type from a binary.Protocol into a
protocol.Protocol using an unexported type.

Per apidiff, the net effect of these changes is:

```
--- go.uber.org/thriftrw/protocol/binary ---
Compatible changes:
- Default: added
- EnvelopeV0Responder: added
- EnvelopeV1Responder: added
- NoEnvelopeResponder: added
- Protocol: added
- Responder: added
```

So nothing changes in the top-level `protocol` package (besides some
deprecations) and the `binary` package exports a bunch of new types.

Caveat: I would have preferred not to export the `*Responder` types and
return a `Responder` struct instead of the interface, but unfortunately,
ur hands are tied because of exporting the responder implementations
originally. So `binary.Protocol.ReadRequest` has to be able to return
one of the three Responder types, which is what necessitates the
interface.
