### PR TITLE
stream: Implement Request and Response handling with Enveloping

### DIFF
--- a/envelope/stream/envelope.go
+++ b/envelope/stream/envelope.go
@@ -19,16 +19,3 @@
 // THE SOFTWARE.
 
 package stream
-
-import (
-	"go.uber.org/thriftrw/protocol/stream"
-	"go.uber.org/thriftrw/wire"
-)
-
-// Enveloper is the interface implemented by a type that can be written with
-// an envelope via a stream.Writer.
-type Enveloper interface {
-	MethodName() string
-	EnvelopeType() wire.EnvelopeType
-	Encode(stream.Writer) error
-}

--- a/protocol/binary/protocol.go
+++ b/protocol/binary/protocol.go
@@ -225,7 +225,6 @@ func (p *Protocol) Handle(
 		if err != nil {
 			return responder, nil, err
 		}
-		defer sr.ReadEnvelopeEnd()
 
 		switch {
 		case buf[0] == 0x00:
@@ -244,8 +243,13 @@ func (p *Protocol) Handle(
 
 		ev, err := h.HandleCall(ctx, &call)
 		if err != nil {
-			return NoEnvelopeResponder, nil, err
+			return responder, nil, err
 		}
+
+		if err := sr.ReadEnvelopeEnd(); err != nil {
+			return responder, nil, err
+		}
+
 		return responder, ev, nil
 	}
 

--- a/protocol/binary/protocol.go
+++ b/protocol/binary/protocol.go
@@ -167,10 +167,9 @@ func (p *Protocol) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Valu
 }
 
 // ReadRequest reads off the request envelope (if present) from an io.Reader,
-// using the provided BodyReader to read off the full request struct,
+// populating the provided BodyReader to read off the full request struct,
 // asserting the EnvelopeType (either OneWay or Unary) if an envlope exists.
-// A ResponseWriter that understands the enveloping used and the request's
-// body are returned.
+// A ResponseWriter that understands the enveloping used is returned.
 //
 // This allows a Thrift request handler to transparently read requests
 // regardless of whether the caller is configured to submit envelopes.
@@ -197,8 +196,6 @@ func (p *Protocol) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Valu
 // the protocol will add more field types, but it is very unlikely that the
 // field type will flow into the MSB (128 type identifiers, starting with the
 // 15 valid types today).
-//
-// Callers must call Close() on the stream.Reader once finished.
 func (p *Protocol) ReadRequest(
 	ctx context.Context,
 	et wire.EnvelopeType,

--- a/protocol/binary/protocol.go
+++ b/protocol/binary/protocol.go
@@ -22,6 +22,7 @@ package binary
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 
@@ -195,11 +196,13 @@ func (p *Protocol) DecodeRequest(et wire.EnvelopeType, r io.ReaderAt) (wire.Valu
 // 15 valid types today).
 //
 // Callers must call Close() on the stream.Reader once finished.
-func (p *Protocol) ReadRequest(et wire.EnvelopeType, r io.Reader, bodyFunc stream.ReadBodyFunc) (stream.ResponseWriter, error) {
+func (p *Protocol) ReadRequest(et wire.EnvelopeType, r io.Reader, h stream.CallHandler) (stream.ResponseWriter, error) {
 	var buf [2]byte
 
+	call := stream.Call{Request: p.Reader(bytes.NewReader(buf[:]))}
+
 	if count, _ := r.Read(buf[0:2]); count < 2 {
-		return NoEnvelopeResponder, bodyFunc(p.Reader(bytes.NewReader(buf[:])))
+		return NoEnvelopeResponder, h.HandleCall(context.Background(), &call)
 	}
 
 	// Reset the Reader to allow for properly reading the envelope, if it exists.
@@ -207,13 +210,14 @@ func (p *Protocol) ReadRequest(et wire.EnvelopeType, r io.Reader, bodyFunc strea
 	sr := p.Reader(r)
 	defer sr.Close()
 
+	call = stream.Call{Request: sr}
 	if buf[0] == 0x00 {
 		eh, err := p.readEnvelopeHeader(sr, et)
 		if err != nil {
 			return NoEnvelopeResponder, err
 		}
 
-		if err := bodyFunc(sr); err != nil {
+		if err := h.HandleCall(context.Background(), &call); err != nil {
 			return NoEnvelopeResponder, err
 		}
 
@@ -229,7 +233,7 @@ func (p *Protocol) ReadRequest(et wire.EnvelopeType, r io.Reader, bodyFunc strea
 			return NoEnvelopeResponder, err
 		}
 
-		if err := bodyFunc(sr); err != nil {
+		if err := h.HandleCall(context.Background(), &call); err != nil {
 			return NoEnvelopeResponder, err
 		}
 
@@ -241,7 +245,7 @@ func (p *Protocol) ReadRequest(et wire.EnvelopeType, r io.Reader, bodyFunc strea
 
 	// For anything else, the request is either not-enveloped or invalid, let the
 	// bodyFunc manage that data.
-	return NoEnvelopeResponder, bodyFunc(sr)
+	return NoEnvelopeResponder, h.HandleCall(context.Background(), &call)
 }
 
 func (p *Protocol) readEnvelopeHeader(sr stream.Reader, et wire.EnvelopeType) (stream.EnvelopeHeader, error) {

--- a/protocol/binary/responder.go
+++ b/protocol/binary/responder.go
@@ -21,7 +21,6 @@
 package binary
 
 import (
-	"context"
 	"io"
 
 	"go.uber.org/thriftrw/protocol/stream"
@@ -44,11 +43,11 @@ func (noEnvelopeResponder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w i
 	return Default.Encode(v, w)
 }
 
-func (noEnvelopeResponder) WriteResponse(et wire.EnvelopeType, w io.Writer, h stream.CallHandler) error {
+func (noEnvelopeResponder) WriteResponse(et wire.EnvelopeType, w io.Writer, ev stream.Enveloper) error {
 	writer := NewStreamWriter(w)
 	defer writer.Close()
 
-	return h.HandleCall(context.Background(), &stream.Call{Response: writer})
+	return ev.Encode(writer)
 }
 
 // NoEnvelopeResponder responds to a request without an envelope.
@@ -78,7 +77,7 @@ func (r EnvelopeV0Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w
 
 // WriteResponse writes an envelope to the writer (non-strict envelope) and
 // returns a borrowed stream.Writer. Callers must call Close() on stream.Writer once finished.
-func (r EnvelopeV0Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, h stream.CallHandler) error {
+func (r EnvelopeV0Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, ev stream.Enveloper) error {
 	writer := NewStreamWriter(w)
 	defer writer.Close()
 
@@ -90,7 +89,7 @@ func (r EnvelopeV0Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, h 
 		return err
 	}
 
-	if err := h.HandleCall(context.Background(), &stream.Call{Response: writer}); err != nil {
+	if err := ev.Encode(writer); err != nil {
 		return err
 	}
 
@@ -121,7 +120,7 @@ func (r EnvelopeV1Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w
 
 // WriteResponse writes an envelope to the writer (strict envelope) and returns a
 // borrowed stream.Writer. Callers must call Close() on stream.Writer once finished.
-func (r EnvelopeV1Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, h stream.CallHandler) error {
+func (r EnvelopeV1Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, ev stream.Enveloper) error {
 	writer := NewStreamWriter(w)
 	defer writer.Close()
 
@@ -133,7 +132,7 @@ func (r EnvelopeV1Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, h 
 		return err
 	}
 
-	if err := h.HandleCall(context.Background(), &stream.Call{Response: writer}); err != nil {
+	if err := ev.Encode(writer); err != nil {
 		return err
 	}
 

--- a/protocol/binary/responder.go
+++ b/protocol/binary/responder.go
@@ -21,6 +21,7 @@
 package binary
 
 import (
+	"context"
 	"io"
 
 	"go.uber.org/thriftrw/protocol/stream"
@@ -43,11 +44,11 @@ func (noEnvelopeResponder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w i
 	return Default.Encode(v, w)
 }
 
-func (noEnvelopeResponder) WriteResponse(et wire.EnvelopeType, w io.Writer, bodyFunc stream.WriteBodyFunc) error {
+func (noEnvelopeResponder) WriteResponse(et wire.EnvelopeType, w io.Writer, h stream.CallHandler) error {
 	writer := NewStreamWriter(w)
 	defer writer.Close()
 
-	return bodyFunc(writer)
+	return h.HandleCall(context.Background(), &stream.Call{Response: writer})
 }
 
 // NoEnvelopeResponder responds to a request without an envelope.
@@ -77,7 +78,7 @@ func (r EnvelopeV0Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w
 
 // WriteResponse writes an envelope to the writer (non-strict envelope) and
 // returns a borrowed stream.Writer. Callers must call Close() on stream.Writer once finished.
-func (r EnvelopeV0Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, bodyFunc stream.WriteBodyFunc) error {
+func (r EnvelopeV0Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, h stream.CallHandler) error {
 	writer := NewStreamWriter(w)
 	defer writer.Close()
 
@@ -89,7 +90,7 @@ func (r EnvelopeV0Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, bo
 		return err
 	}
 
-	if err := bodyFunc(writer); err != nil {
+	if err := h.HandleCall(context.Background(), &stream.Call{Response: writer}); err != nil {
 		return err
 	}
 
@@ -120,7 +121,7 @@ func (r EnvelopeV1Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w
 
 // WriteResponse writes an envelope to the writer (strict envelope) and returns a
 // borrowed stream.Writer. Callers must call Close() on stream.Writer once finished.
-func (r EnvelopeV1Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, bodyFunc stream.WriteBodyFunc) error {
+func (r EnvelopeV1Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, h stream.CallHandler) error {
 	writer := NewStreamWriter(w)
 	defer writer.Close()
 
@@ -132,7 +133,7 @@ func (r EnvelopeV1Responder) WriteResponse(et wire.EnvelopeType, w io.Writer, bo
 		return err
 	}
 
-	if err := bodyFunc(writer); err != nil {
+	if err := h.HandleCall(context.Background(), &stream.Call{Response: writer}); err != nil {
 		return err
 	}
 

--- a/protocol/binary/responder.go
+++ b/protocol/binary/responder.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package binary
+
+import (
+	"io"
+
+	"go.uber.org/thriftrw/protocol/stream"
+	"go.uber.org/thriftrw/wire"
+)
+
+// Responder captures how to respond to a request, concerning whether and what
+// kind of envelope to use, how to match the sequence identifier of the
+// corresponding request.
+type Responder interface {
+	EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error
+}
+
+// noEnvelopeResponder responds to a request without an envelope.
+type noEnvelopeResponder struct{}
+
+func (noEnvelopeResponder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
+	return Default.Encode(v, w)
+}
+
+func (noEnvelopeResponder) WriteResponse(et wire.EnvelopeType, w io.Writer) (stream.Writer, error) {
+	writer := NewStreamWriter(w)
+	return writer, nil
+}
+
+// NoEnvelopeResponder responds to a request without an envelope.
+var NoEnvelopeResponder = &noEnvelopeResponder{}
+
+// EnvelopeV0Responder responds to requests with a non-strict (unversioned) envelope.
+type EnvelopeV0Responder struct {
+	Name  string
+	SeqID int32
+}
+
+// EncodeResponse writes the response to the writer using a non-strict
+// envelope.
+func (r EnvelopeV0Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
+	writer := BorrowWriter(w)
+	err := writer.WriteLegacyEnveloped(wire.Envelope{
+		Name:  r.Name,
+		Type:  t,
+		SeqID: r.SeqID,
+		Value: v,
+	})
+	ReturnWriter(writer)
+	return err
+}
+
+// WriteResponse writes an envelope to the writer (non-strict envelope) and
+// returns a borrowed stream.Writer. Callers must call Close() on stream.Writer once finished.
+func (r EnvelopeV0Responder) WriteResponse(et wire.EnvelopeType, w io.Writer) (stream.Writer, error) {
+	writer := NewStreamWriter(w)
+	err := writer.WriteLegacyEnvelopeBegin(stream.EnvelopeHeader{
+		Name:  r.Name,
+		Type:  et,
+		SeqID: r.SeqID,
+	})
+	return writer, err
+}
+
+// EnvelopeV1Responder responds to requests with a strict, version 1 envelope.
+type EnvelopeV1Responder struct {
+	Name  string
+	SeqID int32
+}
+
+// EncodeResponse writes the response to the writer using a strict, version 1
+// envelope.
+func (r EnvelopeV1Responder) EncodeResponse(v wire.Value, t wire.EnvelopeType, w io.Writer) error {
+	writer := BorrowWriter(w)
+	err := writer.WriteEnveloped(wire.Envelope{
+		Name:  r.Name,
+		Type:  t,
+		SeqID: r.SeqID,
+		Value: v,
+	})
+	ReturnWriter(writer)
+	return err
+}
+
+// WriteResponse writes an envelope to the writer (strict envelope) and returns a
+// borrowed stream.Writer. Callers must call Close() on stream.Writer once finished.
+func (r EnvelopeV1Responder) WriteResponse(et wire.EnvelopeType, w io.Writer) (stream.Writer, error) {
+	writer := NewStreamWriter(w)
+	err := writer.WriteEnvelopeBegin(stream.EnvelopeHeader{
+		Name:  r.Name,
+		Type:  et,
+		SeqID: r.SeqID,
+	})
+	return writer, err
+}

--- a/protocol/binary/stream_envelope.go
+++ b/protocol/binary/stream_envelope.go
@@ -21,31 +21,125 @@
 package binary
 
 import (
-	"errors"
+	"fmt"
 
 	"go.uber.org/thriftrw/protocol/stream"
+	"go.uber.org/thriftrw/wire"
 )
 
 // WriteEnvelopeBegin writes the start of a strict envelope (contains an envelope version).
 func (sw *StreamWriter) WriteEnvelopeBegin(eh stream.EnvelopeHeader) error {
-	return errors.New("not implemented")
+	version := uint32(version1) | uint32(eh.Type)
+
+	if err := sw.WriteInt32(int32(version)); err != nil {
+		return err
+	}
+
+	if err := sw.WriteString(eh.Name); err != nil {
+		return err
+	}
+
+	return sw.WriteInt32(eh.SeqID)
 }
 
 // WriteEnvelopeEnd writes the "end" of an envelope. Since there is no ending
 // to an envelope, this is a no-op.
 func (sw *StreamWriter) WriteEnvelopeEnd() error {
-	return errors.New("not implemented")
+	return nil
+}
+
+// WriteLegacyEnvelopeBegin writes the start of a non-strict envelope (lacks an envelope version).
+func (sw *StreamWriter) WriteLegacyEnvelopeBegin(eh stream.EnvelopeHeader) error {
+	if err := sw.WriteString(eh.Name); err != nil {
+		return err
+	}
+
+	if err := sw.writeByte(uint8(eh.Type)); err != nil {
+		return err
+	}
+
+	return sw.WriteInt32(eh.SeqID)
+}
+
+// WriteLegacyEnvelopeEnd writes the "end" of a legacy envelope. Since there is
+// no ending to a legacy envelope, this is a no-op.
+func (sw *StreamWriter) WriteLegacyEnvelopeEnd() error {
+	return nil
 }
 
 // ReadEnvelopeBegin reads the start of an Apache Thrift envelope. Thrift supports
 // two kinds of envelopes: strict, and non-strict. See ReadEnveloped method
 // for more information on enveloping.
 func (sw *StreamReader) ReadEnvelopeBegin() (stream.EnvelopeHeader, error) {
-	return stream.EnvelopeHeader{}, errors.New("not implemented")
+	var eh stream.EnvelopeHeader
+
+	val, err := sw.ReadInt32()
+	if err != nil {
+		return eh, err
+	}
+
+	if val > 0 {
+		if eh, err = sw.readNonStrictEnvelope(val); err != nil {
+			return eh, err
+		}
+	} else {
+		if eh, err = sw.readStrictEnvelope(val); err != nil {
+			return eh, err
+		}
+	}
+
+	seqID, err := sw.ReadInt32()
+	if err != nil {
+		return eh, err
+	}
+
+	eh.SeqID = seqID
+	return eh, nil
+}
+
+// readNonStrictEnvelope reads off a non-strict envelope as described by protocol.EnvelopeAgnosticProtocol.
+func (sw *StreamReader) readNonStrictEnvelope(length int32) (stream.EnvelopeHeader, error) {
+	var eh stream.EnvelopeHeader
+
+	buf := make([]byte, length)
+	for i := int32(0); i < length; i++ {
+		i8, err := sw.ReadInt8()
+		if err != nil {
+			return eh, err
+		}
+		buf[i] = byte(i8)
+	}
+
+	typ, err := sw.ReadInt8()
+	if err != nil {
+		return eh, err
+	}
+
+	eh.Name = string(buf)
+	eh.Type = wire.EnvelopeType(typ)
+	return eh, nil
+}
+
+func (sw *StreamReader) readStrictEnvelope(ver int32) (stream.EnvelopeHeader, error) {
+	var eh stream.EnvelopeHeader
+
+	if v := uint32(ver) & versionMask; v != version1 {
+		return eh, fmt.Errorf("cannot decode envelope of version: %v", v)
+	}
+
+	name, err := sw.ReadString()
+	if err != nil {
+		return eh, err
+	}
+
+	// Casting automatically truncates to the lowest 8 bits.
+	eh.Type = wire.EnvelopeType(ver)
+	eh.Name = name
+	return eh, nil
 }
 
 // ReadEnvelopeEnd reads the "end" of an envelope.  Since there is no real
 // envelope end, this is a no-op.
 func (sw *StreamReader) ReadEnvelopeEnd() error {
-	return errors.New("not implemented")
+	return nil
 }

--- a/protocol/binary_test.go
+++ b/protocol/binary_test.go
@@ -83,7 +83,7 @@ type testRequestBody struct {
 
 var _ stream.BodyReader = (*testRequestBody)(nil)
 
-func (h testRequestBody) ReadBody(_ context.Context, sr stream.Reader) (stream.Body, error) {
+func (h testRequestBody) Decode(sr stream.Reader) error {
 	h.t.Helper()
 
 	require.NoError(h.t, sr.ReadStructBegin(), "failed to read struct begin")
@@ -94,7 +94,7 @@ func (h testRequestBody) ReadBody(_ context.Context, sr stream.Reader) (stream.B
 	require.NoError(h.t, sr.ReadStructEnd(), "failed to read struct end")
 	h.fh = &tempFh
 
-	return nil, nil
+	return nil
 }
 
 type emptyBody struct {
@@ -102,8 +102,8 @@ type emptyBody struct {
 
 var _ stream.BodyReader = (*emptyBody)(nil)
 
-func (h emptyBody) ReadBody(context.Context, stream.Reader) (stream.Body, error) {
-	return nil, nil
+func (h emptyBody) Decode(stream.Reader) error {
+	return nil
 }
 
 type encodeDecodeTest struct {
@@ -1602,7 +1602,7 @@ func TestStreamingEnvelopeErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.errMsg, func(t *testing.T) {
-			responder, _, err := binary.Default.ReadRequest(context.Background(), tt.inputEnvType, bytes.NewReader(tt.inputReqBytes), &emptyBody{})
+			responder, err := binary.Default.ReadRequest(context.Background(), tt.inputEnvType, bytes.NewReader(tt.inputReqBytes), &emptyBody{})
 			require.Error(t, err, "ReadRequest should fail")
 			require.Equal(t, binary.NoEnvelopeResponder, responder, "ReadRequest should fail with noEnvelopeResponder")
 			assert.Contains(t, err.Error(), tt.errMsg, "ReadRequest should fail with error message")
@@ -1700,7 +1700,7 @@ func TestStreamingEnvelopeSuccessful(t *testing.T) {
 				fh: &fh,
 			}
 
-			responder, _, err := binary.Default.ReadRequest(context.Background(), tt.inputEnvType, bytes.NewReader(tt.inputReqBytes), h)
+			responder, err := binary.Default.ReadRequest(context.Background(), tt.inputEnvType, bytes.NewReader(tt.inputReqBytes), h)
 			require.NoError(t, err, "failed to read request with envelope")
 			require.True(t, tt.wantResponderType == reflect.TypeOf(responder), "read request should have responder want %v got %T", tt.wantResponderType, responder)
 

--- a/protocol/binary_test.go
+++ b/protocol/binary_test.go
@@ -35,6 +35,30 @@ import (
 	"go.uber.org/thriftrw/wire"
 )
 
+var (
+	_testNonStrictEnvelopeOneWayBytes = []byte{
+		// envelope
+		0x00, 0x00, 0x00, 0x05, // length:4 = 5
+		0x77, 0x72, 0x69, 0x74, 0x65, // 'write'
+		0x04,                   // type:1 = OneWay
+		0x00, 0x00, 0x00, 0x2a, // seqid:4 = 42
+	}
+
+	_testNonStrictEnvelopeExceptionBytes = []byte{
+		// envelope
+		0x00, 0x00, 0x00, 0x03, 'a', 'b', 'c', // name~4 = "abc"
+		0x03,                   // type:1 = Exception
+		0x00, 0x00, 0x15, 0x3c, // seqID:4 = 5436
+	}
+
+	_testStrictEnvelopeCallBytes = []byte{
+		// envelope
+		0x80, 0x01, 0x00, 0x01, // version|type:4 = 1 | call
+		0x00, 0x00, 0x00, 0x03, 'a', 'b', 'c', // name~4 = "abc"
+		0x00, 0x00, 0x15, 0x3c, // seqID:4 = 5436
+	}
+)
+
 type encodeDecodeTest struct {
 	msg     string
 	value   wire.Value
@@ -75,6 +99,18 @@ func getStreamReader(t *testing.T, encoded []byte) stream.Reader {
 	t.Helper()
 
 	return BinaryStreamer.Reader(bytes.NewReader(encoded))
+}
+
+func readStructFieldHeader(t *testing.T, r stream.Reader) stream.FieldHeader {
+	t.Helper()
+
+	require.NoError(t, r.ReadStructBegin(), "failed to read struct begin")
+	fh, ok, err := r.ReadFieldBegin()
+	require.NoError(t, err, "failed to read field begin")
+	require.True(t, ok, "failed to read field begin")
+	require.NoError(t, r.ReadFieldEnd(), "failed to read field end")
+	require.NoError(t, r.ReadStructEnd(), "failed to read struct end")
+	return fh
 }
 
 type failureTest struct {
@@ -1482,6 +1518,170 @@ func TestBinaryEnvelopeSuccessful(t *testing.T) {
 		}
 
 		assert.Equal(t, tt.encoded, buf.Bytes(), "%v: reencoded bytes mismatch")
+	}
+}
+
+func TestStreamingEnvelopeErrors(t *testing.T) {
+	tests := []struct {
+		inputEnvType  wire.EnvelopeType
+		inputReqBytes []byte
+		errMsg        string
+	}{
+		{
+			inputEnvType: wire.OneWay,
+			inputReqBytes: []byte{
+				// envelope
+				0x00, 0x00, 0x00, 0x03, 'a', 'b', 'c', // name~4 = "abc"
+				0x03,                   // type:1 = Exception
+				0x00, 0x00, 0x15, 0x3c, // seqID:4 = 5436
+
+				// request
+			},
+			errMsg: "unexpected envelope type",
+		},
+		{
+			inputEnvType: wire.Call,
+			inputReqBytes: []byte{
+				// envelope
+				0x80, 0x02, 0x00, 0x01, // version|type:4 = 2 | call
+				0x00, 0x00, 0x00, 0x03, 'a', 'b', 'c', // name~4 = "abc"
+				0x00, 0x00, 0x15, 0x3c, // seqID:4 = 5436
+
+				// request
+			},
+			errMsg: "cannot decode envelope of version",
+		},
+		{
+			inputEnvType: wire.Call,
+			inputReqBytes: []byte{
+				// envelope
+				0x80, 0x02, 0x00, 0x01, // version|type:4 = 2 | call
+				0x00, 0x00, 0x00, 0x03, 'a', 'b', 'c', // name~4 = "abc"
+				0x00, 0x00, 0x15, 0x3c, // seqID:4 = 5436
+
+				// request
+			},
+			errMsg: "cannot decode envelope of version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.errMsg, func(t *testing.T) {
+			_, responder, err := binary.Default.ReadRequest(tt.inputEnvType, bytes.NewReader(tt.inputReqBytes))
+			require.Error(t, err, "ReadRequest should fail")
+			require.Equal(t, binary.NoEnvelopeResponder, responder, "ReadRequest should fail with noEnvelopeResponder")
+			assert.Contains(t, err.Error(), tt.errMsg, "ReadRequest should fail with error message")
+		})
+	}
+}
+
+func TestStreamingEnvelopeSuccessful(t *testing.T) {
+	tests := []struct {
+		msg               string
+		inputReqBytes     []byte
+		inputEnvType      wire.EnvelopeType
+		wantReqFieldID    int16
+		wantResponderType reflect.Type
+		wantResBytes      []byte
+	}{
+		{
+			msg:               "no envelope",
+			inputEnvType:      wire.OneWay,
+			inputReqBytes:     tbinary(vstruct(vfield(1, vbinary("hello")))),
+			wantReqFieldID:    1,
+			wantResponderType: reflect.TypeOf(binary.NoEnvelopeResponder),
+			wantResBytes: 	   tbinary(vstruct()),
+		},
+		{
+			msg:          "non-strict envelope, envelope type OneWay",
+			inputEnvType: wire.OneWay,
+			inputReqBytes: append(
+				// envelope
+				_testNonStrictEnvelopeOneWayBytes,
+
+				// request
+				tbinary(vstruct(vfield(2, vbinary("hello"))))...,
+			),
+			wantReqFieldID:    2,
+			wantResponderType: reflect.TypeOf((*binary.EnvelopeV0Responder)(nil)),
+			wantResBytes:      append(
+				// envelope
+				_testNonStrictEnvelopeOneWayBytes,
+
+				// response
+				tbinary(vstruct())...,
+			),
+		},
+		{
+			msg:          "strict envelope, envelope type Call",
+			inputEnvType: wire.Call,
+			inputReqBytes: append(
+				// envelope
+				_testStrictEnvelopeCallBytes,
+
+				// request
+				tbinary(vstruct(vfield(3, vbinary("hello"))))...,
+			),
+			wantReqFieldID:    3,
+			wantResponderType: reflect.TypeOf((*binary.EnvelopeV1Responder)(nil)),
+			wantResBytes:      append(
+				// envelope
+				_testStrictEnvelopeCallBytes,
+
+				// response
+				tbinary(vstruct())...,
+			),
+		},
+		{
+			msg:          "non-strict envelope, envelope type Exception",
+			inputEnvType: wire.Exception,
+			inputReqBytes: append(
+				// envelope
+				_testNonStrictEnvelopeExceptionBytes,
+
+				// request
+				tbinary(vstruct(vfield(4, vbinary("hello"))))...,
+			),
+			wantReqFieldID:    4,
+			wantResponderType: reflect.TypeOf((*binary.EnvelopeV0Responder)(nil)),
+			wantResBytes:      append(
+				// envelope
+				_testNonStrictEnvelopeExceptionBytes,
+
+				// response
+				tbinary(vstruct())...,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			// Verify whether we can infer the presence of the envelope
+			// reliably when reading a request.
+			reader, responder, err := binary.Default.ReadRequest(tt.inputEnvType, bytes.NewReader(tt.inputReqBytes))
+			require.NoError(t, err, "failed to read request with envelope")
+			require.True(t, tt.wantResponderType == reflect.TypeOf(responder), "read request should have responder want %v got %T", tt.wantResponderType, responder)
+
+			// Verify whether we can read the correct request field ID from the stream.Reader
+			// This is a basic test to ensure the stream.Reader is at the correct offset in the request.
+			// It is not intended to test the functionality of stream.Reader
+			fh := readStructFieldHeader(t, reader)
+			require.Equal(t, tt.wantReqFieldID, fh.ID, "request field ID mismatch")
+			require.NoError(t, reader.Skip(fh.Type), "failed to skip")
+
+			// Verify response has the correct envelope
+			writer := &bytes.Buffer{}
+			ws, err := responder.WriteResponse(tt.inputEnvType, writer)
+			require.NoError(t, err, "failed to write response with envelope")
+			require.NoError(t, reader.Close())
+
+			// Verify response can be written to with an empty struct
+			// This is an action executed on each test to verify stream.Writer is at the correct offset
+			require.NoError(t, ws.WriteStructBegin(), "failed to write response struct begin")
+			require.NoError(t, ws.WriteStructEnd(), "failed to write response struct end")
+			require.Equal(t, tt.wantResBytes, writer.Bytes(), "encoded response envelope bytes mismatch")
+			assert.NoError(t, ws.Close())
+		})
 	}
 }
 

--- a/protocol/stream/envelope.go
+++ b/protocol/stream/envelope.go
@@ -26,6 +26,9 @@ import (
 	"go.uber.org/thriftrw/wire"
 )
 
+type ReadBodyFunc func(Reader) error
+type WriteBodyFunc func(Writer) error
+
 // RequestReader captures how to read from a request in a streaming fashion.
 type RequestReader interface {
 	// ReadRequest reads off the request envelope (if present) from a Reader
@@ -34,7 +37,7 @@ type RequestReader interface {
 	// regardless of whether the caller is configured to submit envelopes.
 	// The caller specifies the expected EnvelopeType, either OneWay or Unary,
 	// on which the read asserts the specified envelope is present.
-	ReadRequest(wire.EnvelopeType, io.Reader) (body Reader, res ResponseWriter, err error)
+	ReadRequest(wire.EnvelopeType, io.Reader, ReadBodyFunc) (res ResponseWriter, err error)
 }
 
 // ResponseWriter captures how to respond to a request in a streaming fashion.
@@ -45,5 +48,5 @@ type ResponseWriter interface {
 	// whether successful or not (error), users must call Close() on the stream.Writer.
 	//
 	// The EnvelopeType should be either wire.Reply or wire.Exception.
-	WriteResponse(wire.EnvelopeType, io.Writer) (body Writer, err error)
+	WriteResponse(wire.EnvelopeType, io.Writer, WriteBodyFunc) (err error)
 }

--- a/protocol/stream/envelope.go
+++ b/protocol/stream/envelope.go
@@ -26,9 +26,6 @@ import (
 	"go.uber.org/thriftrw/wire"
 )
 
-type ReadBodyFunc func(Reader) error
-type WriteBodyFunc func(Writer) error
-
 // RequestReader captures how to read from a request in a streaming fashion.
 type RequestReader interface {
 	// ReadRequest reads off the request envelope (if present) from a Reader
@@ -37,7 +34,7 @@ type RequestReader interface {
 	// regardless of whether the caller is configured to submit envelopes.
 	// The caller specifies the expected EnvelopeType, either OneWay or Unary,
 	// on which the read asserts the specified envelope is present.
-	ReadRequest(wire.EnvelopeType, io.Reader, ReadBodyFunc) (res ResponseWriter, err error)
+	ReadRequest(wire.EnvelopeType, io.Reader, CallHandler) (res ResponseWriter, err error)
 }
 
 // ResponseWriter captures how to respond to a request in a streaming fashion.
@@ -48,5 +45,5 @@ type ResponseWriter interface {
 	// whether successful or not (error), users must call Close() on the stream.Writer.
 	//
 	// The EnvelopeType should be either wire.Reply or wire.Exception.
-	WriteResponse(wire.EnvelopeType, io.Writer, WriteBodyFunc) (err error)
+	WriteResponse(wire.EnvelopeType, io.Writer, CallHandler) (err error)
 }

--- a/protocol/stream/envelope.go
+++ b/protocol/stream/envelope.go
@@ -51,11 +51,6 @@ type Handler interface {
 	// regardless of whether the caller is configured to submit envelopes.
 	// The caller specifies the expected EnvelopeType, either OneWay or Unary,
 	// on which the read asserts the specified envelope is present.
-
-	// XXX: thrfitrw defines the wire types that can be returned in a response
-	// (Reply or Exception), can `Handle` handle sending back the response as
-	// well? likely no, Handle doesn't know/care whether the call is a oneway or
-	// not
 	Handle(context.Context, wire.EnvelopeType, io.Reader, CallHandler) (ResponseWriter, Enveloper, error)
 }
 
@@ -67,5 +62,5 @@ type ResponseWriter interface {
 	// whether successful or not (error), users must call Close() on the stream.Writer.
 	//
 	// The EnvelopeType should be either wire.Reply or wire.Exception.
-	WriteResponse(wire.EnvelopeType, io.Writer, Enveloper) (err error)
+	WriteResponse(wire.EnvelopeType, io.Writer, Enveloper) error
 }

--- a/protocol/stream/envelope.go
+++ b/protocol/stream/envelope.go
@@ -27,16 +27,9 @@ import (
 	"go.uber.org/thriftrw/wire"
 )
 
-// Body represents a type that can be read out from a stream.Writer.
-type Body interface {
-	Decode(Reader) error
-}
-
-// A BodyReader knows how to read the body of a thriftrw type.
+// BodyReader represents a type that can be read out from a stream.Reader.
 type BodyReader interface {
-	// ReadBody returns a thriftrw type that has read the contents off the wire
-	// using the supplied Reader.
-	ReadBody(context.Context, Reader) (Body, error)
+	Decode(Reader) error
 }
 
 // Enveloper is the interface implemented by a type that can be written with
@@ -57,7 +50,7 @@ type RequestReader interface {
 	//
 	// This allows a Thrift request handler to transparently read requests
 	// regardless of whether the caller is configured to submit envelopes.
-	ReadRequest(context.Context, wire.EnvelopeType, io.Reader, BodyReader) (ResponseWriter, Body, error)
+	ReadRequest(context.Context, wire.EnvelopeType, io.Reader, BodyReader) (ResponseWriter, error)
 }
 
 // ResponseWriter captures how to respond to a request in a streaming fashion.

--- a/protocol/stream/envelope.go
+++ b/protocol/stream/envelope.go
@@ -42,6 +42,8 @@ type Enveloper interface {
 
 // RequestReader captures how to read from a request in a streaming fashion.
 type RequestReader interface {
+	Protocol
+
 	// ReadRequest reads off the request envelope (if present) from an io.Reader,
 	// using the provided BodyReader to read off the full request struct,
 	// asserting the EnvelopeType (either OneWay or Unary) if an envlope exists.

--- a/protocol/stream/stream.go
+++ b/protocol/stream/stream.go
@@ -50,8 +50,6 @@ type Call struct {
 }
 
 type CallHandler interface {
-	iface.Private
-
 	HandleCall(context.Context, *Call) error
 }
 

--- a/protocol/stream/stream.go
+++ b/protocol/stream/stream.go
@@ -23,6 +23,7 @@
 package stream
 
 import (
+	"context"
 	"io"
 
 	"go.uber.org/thriftrw/internal/iface"
@@ -41,6 +42,17 @@ type Protocol interface {
 	// Reader returns a streaming implementation of a decoder for a
 	// Thrift value.
 	Reader(r io.Reader) Reader
+}
+
+type Call struct {
+	Request  Reader
+	Response Writer
+}
+
+type CallHandler interface {
+	iface.Private
+
+	HandleCall(context.Context, *Call) error
 }
 
 // EnvelopeHeader represents the envelope of a response or a request which includes

--- a/protocol/stream/stream.go
+++ b/protocol/stream/stream.go
@@ -23,7 +23,6 @@
 package stream
 
 import (
-	"context"
 	"io"
 
 	"go.uber.org/thriftrw/internal/iface"
@@ -42,15 +41,6 @@ type Protocol interface {
 	// Reader returns a streaming implementation of a decoder for a
 	// Thrift value.
 	Reader(r io.Reader) Reader
-}
-
-type Call struct {
-	Request  Reader
-	Response Writer
-}
-
-type CallHandler interface {
-	HandleCall(context.Context, *Call) error
 }
 
 // EnvelopeHeader represents the envelope of a response or a request which includes


### PR DESCRIPTION
Based off of the implementation by @usmyth for enveloping, perform reading out a
request as well as providing an appropriate `stream.ReponseWriter`, based on the
enveloping that was included on the request itself.

In both cases of reading out the request as well as providing a
`stream.ResponseWriter`, the interfaces for these needed to change to support
doing so with enveloping.  Since the envelope's begin and end are meant to
encapsulate the request and response body, an object needs to be provided that
understands how to parse, or write out these bodies respectively.

For the request flow, this object implements a `stream.BodyReader` to parse out
the body and should be a thriftrw object that reflects the request's body.  For
the response flow, a `stream.Enveloper` that reflects the response's body and is
also a compatible thriftrw object, must be provided.