### PR TITLE
ast: add Annotations(Node) []*Annotation

### DIFF
--- a/ast/annotation.go
+++ b/ast/annotation.go
@@ -49,6 +49,14 @@ func (ann *Annotation) String() string {
 	return fmt.Sprintf("%s = %q", ann.Name, ann.Value)
 }
 
+// Annotations returns the annotations for the given node.
+func Annotations(n Node) []*Annotation {
+	if na, ok := n.(nodeWithAnnotations); ok {
+		return na.annotations()
+	}
+	return nil
+}
+
 // FormatAnnotations formats a collection of annotations into a string.
 func FormatAnnotations(anns []*Annotation) string {
 	if len(anns) == 0 {
@@ -62,3 +70,24 @@ func FormatAnnotations(anns []*Annotation) string {
 
 	return "(" + strings.Join(as, ", ") + ")"
 }
+
+// Nodes which have annoations can implement this interface.
+type nodeWithAnnotations interface {
+	Node
+
+	annotations() []*Annotation
+}
+
+var (
+	_ nodeWithAnnotations = BaseType{}
+	_ nodeWithAnnotations = (*Enum)(nil)
+	_ nodeWithAnnotations = (*EnumItem)(nil)
+	_ nodeWithAnnotations = (*Field)(nil)
+	_ nodeWithAnnotations = (*Function)(nil)
+	_ nodeWithAnnotations = ListType{}
+	_ nodeWithAnnotations = MapType{}
+	_ nodeWithAnnotations = (*Service)(nil)
+	_ nodeWithAnnotations = SetType{}
+	_ nodeWithAnnotations = (*Struct)(nil)
+	_ nodeWithAnnotations = (*Typedef)(nil)
+)

--- a/ast/annotation_test.go
+++ b/ast/annotation_test.go
@@ -21,10 +21,56 @@
 package ast
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAnnotations(t *testing.T) {
+	anns := []*Annotation{
+		{Name: "annotation", Value: "value"},
+	}
+
+	tests := []struct {
+		give Node
+		want []*Annotation
+	}{
+		{give: &Annotation{}, want: nil},
+		{give: BaseType{Annotations: anns}, want: anns},
+		{give: &Constant{}, want: nil},
+		{give: ConstantBoolean(true), want: nil},
+		{give: ConstantDouble(42.0), want: nil},
+		{give: ConstantInteger(42), want: nil},
+		{give: ConstantMap{Line: 2, Column: 1}, want: nil},
+		{give: ConstantMapItem{Line: 3, Column: 1}, want: nil},
+		{give: ConstantList{Line: 4, Column: 1}, want: nil},
+		{give: ConstantReference{Line: 5, Column: 1}, want: nil},
+		{give: ConstantString("foo"), want: nil},
+		{give: &CppInclude{}, want: nil},
+		{give: &Enum{Annotations: anns}, want: anns},
+		{give: &EnumItem{Annotations: anns}, want: anns},
+		{give: &Field{Annotations: anns}, want: anns},
+		{give: &Function{Annotations: anns}, want: anns},
+		{give: &Include{}, want: nil},
+		{give: ListType{Annotations: anns}, want: anns},
+		{give: MapType{Annotations: anns}, want: anns},
+		{give: &Namespace{}, want: nil},
+		{give: &Program{}, want: nil},
+		{give: &Service{Annotations: anns}, want: anns},
+		{give: SetType{Annotations: anns}, want: anns},
+		{give: &Struct{Annotations: anns}, want: anns},
+		{give: &Typedef{Annotations: anns}, want: anns},
+		{give: TypeReference{}, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%T", tt.give), func(t *testing.T) {
+			actual := Annotations(tt.give)
+			assert.Equal(t, tt.want, actual)
+		})
+	}
+}
 
 func TestFormatAnnotations(t *testing.T) {
 	var anns []*Annotation

--- a/ast/definition.go
+++ b/ast/definition.go
@@ -81,6 +81,8 @@ type Typedef struct {
 func (*Typedef) node()       {}
 func (*Typedef) definition() {}
 
+func (t *Typedef) annotations() []*Annotation { return t.Annotations }
+
 func (t *Typedef) pos() Position { return Position{Line: t.Line, Column: t.Column} }
 
 func (t *Typedef) visitChildren(ss nodeStack, v visitor) {
@@ -116,6 +118,8 @@ type Enum struct {
 func (*Enum) node()       {}
 func (*Enum) definition() {}
 
+func (e *Enum) annotations() []*Annotation { return e.Annotations }
+
 func (e *Enum) pos() Position { return Position{Line: e.Line, Column: e.Column} }
 
 func (e *Enum) visitChildren(ss nodeStack, v visitor) {
@@ -145,6 +149,8 @@ type EnumItem struct {
 }
 
 func (*EnumItem) node() {}
+
+func (i *EnumItem) annotations() []*Annotation { return i.Annotations }
 
 func (i *EnumItem) pos() Position { return Position{Line: i.Line, Column: i.Column} }
 
@@ -198,6 +204,8 @@ type Struct struct {
 func (*Struct) node()       {}
 func (*Struct) definition() {}
 
+func (s *Struct) annotations() []*Annotation { return s.Annotations }
+
 func (s *Struct) pos() Position { return Position{Line: s.Line, Column: s.Column} }
 
 func (s *Struct) visitChildren(ss nodeStack, v visitor) {
@@ -235,6 +243,8 @@ type Service struct {
 func (*Service) node()       {}
 func (*Service) definition() {}
 
+func (s *Service) annotations() []*Annotation { return s.Annotations }
+
 func (s *Service) pos() Position { return Position{Line: s.Line, Column: s.Column} }
 
 func (s *Service) visitChildren(ss nodeStack, v visitor) {
@@ -270,6 +280,8 @@ type Function struct {
 }
 
 func (*Function) node() {}
+
+func (n *Function) annotations() []*Annotation { return n.Annotations }
 
 func (n *Function) pos() Position { return Position{Line: n.Line, Column: n.Column} }
 
@@ -319,6 +331,8 @@ type Field struct {
 }
 
 func (*Field) node() {}
+
+func (n *Field) annotations() []*Annotation { return n.Annotations }
 
 func (n *Field) pos() Position { return Position{Line: n.Line, Column: n.Column} }
 

--- a/ast/type.go
+++ b/ast/type.go
@@ -68,6 +68,8 @@ type BaseType struct {
 func (BaseType) node()      {}
 func (BaseType) fieldType() {}
 
+func (bt BaseType) annotations() []*Annotation { return bt.Annotations }
+
 func (bt BaseType) pos() Position { return Position{Line: bt.Line, Column: bt.Column} }
 
 func (bt BaseType) visitChildren(ss nodeStack, v visitor) {
@@ -120,6 +122,8 @@ type MapType struct {
 func (MapType) node()      {}
 func (MapType) fieldType() {}
 
+func (mt MapType) annotations() []*Annotation { return mt.Annotations }
+
 func (mt MapType) pos() Position { return Position{Line: mt.Line, Column: mt.Column} }
 
 func (mt MapType) visitChildren(ss nodeStack, v visitor) {
@@ -154,6 +158,8 @@ type ListType struct {
 func (ListType) node()      {}
 func (ListType) fieldType() {}
 
+func (lt ListType) annotations() []*Annotation { return lt.Annotations }
+
 func (lt ListType) pos() Position { return Position{Line: lt.Line, Column: lt.Column} }
 
 func (lt ListType) visitChildren(ss nodeStack, v visitor) {
@@ -186,6 +192,8 @@ type SetType struct {
 
 func (SetType) node()      {}
 func (SetType) fieldType() {}
+
+func (st SetType) annotations() []*Annotation { return st.Annotations }
 
 func (st SetType) pos() Position { return Position{Line: st.Line, Column: st.Column} }
 


### PR DESCRIPTION
It's useful to have a single way to retrieve an arbitrary Node's
annotations without resorting to type switches or reflection.

This change introduces a nodeWithAnnotations interface and an exported
Annotations() function. All Node types which support annotations support
this interface.