### PR TITLE
protocol/stream: Unembed stream.Protocol from stream.RequestReader

### DIFF
--- a/protocol/stream/envelope.go
+++ b/protocol/stream/envelope.go
@@ -42,8 +42,6 @@ type Enveloper interface {
 
 // RequestReader captures how to read from a request in a streaming fashion.
 type RequestReader interface {
-	Protocol
-
 	// ReadRequest reads off the request envelope (if present) from an io.Reader,
 	// using the provided BodyReader to read off the full request struct,
 	// asserting the EnvelopeType (either OneWay or Unary) if an envlope exists.


### PR DESCRIPTION
`stream.RequestReader` was previously thought to need `stream.Protocol` to have
equivalency to `protocol.EnvelopeAgnosticProtocol`.  This embed is not strictly
required, so it should be removed.