### PR TITLE
Upgrade to Ragel version 6.10 (from 6.9)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BUILD_DIR = $(shell pwd)/build
-RAGEL_VERSION = 6.9
+RAGEL_VERSION = 6.10
 
 export GOBIN = $(BUILD_DIR)/bin
 


### PR DESCRIPTION
This doesn't change anything in current practice aside from moving to
the latest stable version of Ragel. From the changelog:

Ragel 6.10 - Mar 24, 2017
=========================
 -C codegen: test P vs PE in goto/call/ret statements in EOF actions, just
  before re-entering. If at the end of the input block then the EOF check is
  jumped to. This change prevents overrunning the buffer if control flow is
  issued in an EOF action without fixing the input pointer first. If a program
  properly issues an fhold before the control flow the program won't be
  affected.
 -Updated action label generation. The previous set of conditions for
  generating the label didn't cover actions coming from the eofAction pointer
  (eof trans covered since it points into the set of transitions).
 -Use separate signed/unsigned values for host type min/max. Using separate
  values avoids the need to type cast before the data goes into FsmCtx structs.
  Keep it in native types until it is used.
 -Optionally do not generate entry point variables. Adds noentry write option
  for data.
 -Various warning elimination and build updates.