### PR TITLE
binary/reader: Return to pool after ReadValue

### DIFF
--- a/protocol/binary/reader.go
+++ b/protocol/binary/reader.go
@@ -256,5 +256,6 @@ func NewReader(r io.ReaderAt) Reader {
 // Returns the Value, the new offset, and an error if there was a decode error.
 func (br *Reader) ReadValue(t wire.Type, off int64) (wire.Value, int64, error) {
 	reader := newReader(br.reader, off)
+	defer reader.close()
 	return reader.ReadValue(t, off)
 }


### PR DESCRIPTION
We need to return the `*reader` to the pool after reading from it inside
the non-streaming wire.Value reader.

I ran this the decode benchmarks with a `-count 10`.

```
name                                                  old time/op    new time/op    delta
RoundTrip/PrimitiveOptionalStruct/Decode-4              2.97µs ± 1%    2.89µs ± 2%  -2.73%  (p=0.000 n=8+9)
RoundTrip/PrimitiveOptionalStruct/Streaming_Decode-4    1.88µs ± 2%    1.84µs ± 4%  -1.74%  (p=0.013 n=9+9)
RoundTrip/Graph/Decode-4                                9.83µs ± 4%    9.62µs ± 1%  -2.11%  (p=0.000 n=9+9)
RoundTrip/Graph/Streaming_Decode-4                      2.73µs ± 2%    2.63µs ± 2%  -3.69%  (p=0.000 n=9+9)
RoundTrip/ContainersOfContainers/Decode-4                130µs ± 2%     136µs ±15%    ~     (p=0.912 n=10+10)
RoundTrip/ContainersOfContainers/Streaming_Decode-4     30.3µs ± 2%    30.2µs ± 2%    ~     (p=0.489 n=9+9)

name                                                  old alloc/op   new alloc/op   delta
RoundTrip/PrimitiveOptionalStruct/Decode-4              1.45kB ± 0%    1.40kB ± 0%  -3.31%  (p=0.000 n=10+10)
RoundTrip/PrimitiveOptionalStruct/Streaming_Decode-4     56.0B ± 0%     56.0B ± 0%    ~     (all equal)
RoundTrip/Graph/Decode-4                                3.57kB ± 0%    3.52kB ± 0%  -1.34%  (p=0.000 n=9+9)
RoundTrip/Graph/Streaming_Decode-4                        168B ± 0%      168B ± 0%    ~     (all equal)
RoundTrip/ContainersOfContainers/Decode-4               29.4kB ± 0%    29.3kB ± 0%  -0.16%  (p=0.000 n=10+10)
RoundTrip/ContainersOfContainers/Streaming_Decode-4     10.1kB ± 0%    10.1kB ± 0%    ~     (p=0.973 n=10+10)

name                                                  old allocs/op  new allocs/op  delta
RoundTrip/PrimitiveOptionalStruct/Decode-4                15.0 ± 0%      14.0 ± 0%  -6.67%  (p=0.000 n=10+10)
RoundTrip/PrimitiveOptionalStruct/Streaming_Decode-4      10.0 ± 0%      10.0 ± 0%    ~     (all equal)
RoundTrip/Graph/Decode-4                                  64.0 ± 0%      63.0 ± 0%  -1.56%  (p=0.000 n=10+10)
RoundTrip/Graph/Streaming_Decode-4                        10.0 ± 0%      10.0 ± 0%    ~     (all equal)
RoundTrip/ContainersOfContainers/Decode-4                  873 ± 0%       872 ± 0%  -0.11%  (p=0.000 n=10+10)
RoundTrip/ContainersOfContainers/Streaming_Decode-4        146 ± 0%       146 ± 0%    ~     (p=1.000 n=10+10)
```

This caused only a slight improvement to the benchmark, but it's a
change we need regardless.
