### PR TITLE
binary/reader: Skip fixed witdth collections faster

### DIFF
--- a/protocol/binary/reader.go
+++ b/protocol/binary/reader.go
@@ -100,14 +100,8 @@ func (r *reader) readMapStream() (wire.MapItemList, error) {
 	}
 
 	start := r.or.offset
-	for i := 0; i < mh.Length; i++ {
-		if err := r.sr.Skip(mh.KeyType); err != nil {
-			return nil, err
-		}
-
-		if err := r.sr.Skip(mh.ValueType); err != nil {
-			return nil, err
-		}
+	if err := r.sr.skipMapItems(mh.KeyType, mh.ValueType, int32(mh.Length)); err != nil {
+		return nil, err
 	}
 
 	if err := r.sr.ReadMapEnd(); err != nil {
@@ -131,10 +125,8 @@ func (r *reader) readListStream() (wire.ValueList, error) {
 	}
 
 	start := r.or.offset
-	for i := 0; i < lh.Length; i++ {
-		if err := r.sr.Skip(lh.Type); err != nil {
-			return nil, err
-		}
+	if err := r.sr.skipListItems(lh.Type, lh.Length); err != nil {
+		return nil, err
 	}
 
 	if err := r.sr.ReadListEnd(); err != nil {
@@ -157,10 +149,8 @@ func (r *reader) readSetStream() (wire.ValueList, error) {
 	}
 
 	start := r.or.offset
-	for i := 0; i < sh.Length; i++ {
-		if err := r.sr.Skip(sh.Type); err != nil {
-			return nil, err
-		}
+	if err := r.sr.skipListItems(sh.Type, sh.Length); err != nil {
+		return nil, err
 	}
 
 	if err := r.sr.ReadSetEnd(); err != nil {


### PR DESCRIPTION
When skipping over collections in binary.Reader, we currently do:

    for i := 0; i < length; i++ {
        skip()
    }

This is suboptimal for cases where the number of bytes skipped by
`skip()` will be the same for each call because we can just skip
`length * width` bytes.

Re-use logic from the streaming reader that already does this when
possible.

```
name                                                  old time/op    new time/op    delta
RoundTrip/PrimitiveOptionalStruct/Decode-4              3.03µs ±10%    2.91µs ± 2%   -3.92%  (p=0.013 n=10+9)
RoundTrip/PrimitiveOptionalStruct/Streaming_Decode-4    1.90µs ± 2%    1.88µs ± 3%   -1.01%  (p=0.033 n=10+9)
RoundTrip/Graph/Decode-4                                9.88µs ± 2%    9.93µs ± 4%     ~     (p=0.714 n=8+10)
RoundTrip/Graph/Streaming_Decode-4                      2.72µs ± 2%    2.70µs ± 5%     ~     (p=0.258 n=9+9)
RoundTrip/ContainersOfContainers/Decode-4                133µs ± 9%      69µs ± 1%  -48.47%  (p=0.000 n=10+8)
RoundTrip/ContainersOfContainers/Streaming_Decode-4     31.0µs ± 5%    30.4µs ± 2%   -2.01%  (p=0.043 n=9+10)

name                                                  old alloc/op   new alloc/op   delta
RoundTrip/PrimitiveOptionalStruct/Decode-4              1.40kB ± 0%    1.40kB ± 0%     ~     (all equal)
RoundTrip/PrimitiveOptionalStruct/Streaming_Decode-4     56.0B ± 0%     56.0B ± 0%     ~     (all equal)
RoundTrip/Graph/Decode-4                                3.52kB ± 0%    3.52kB ± 0%     ~     (all equal)
RoundTrip/Graph/Streaming_Decode-4                        168B ± 0%      168B ± 0%     ~     (all equal)
RoundTrip/ContainersOfContainers/Decode-4               29.3kB ± 0%    15.7kB ± 0%  -46.36%  (p=0.000 n=10+9)
RoundTrip/ContainersOfContainers/Streaming_Decode-4     10.1kB ± 0%    10.1kB ± 0%     ~     (all equal)

name                                                  old allocs/op  new allocs/op  delta
RoundTrip/PrimitiveOptionalStruct/Decode-4                14.0 ± 0%      14.0 ± 0%     ~     (all equal)
RoundTrip/PrimitiveOptionalStruct/Streaming_Decode-4      10.0 ± 0%      10.0 ± 0%     ~     (all equal)
RoundTrip/Graph/Decode-4                                  63.0 ± 0%      63.0 ± 0%     ~     (all equal)
RoundTrip/Graph/Streaming_Decode-4                        10.0 ± 0%      10.0 ± 0%     ~     (all equal)
RoundTrip/ContainersOfContainers/Decode-4                  872 ± 0%       306 ± 0%  -64.91%  (p=0.000 n=10+10)
RoundTrip/ContainersOfContainers/Streaming_Decode-4        146 ± 0%       146 ± 0%     ~     (p=0.059 n=10+8)
```
