### PR TITLE
stream: optimize StreamReader, RequestRequest with io.Seeker

### DIFF
--- a/protocol/binary/protocol_test.go
+++ b/protocol/binary/protocol_test.go
@@ -1,0 +1,146 @@
+package binary_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/thriftrw/protocol/binary"
+	"go.uber.org/thriftrw/protocol/stream"
+	"go.uber.org/thriftrw/wire"
+)
+
+func TestReadRequestSeekMiddle(t *testing.T) {
+	// ReadRequest looks ahead into the buffer and seeks back if it sees an
+	// envelope. This test ensures that when we seek back, we seek back to
+	// the start of the envelope, and not to the start of the entire file.
+
+	buff := append(
+		[]byte("hello"),
+		encodeEnvelope(t, "Cache::clear", wire.Call, 42)...,
+	)
+
+	r := bytes.NewReader(buff)
+
+	// Move to somewhere near the middle of the buffer so that when
+	// ReadRequest seeks back, it has to come back to this exact position.
+	hello := make([]byte, 5)
+	_, err := r.Read(hello)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(hello))
+
+	_, err = binary.Default.ReadRequest(
+		context.Background(),
+		wire.Call,
+		r,
+		new(emptyStructReader),
+	)
+	require.NoError(t, err)
+}
+
+// Serializes an envelope to bytes.
+func encodeEnvelope(t testing.TB,
+	name string,
+	typ wire.EnvelopeType,
+	seqID int32,
+	fields ...wire.Field,
+) []byte {
+	var buff bytes.Buffer
+	err := binary.Default.EncodeEnveloped(wire.Envelope{
+		Name:  name,
+		Type:  typ,
+		SeqID: seqID,
+		Value: wire.NewValueStruct(wire.Struct{
+			Fields: fields,
+		}),
+	}, &buff)
+	require.NoError(t, err)
+	return buff.Bytes()
+}
+
+// Measures the cost of looking ahead in Binary.ReadRequest to determine if the
+// request is enveloped.
+func BenchmarkReadRequestLookahead(b *testing.B) {
+	// Build an enveloped payload with an empty struct to only measure the
+	// cost of looking ahead.
+	bs := encodeEnvelope(b, "Cache::clear", wire.Call, 42) // empty struct
+
+	// bufferedReader is an interface implemented by bytes.Reader. It lets
+	// us use the same benchmarking logic for readers that support seek and
+	// those that do not.
+	type bufferReader interface {
+		io.Reader
+
+		// Reset resets the position of this buffered reader,
+		// specifying that it should read from the provided buffer.
+		Reset([]byte)
+	}
+
+	benchmarks := []struct {
+		desc   string
+		reader bufferReader
+	}{
+		{
+			// bytes.Reader supports seek This will use the
+			// optimized path.
+			desc:   "with seek",
+			reader: bytes.NewReader(nil),
+		},
+		{
+			// sliceReader does not support seek. This will
+			// construct a multi-reader with the buffered text.
+			desc:   "no seek",
+			reader: new(sliceReader),
+		},
+	}
+
+	for _, bb := range benchmarks {
+		b.Run(bb.desc, func(b *testing.B) {
+			var body emptyStructReader
+
+			ctx := context.Background()
+			for i := 0; i < b.N; i++ {
+				bb.reader.Reset(bs)
+
+				_, err := binary.Default.ReadRequest(
+					ctx,
+					wire.Call,
+					bb.reader,
+					&body,
+				)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+type emptyStructReader struct{}
+
+func (*emptyStructReader) Decode(r stream.Reader) error {
+	if err := r.ReadStructBegin(); err != nil {
+		return err
+	}
+	return r.ReadStructEnd()
+}
+
+// sliceReader is an io.Reader that reads from a slice incrementally. It does
+// not implement io.Seeker.
+type sliceReader struct {
+	bs  []byte
+	idx int
+}
+
+// Reset resets the position of the slice reader and specifies that it should
+// read from the given slice.
+func (r *sliceReader) Reset(bs []byte) {
+	r.bs = bs
+	r.idx = 0
+}
+
+func (r *sliceReader) Read(bs []byte) (int, error) {
+	n := copy(bs, r.bs[r.idx:])
+	r.idx += n
+	return n, nil
+}

--- a/protocol/binary/stream_reader.go
+++ b/protocol/binary/stream_reader.go
@@ -71,21 +71,21 @@ type StreamReader struct {
 	// the implementation of the io.Reader we're using.
 	discard func(int64) error
 
-	// These are bound versions of the discardStream and discardOffset
+	// These are bound versions of the discardStream and discardSeek
 	// methods on the StreamReader. Putting them here ensures that we don't
 	// cause an alloc when we do "sr.discard = sr.discardOffset".
 	_discardStream func(int64) error
-	_discardOffset func(int64) error
+	_discardSeek   func(int64) error
 
-	// This field is set only if the wrapped reader is an offset reader.
-	// ONLY USE if you are discardOffset.
-	_or *offsetReader
+	// This field is set only if the wrapped reader is an io.Seeker. ONLY
+	// USE if you are discardSeek.
+	_seeker io.Seeker
 }
 
 var streamReaderPool = sync.Pool{
 	New: func() interface{} {
 		sr := new(StreamReader)
-		sr._discardOffset = sr.discardOffset
+		sr._discardSeek = sr.discardSeek
 		sr._discardStream = sr.discardStream
 		return sr
 	},
@@ -99,18 +99,18 @@ func NewStreamReader(r io.Reader) *StreamReader {
 	sr := streamReaderPool.Get().(*StreamReader)
 	sr.reader = r
 	sr.discard = sr._discardStream
-	if or, ok := r.(*offsetReader); ok {
-		// If we're wrapping an offsetReader, we can skip bytes much
-		// more efficiently.
-		sr._or = or
-		sr.discard = sr._discardOffset
+	if seeker, ok := r.(io.Seeker); ok {
+		// If we're wrapping a seeker (like *offsetReader), we can skip
+		// bytes much more efficiently.
+		sr._seeker = seeker
+		sr.discard = sr._discardSeek
 	}
 	return sr
 }
 
 func returnStreamReader(sr *StreamReader) {
 	sr.reader = nil
-	sr._or = nil
+	sr._seeker = nil
 	streamReaderPool.Put(sr)
 }
 
@@ -125,9 +125,9 @@ func (sr *StreamReader) read(bs []byte) (int, error) {
 	return n, err
 }
 
-func (sr *StreamReader) discardOffset(n int64) error {
-	sr._or.offset += n
-	return nil
+func (sr *StreamReader) discardSeek(n int64) error {
+	_, err := sr._seeker.Seek(n, io.SeekCurrent)
+	return err
 }
 
 func (sr *StreamReader) discardStream(n int64) error {


### PR DESCRIPTION
This implements the `io.Seeker` interface on `offsetReader`,
generalizing access and manipulation of the offset.

With that available, it makes two changes:

- For #526, this changes ReadRequest to use `Seek` instead of an
  `io.MultiReader` to seek back after the look ahead to check whether
  there is an envelope.
- More generally, this cleans up the special casing in `StreamReader`
  which cast the `io.Reader` directly into an `*offsetReader` to
  manipulate its offset. Now, we do so with the `Seek` method.

Each commit is individually reviewable.

In terms of performance impact, the optimization in `ReadRequest`
improves performance slightly for readers that implement that interface:

```
name                              time/op
ReadRequestLookahead/with_seek-4   939ns ± 9%
ReadRequestLookahead/no_seek-4    1.13µs ± 1%

name                              alloc/op
ReadRequestLookahead/with_seek-4   56.0B ± 0%
ReadRequestLookahead/no_seek-4      160B ± 0%

name                              allocs/op
ReadRequestLookahead/with_seek-4    4.00 ± 0%
ReadRequestLookahead/no_seek-4      7.00 ± 0%
```

The change to StreamReader has no effect on performance but it results
in slightly cleaner code, which is also desirable.