### PR TITLE
Responder: Deduplicate interface

### DIFF
--- a/protocol/binary.go
+++ b/protocol/binary.go
@@ -21,11 +21,8 @@
 package protocol
 
 import (
-	"io"
-
 	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/protocol/stream"
-	"go.uber.org/thriftrw/wire"
 )
 
 // Binary implements the Thrift Binary Protocol.
@@ -104,16 +101,7 @@ var EnvelopeAgnosticBinary EnvelopeAgnosticProtocol
 func init() {
 	Binary = binary.Default
 	BinaryStreamer = binary.Default
-	EnvelopeAgnosticBinary = binaryAdapter{binary.Default}
-}
-
-// adapts binary.Protocol (which returns a binary.Responder) into
-// protocol.Protocol (which returns a protocol.Responder).
-type binaryAdapter struct{ *binary.Protocol }
-
-func (b binaryAdapter) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Value, Responder, error) {
-	v, res, err := b.Protocol.DecodeRequest(et, r)
-	return v, res, err
+	EnvelopeAgnosticBinary = binary.Default
 }
 
 // NoEnvelopeResponder responds to a request without an envelope.

--- a/protocol/binary/protocol.go
+++ b/protocol/binary/protocol.go
@@ -25,6 +25,7 @@ import (
 	"io"
 
 	"go.uber.org/thriftrw/internal/iface"
+	"go.uber.org/thriftrw/protocol/envelope"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/thriftrw/wire"
 )
@@ -111,7 +112,7 @@ func (*Protocol) DecodeEnveloped(r io.ReaderAt) (wire.Envelope, error) {
 // the protocol will add more field types, but it is very unlikely that the
 // field type will flow into the MSB (128 type identifiers, starting with the
 // 15 valid types today).
-func (p *Protocol) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Value, Responder, error) {
+func (p *Protocol) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Value, envelope.Responder, error) {
 	var buf [2]byte
 
 	// If we fail to read two bytes, the only possible valid value is the empty struct.
@@ -158,13 +159,6 @@ func (p *Protocol) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Valu
 	// identifiers, outside the 0-15 range.
 	val, err := p.Decode(r, wire.TStruct)
 	return val, NoEnvelopeResponder, err
-}
-
-// Responder captures how to respond to a request, concerning whether and what
-// kind of envelope to use, how to match the sequence identifier of the
-// corresponding request.
-type Responder interface {
-	EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error
 }
 
 // noEnvelopeResponder responds to a request without an envelope.

--- a/protocol/envelope/responder.go
+++ b/protocol/envelope/responder.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package envelope
+
+import (
+	"io"
+
+	"go.uber.org/thriftrw/wire"
+)
+
+// Responder captures how to respond to a request, concerning whether and what
+// kind of envelope to use, how to match the sequence identifier of the
+// corresponding request.
+type Responder interface {
+	EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -24,6 +24,7 @@ package protocol
 import (
 	"io"
 
+	"go.uber.org/thriftrw/protocol/envelope"
 	"go.uber.org/thriftrw/wire"
 )
 
@@ -65,9 +66,6 @@ type EnvelopeAgnosticProtocol interface {
 // Responder captures how to respond to a request, concerning whether and what
 // kind of envelope to use, how to match the sequence identifier of the
 // corresponding request.
-type Responder interface {
-	// EncodeResponse writes a response value to the writer, with the envelope
-	// style of the corresponding request.
-	// The EnvelopeType should be either wire.Reply or wire.Exception.
-	EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error
-}
+//
+// Deprecated: Use envelope.Responder.
+type Responder = envelope.Responder

--- a/thrifttest/mock_protocol.go
+++ b/thrifttest/mock_protocol.go
@@ -26,7 +26,7 @@ package thrifttest
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	protocol "go.uber.org/thriftrw/protocol"
+	envelope "go.uber.org/thriftrw/protocol/envelope"
 	wire "go.uber.org/thriftrw/wire"
 	io "io"
 	reflect "reflect"
@@ -167,11 +167,11 @@ func (mr *MockEnvelopeAgnosticProtocolMockRecorder) DecodeEnveloped(arg0 interfa
 }
 
 // DecodeRequest mocks base method
-func (m *MockEnvelopeAgnosticProtocol) DecodeRequest(arg0 wire.EnvelopeType, arg1 io.ReaderAt) (wire.Value, protocol.Responder, error) {
+func (m *MockEnvelopeAgnosticProtocol) DecodeRequest(arg0 wire.EnvelopeType, arg1 io.ReaderAt) (wire.Value, envelope.Responder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DecodeRequest", arg0, arg1)
 	ret0, _ := ret[0].(wire.Value)
-	ret1, _ := ret[1].(protocol.Responder)
+	ret1, _ := ret[1].(envelope.Responder)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }


### PR DESCRIPTION
In #516, we tried to move binary-specific concerns into the binary
subpackage. Unfortunately, this has the effect of declaring two
different `Responder` interfaces:

    protocol/
      envelope.go     // type Responder
      binary/
        protocol.go   // type Responder

Although these two interfaces are equivalent, and any type that
implements one implements the other, this introduced a problem: an
interface that has a method that *returns* one of these interfaces does
not automatically support the other interface. That is,
`*binary.Protocol`, which returns a `binary.Responder` does not
implement `protocol.EnvelopeAgnosticProtocol`, which returns a
`protocol.Responder`.

    // compilation error!
    var p protocol.EnvelopeAgnosticProtocol = binary.Default

To address this, we introduced an adapter in the `protocol` package that
adapts a `*binary.Default` into a `protocol.EnvelopeAgnosticProtocol` by
altering the return type of the `DecodeRequest` method.

This isn't great, especially because this means that we either need this
adapter everywhere, or we need to remember to use
`EnvelopeAgnosticBinary` in different places. In particular, it breaks
code like the following:

    var proto protocol.Protocol = binary.Default
    if p, ok := protocol.(protocol.EnvelopeAgnosticProtocol); ok {
        p.DecodeRequest(..)
    }

Because `binary.Default` (of type `*binary.Protocol`) does not implement
that interface.

More importantly, this breaks the following code as well, which
previously worked just fine:

    var proto protocol.Protocol = protocol.Binary
    if p, ok := protocol.(protocol.EnvelopeAgnosticProtocol); ok {
        p.DecodeRequest(..)
    }

To address these problems, declare the `Responder` interface in a new
subpackage of `protocol`, and alias the `protocol.Responder` to that
interface.

With this, `*binary.Protocol` now implements `EnvelopeAgnosticProtocol`
