### PR TITLE
streaming: Skip over unrecognized fields and fields not matching the expected type

### DIFF
--- a/gen/field.go
+++ b/gen/field.go
@@ -601,10 +601,9 @@ func (f fieldGroupGenerator) Decode(g Generator) error {
 			}
 
 			for <$ok> {
-				switch <$fh>.ID {
+				switch {
 				<range .Fields ->
-				case <.ID>:
-					if <$fh>.Type == <typeCode .Type> {
+				case <$fh>.ID == <.ID> && <$fh>.Type == <typeCode .Type>:
 						<- $lhs := printf "%s.%s" $v (goName .) ->
 						<- if .Required ->
 							<$lhs>, err = <decode .Type $sr>
@@ -617,11 +616,6 @@ func (f fieldGroupGenerator) Decode(g Generator) error {
 						<if .Required ->
 							<$isSet.Rotate (printf "%sIsSet" .Name)> = true
 						<- end>
-					} else {
-						if err := <$sr>.Skip(<$fh>.Type); err != nil {
-							return err
-						}
-					}
 				<end ->
 				default:
 					if err := <$sr>.Skip(<$fh>.Type); err != nil {

--- a/gen/field.go
+++ b/gen/field.go
@@ -617,8 +617,16 @@ func (f fieldGroupGenerator) Decode(g Generator) error {
 						<if .Required ->
 							<$isSet.Rotate (printf "%sIsSet" .Name)> = true
 						<- end>
+					} else {
+						if err := <$sr>.Skip(<$fh>.Type); err != nil {
+							return err
+						}
 					}
 				<end ->
+				default:
+					if err := <$sr>.Skip(<$fh>.Type); err != nil {
+						return err
+					}
 				}
 
 				if err := <$sr>.ReadFieldEnd(); err != nil {

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -213,6 +213,10 @@ func (v *AccessorConflict) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -223,6 +227,10 @@ func (v *AccessorConflict) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TBool {
@@ -233,6 +241,14 @@ func (v *AccessorConflict) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -542,6 +558,10 @@ func (v *AccessorNoConflict) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -552,6 +572,14 @@ func (v *AccessorNoConflict) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1439,6 +1467,10 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TSet {
@@ -1447,6 +1479,10 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TMap {
@@ -1455,6 +1491,14 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1824,6 +1868,10 @@ func (v *StructCollision) Decode(sr stream.Reader) error {
 					return err
 				}
 				collisionFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -1832,6 +1880,14 @@ func (v *StructCollision) Decode(sr stream.Reader) error {
 					return err
 				}
 				collision_fieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2111,6 +2167,10 @@ func (v *UnionCollision) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -2121,6 +2181,14 @@ func (v *UnionCollision) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2405,6 +2473,14 @@ func (v *WithDefault) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2915,6 +2991,10 @@ func (v *StructCollision2) Decode(sr stream.Reader) error {
 					return err
 				}
 				collisionFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -2923,6 +3003,14 @@ func (v *StructCollision2) Decode(sr stream.Reader) error {
 					return err
 				}
 				collision_fieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -3202,6 +3290,10 @@ func (v *UnionCollision2) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -3212,6 +3304,14 @@ func (v *UnionCollision2) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -203,49 +203,31 @@ func (v *AccessorConflict) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Name = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Name = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.GetName2 = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.GetName2 = &x
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.IsSetName2 = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.IsSetName2 = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -548,35 +530,23 @@ func (v *AccessorNoConflict) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Getname = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Getname = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.GetName = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.GetName = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1459,43 +1429,25 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.A, err = _List_String_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.A, err = _List_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TSet {
-				v.B, err = _Set_String_mapType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TSet:
+			v.B, err = _Set_String_mapType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TMap {
-				v.C, err = _Map_String_String_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TMap:
+			v.C, err = _Map_String_String_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1860,31 +1812,19 @@ func (v *StructCollision) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBool {
-				v.CollisionField, err = sr.ReadBool()
-				if err != nil {
-					return err
-				}
-				collisionFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBool:
+			v.CollisionField, err = sr.ReadBool()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.CollisionField2, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				collision_fieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			collisionFieldIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.CollisionField2, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
+			collision_fieldIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2157,35 +2097,23 @@ func (v *UnionCollision) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.CollisionField = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.CollisionField = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.CollisionField2 = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.CollisionField2 = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2465,19 +2393,13 @@ func (v *WithDefault) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.Pouet, err = _StructCollision_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.Pouet, err = _StructCollision_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2983,31 +2905,19 @@ func (v *StructCollision2) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBool {
-				v.CollisionField, err = sr.ReadBool()
-				if err != nil {
-					return err
-				}
-				collisionFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBool:
+			v.CollisionField, err = sr.ReadBool()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.CollisionField2, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				collision_fieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			collisionFieldIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.CollisionField2, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
+			collision_fieldIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3280,35 +3190,23 @@ func (v *UnionCollision2) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.CollisionField = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.CollisionField = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.CollisionField2 = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.CollisionField2 = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -2414,115 +2414,61 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.ListOfLists, err = _List_List_I32_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.ListOfLists, err = _List_List_I32_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TList {
-				v.ListOfSets, err = _List_Set_I32_mapType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TList:
+			v.ListOfSets, err = _List_Set_I32_mapType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TList {
-				v.ListOfMaps, err = _List_Map_I32_I32_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TList:
+			v.ListOfMaps, err = _List_Map_I32_I32_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TSet {
-				v.SetOfSets, err = _Set_Set_String_mapType_sliceType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 4 && fh.Type == wire.TSet:
+			v.SetOfSets, err = _Set_Set_String_mapType_sliceType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TSet {
-				v.SetOfLists, err = _Set_List_String_sliceType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TSet:
+			v.SetOfLists, err = _Set_List_String_sliceType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TSet {
-				v.SetOfMaps, err = _Set_Map_String_String_sliceType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 6 && fh.Type == wire.TSet:
+			v.SetOfMaps, err = _Set_Map_String_String_sliceType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 7:
-			if fh.Type == wire.TMap {
-				v.MapOfMapToInt, err = _Map_Map_String_I32_I64_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 7 && fh.Type == wire.TMap:
+			v.MapOfMapToInt, err = _Map_Map_String_I32_I64_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 8:
-			if fh.Type == wire.TMap {
-				v.MapOfListToSet, err = _Map_List_I32_Set_I64_mapType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 8 && fh.Type == wire.TMap:
+			v.MapOfListToSet, err = _Map_List_I32_Set_I64_mapType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 9:
-			if fh.Type == wire.TMap {
-				v.MapOfSetToListOfDouble, err = _Map_Set_I32_mapType_List_Double_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 9 && fh.Type == wire.TMap:
+			v.MapOfSetToListOfDouble, err = _Map_Set_I32_mapType_List_Double_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3949,43 +3895,25 @@ func (v *EnumContainers) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.ListOfEnums, err = _List_EnumDefault_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.ListOfEnums, err = _List_EnumDefault_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TSet {
-				v.SetOfEnums, err = _Set_EnumWithValues_mapType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TSet:
+			v.SetOfEnums, err = _Set_EnumWithValues_mapType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TMap {
-				v.MapOfEnums, err = _Map_EnumWithDuplicateValues_I32_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TMap:
+			v.MapOfEnums, err = _Map_EnumWithDuplicateValues_I32_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4571,31 +4499,19 @@ func (v *ListOfConflictingEnums) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.Records, err = _List_RecordType_Decode(sr)
-				if err != nil {
-					return err
-				}
-				recordsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.Records, err = _List_RecordType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TList {
-				v.OtherRecords, err = _List_RecordType_1_Decode(sr)
-				if err != nil {
-					return err
-				}
-				otherRecordsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			recordsIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TList:
+			v.OtherRecords, err = _List_RecordType_1_Decode(sr)
+			if err != nil {
+				return err
 			}
+			otherRecordsIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5120,31 +5036,19 @@ func (v *ListOfConflictingUUIDs) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.Uuids, err = _List_UUID_Decode(sr)
-				if err != nil {
-					return err
-				}
-				uuidsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.Uuids, err = _List_UUID_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TList {
-				v.OtherUUIDs, err = _List_UUID_1_Decode(sr)
-				if err != nil {
-					return err
-				}
-				otherUUIDsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			uuidsIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TList:
+			v.OtherUUIDs, err = _List_UUID_1_Decode(sr)
+			if err != nil {
+				return err
 			}
+			otherUUIDsIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5419,19 +5323,13 @@ func (v *ListOfOptionalPrimitives) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.ListOfStrings, err = _List_String_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.ListOfStrings, err = _List_String_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5635,19 +5533,13 @@ func (v *ListOfRequiredPrimitives) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.ListOfStrings, err = _List_String_Decode(sr)
-				if err != nil {
-					return err
-				}
-				listOfStringsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.ListOfStrings, err = _List_String_Decode(sr)
+			if err != nil {
+				return err
 			}
+			listOfStringsIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -6171,31 +6063,19 @@ func (v *MapOfBinaryAndString) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TMap {
-				v.BinaryToString, err = _Map_Binary_String_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TMap:
+			v.BinaryToString, err = _Map_Binary_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TMap {
-				v.StringToBinary, err = _Map_String_Binary_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TMap:
+			v.StringToBinary, err = _Map_String_Binary_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -7196,79 +7076,43 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.ListOfBinary, err = _List_Binary_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.ListOfBinary, err = _List_Binary_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TList {
-				v.ListOfInts, err = _List_I64_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TList:
+			v.ListOfInts, err = _List_I64_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TSet {
-				v.SetOfStrings, err = _Set_String_mapType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TSet:
+			v.SetOfStrings, err = _Set_String_mapType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TSet {
-				v.SetOfBytes, err = _Set_Byte_mapType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 4 && fh.Type == wire.TSet:
+			v.SetOfBytes, err = _Set_Byte_mapType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TMap {
-				v.MapOfIntToString, err = _Map_I32_String_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TMap:
+			v.MapOfIntToString, err = _Map_I32_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TMap {
-				v.MapOfStringToBool, err = _Map_String_Bool_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 6 && fh.Type == wire.TMap:
+			v.MapOfStringToBool, err = _Map_String_Bool_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -7943,43 +7787,25 @@ func (v *PrimitiveContainersRequired) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.ListOfStrings, err = _List_String_Decode(sr)
-				if err != nil {
-					return err
-				}
-				listOfStringsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.ListOfStrings, err = _List_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TSet {
-				v.SetOfInts, err = _Set_I32_mapType_Decode(sr)
-				if err != nil {
-					return err
-				}
-				setOfIntsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			listOfStringsIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TSet:
+			v.SetOfInts, err = _Set_I32_mapType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TMap {
-				v.MapOfIntsToDoubles, err = _Map_I64_Double_Decode(sr)
-				if err != nil {
-					return err
-				}
-				mapOfIntsToDoublesIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			setOfIntsIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TMap:
+			v.MapOfIntsToDoubles, err = _Map_I64_Double_Decode(sr)
+			if err != nil {
+				return err
 			}
+			mapOfIntsToDoublesIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -2422,6 +2422,10 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TList {
@@ -2430,6 +2434,10 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TList {
@@ -2438,6 +2446,10 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TSet {
@@ -2446,6 +2458,10 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TSet {
@@ -2454,6 +2470,10 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TSet {
@@ -2462,6 +2482,10 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 7:
 			if fh.Type == wire.TMap {
@@ -2470,6 +2494,10 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 8:
 			if fh.Type == wire.TMap {
@@ -2478,6 +2506,10 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 9:
 			if fh.Type == wire.TMap {
@@ -2486,6 +2518,14 @@ func (v *ContainersOfContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -3917,6 +3957,10 @@ func (v *EnumContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TSet {
@@ -3925,6 +3969,10 @@ func (v *EnumContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TMap {
@@ -3933,6 +3981,14 @@ func (v *EnumContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -4523,6 +4579,10 @@ func (v *ListOfConflictingEnums) Decode(sr stream.Reader) error {
 					return err
 				}
 				recordsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TList {
@@ -4531,6 +4591,14 @@ func (v *ListOfConflictingEnums) Decode(sr stream.Reader) error {
 					return err
 				}
 				otherRecordsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -5060,6 +5128,10 @@ func (v *ListOfConflictingUUIDs) Decode(sr stream.Reader) error {
 					return err
 				}
 				uuidsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TList {
@@ -5068,6 +5140,14 @@ func (v *ListOfConflictingUUIDs) Decode(sr stream.Reader) error {
 					return err
 				}
 				otherUUIDsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -5347,6 +5427,14 @@ func (v *ListOfOptionalPrimitives) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -5555,6 +5643,14 @@ func (v *ListOfRequiredPrimitives) Decode(sr stream.Reader) error {
 					return err
 				}
 				listOfStringsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -6083,6 +6179,10 @@ func (v *MapOfBinaryAndString) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TMap {
@@ -6091,6 +6191,14 @@ func (v *MapOfBinaryAndString) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -7096,6 +7204,10 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TList {
@@ -7104,6 +7216,10 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TSet {
@@ -7112,6 +7228,10 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TSet {
@@ -7120,6 +7240,10 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TMap {
@@ -7128,6 +7252,10 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TMap {
@@ -7136,6 +7264,14 @@ func (v *PrimitiveContainers) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -7815,6 +7951,10 @@ func (v *PrimitiveContainersRequired) Decode(sr stream.Reader) error {
 					return err
 				}
 				listOfStringsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TSet {
@@ -7823,6 +7963,10 @@ func (v *PrimitiveContainersRequired) Decode(sr stream.Reader) error {
 					return err
 				}
 				setOfIntsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TMap {
@@ -7831,6 +7975,14 @@ func (v *PrimitiveContainersRequired) Decode(sr stream.Reader) error {
 					return err
 				}
 				mapOfIntsToDoublesIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -435,35 +435,23 @@ func (v *Records) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TI32 {
-				var x RecordType
-				x, err = _RecordType_Decode(sr)
-				v.RecordType = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TI32:
+			var x RecordType
+			x, err = _RecordType_Decode(sr)
+			v.RecordType = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI32 {
-				var x enums.RecordType
-				x, err = _RecordType_1_Decode(sr)
-				v.OtherRecordType = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TI32:
+			var x enums.RecordType
+			x, err = _RecordType_1_Decode(sr)
+			v.OtherRecordType = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -445,6 +445,10 @@ func (v *Records) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI32 {
@@ -455,6 +459,14 @@ func (v *Records) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -1903,6 +1903,14 @@ func (v *StructWithOptionalEnum) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -1893,21 +1893,15 @@ func (v *StructWithOptionalEnum) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TI32 {
-				var x EnumDefault
-				x, err = _EnumDefault_Decode(sr)
-				v.E = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TI32:
+			var x EnumDefault
+			x, err = _EnumDefault_Decode(sr)
+			v.E = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -174,6 +174,10 @@ func (v *DoesNotExistException) Decode(sr stream.Reader) error {
 					return err
 				}
 				keyIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -184,6 +188,14 @@ func (v *DoesNotExistException) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -463,6 +475,10 @@ func (v *DoesNotExistException2) Decode(sr stream.Reader) error {
 					return err
 				}
 				keyIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -473,6 +489,14 @@ func (v *DoesNotExistException2) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -666,6 +690,10 @@ func (v *EmptyException) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -166,33 +166,21 @@ func (v *DoesNotExistException) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Key, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				keyIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Key, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Error2 = &x
-				if err != nil {
-					return err
-				}
+			keyIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Error2 = &x
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -467,33 +455,21 @@ func (v *DoesNotExistException2) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Key, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				keyIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Key, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Error2 = &x
-				if err != nil {
-					return err
-				}
+			keyIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Error2 = &x
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -689,7 +665,7 @@ func (v *EmptyException) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -153,19 +153,13 @@ func (v *DocumentStruct) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.Second, err = _Second_Decode(sr)
-				if err != nil {
-					return err
-				}
-				secondIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.Second, err = _Second_Decode(sr)
+			if err != nil {
+				return err
 			}
+			secondIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -161,6 +161,14 @@ func (v *DocumentStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				secondIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -153,19 +153,13 @@ func (v *DocumentStructure) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.R2, err = _Second_Decode(sr)
-				if err != nil {
-					return err
-				}
-				r2IsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.R2, err = _Second_Decode(sr)
+			if err != nil {
+				return err
 			}
+			r2IsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -161,6 +161,14 @@ func (v *DocumentStructure) Decode(sr stream.Reader) error {
 					return err
 				}
 				r2IsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/non_hyphenated/non_hyphenated.go
+++ b/gen/internal/tests/non_hyphenated/non_hyphenated.go
@@ -96,6 +96,10 @@ func (v *First) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -234,6 +238,10 @@ func (v *Second) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {

--- a/gen/internal/tests/non_hyphenated/non_hyphenated.go
+++ b/gen/internal/tests/non_hyphenated/non_hyphenated.go
@@ -95,7 +95,7 @@ func (v *First) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -237,7 +237,7 @@ func (v *Second) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -988,6 +988,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				boolFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI8 {
@@ -996,6 +1000,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				byteFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TI16 {
@@ -1004,6 +1012,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				int16FieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TI32 {
@@ -1012,6 +1024,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				int32FieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TI64 {
@@ -1020,6 +1036,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				int64FieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TDouble {
@@ -1028,6 +1048,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				doubleFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 7:
 			if fh.Type == wire.TBinary {
@@ -1036,6 +1060,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				stringFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 8:
 			if fh.Type == wire.TBinary {
@@ -1044,6 +1072,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				binaryFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 9:
 			if fh.Type == wire.TList {
@@ -1052,6 +1084,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				listOfStringsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 10:
 			if fh.Type == wire.TSet {
@@ -1060,6 +1096,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				setOfIntsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 11:
 			if fh.Type == wire.TMap {
@@ -1068,6 +1108,14 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				mapOfIntsToDoublesIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -980,139 +980,73 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBool {
-				v.BoolField, err = sr.ReadBool()
-				if err != nil {
-					return err
-				}
-				boolFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBool:
+			v.BoolField, err = sr.ReadBool()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI8 {
-				v.ByteField, err = sr.ReadInt8()
-				if err != nil {
-					return err
-				}
-				byteFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			boolFieldIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TI8:
+			v.ByteField, err = sr.ReadInt8()
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TI16 {
-				v.Int16Field, err = sr.ReadInt16()
-				if err != nil {
-					return err
-				}
-				int16FieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			byteFieldIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TI16:
+			v.Int16Field, err = sr.ReadInt16()
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TI32 {
-				v.Int32Field, err = sr.ReadInt32()
-				if err != nil {
-					return err
-				}
-				int32FieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			int16FieldIsSet = true
+		case fh.ID == 4 && fh.Type == wire.TI32:
+			v.Int32Field, err = sr.ReadInt32()
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TI64 {
-				v.Int64Field, err = sr.ReadInt64()
-				if err != nil {
-					return err
-				}
-				int64FieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			int32FieldIsSet = true
+		case fh.ID == 5 && fh.Type == wire.TI64:
+			v.Int64Field, err = sr.ReadInt64()
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TDouble {
-				v.DoubleField, err = sr.ReadDouble()
-				if err != nil {
-					return err
-				}
-				doubleFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			int64FieldIsSet = true
+		case fh.ID == 6 && fh.Type == wire.TDouble:
+			v.DoubleField, err = sr.ReadDouble()
+			if err != nil {
+				return err
 			}
-		case 7:
-			if fh.Type == wire.TBinary {
-				v.StringField, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				stringFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			doubleFieldIsSet = true
+		case fh.ID == 7 && fh.Type == wire.TBinary:
+			v.StringField, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 8:
-			if fh.Type == wire.TBinary {
-				v.BinaryField, err = sr.ReadBinary()
-				if err != nil {
-					return err
-				}
-				binaryFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			stringFieldIsSet = true
+		case fh.ID == 8 && fh.Type == wire.TBinary:
+			v.BinaryField, err = sr.ReadBinary()
+			if err != nil {
+				return err
 			}
-		case 9:
-			if fh.Type == wire.TList {
-				v.ListOfStrings, err = _List_String_Decode(sr)
-				if err != nil {
-					return err
-				}
-				listOfStringsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			binaryFieldIsSet = true
+		case fh.ID == 9 && fh.Type == wire.TList:
+			v.ListOfStrings, err = _List_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 10:
-			if fh.Type == wire.TSet {
-				v.SetOfInts, err = _Set_I32_mapType_Decode(sr)
-				if err != nil {
-					return err
-				}
-				setOfIntsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			listOfStringsIsSet = true
+		case fh.ID == 10 && fh.Type == wire.TSet:
+			v.SetOfInts, err = _Set_I32_mapType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 11:
-			if fh.Type == wire.TMap {
-				v.MapOfIntsToDoubles, err = _Map_I64_Double_Decode(sr)
-				if err != nil {
-					return err
-				}
-				mapOfIntsToDoublesIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			setOfIntsIsSet = true
+		case fh.ID == 11 && fh.Type == wire.TMap:
+			v.MapOfIntsToDoubles, err = _Map_I64_Double_Decode(sr)
+			if err != nil {
+				return err
 			}
+			mapOfIntsToDoublesIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -175,31 +175,19 @@ func (v *ConflictingNamesSetValueArgs) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Key, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				keyIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Key, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.Value, err = sr.ReadBinary()
-				if err != nil {
-					return err
-				}
-				valueIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			keyIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.Value, err = sr.ReadBinary()
+			if err != nil {
+				return err
 			}
+			valueIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -419,21 +407,15 @@ func (v *InternalError) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Message = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Message = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -686,7 +668,7 @@ func (v *Cache_Clear_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -897,21 +879,15 @@ func (v *Cache_ClearAfter_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TI64 {
-				var x int64
-				x, err = sr.ReadInt64()
-				v.DurationMS = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TI64:
+			var x int64
+			x, err = sr.ReadInt64()
+			v.DurationMS = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1173,19 +1149,13 @@ func (v *ConflictingNames_SetValue_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.Request, err = _ConflictingNamesSetValueArgs_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.Request, err = _ConflictingNamesSetValueArgs_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1445,7 +1415,7 @@ func (v *ConflictingNames_SetValue_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1652,21 +1622,15 @@ func (v *KeyValue_DeleteValue_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				var x Key
-				x, err = _Key_Decode(sr)
-				v.Key = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			var x Key
+			x, err = _Key_Decode(sr)
+			v.Key = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2075,31 +2039,19 @@ func (v *KeyValue_DeleteValue_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.DoesNotExist, err = _DoesNotExistException_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.DoesNotExist, err = _DoesNotExistException_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.InternalError, err = _InternalError_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.InternalError, err = _InternalError_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2445,19 +2397,13 @@ func (v *KeyValue_GetManyValues_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.Range, err = _List_Key_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.Range, err = _List_Key_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2965,31 +2911,19 @@ func (v *KeyValue_GetManyValues_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 0:
-			if fh.Type == wire.TList {
-				v.Success, err = _List_ArbitraryValue_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 0 && fh.Type == wire.TList:
+			v.Success, err = _List_ArbitraryValue_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.DoesNotExist, err = _DoesNotExistException_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.DoesNotExist, err = _DoesNotExistException_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3271,21 +3205,15 @@ func (v *KeyValue_GetValue_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				var x Key
-				x, err = _Key_Decode(sr)
-				v.Key = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			var x Key
+			x, err = _Key_Decode(sr)
+			v.Key = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3657,31 +3585,19 @@ func (v *KeyValue_GetValue_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 0:
-			if fh.Type == wire.TStruct {
-				v.Success, err = _ArbitraryValue_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 0 && fh.Type == wire.TStruct:
+			v.Success, err = _ArbitraryValue_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.DoesNotExist, err = _DoesNotExistException_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.DoesNotExist, err = _DoesNotExistException_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3966,33 +3882,21 @@ func (v *KeyValue_SetValue_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				var x Key
-				x, err = _Key_Decode(sr)
-				v.Key = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			var x Key
+			x, err = _Key_Decode(sr)
+			v.Key = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.Value, err = _ArbitraryValue_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.Value, err = _ArbitraryValue_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4280,7 +4184,7 @@ func (v *KeyValue_SetValue_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4518,31 +4422,19 @@ func (v *KeyValue_SetValueV2_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Key, err = _Key_Decode(sr)
-				if err != nil {
-					return err
-				}
-				keyIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Key, err = _Key_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.Value, err = _ArbitraryValue_Decode(sr)
-				if err != nil {
-					return err
-				}
-				valueIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			keyIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.Value, err = _ArbitraryValue_Decode(sr)
+			if err != nil {
+				return err
 			}
+			valueIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4823,7 +4715,7 @@ func (v *KeyValue_SetValueV2_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4983,7 +4875,7 @@ func (v *KeyValue_Size_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5277,21 +5169,15 @@ func (v *KeyValue_Size_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 0:
-			if fh.Type == wire.TI64 {
-				var x int64
-				x, err = sr.ReadInt64()
-				v.Success = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 0 && fh.Type == wire.TI64:
+			var x int64
+			x, err = sr.ReadInt64()
+			v.Success = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5484,7 +5370,7 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) Decode(sr stream.R
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5713,7 +5599,7 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) Decode(sr stream
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -183,6 +183,10 @@ func (v *ConflictingNamesSetValueArgs) Decode(sr stream.Reader) error {
 					return err
 				}
 				keyIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -191,6 +195,14 @@ func (v *ConflictingNamesSetValueArgs) Decode(sr stream.Reader) error {
 					return err
 				}
 				valueIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -417,6 +429,14 @@ func (v *InternalError) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -667,6 +687,10 @@ func (v *Cache_Clear_Args) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -883,6 +907,14 @@ func (v *Cache_ClearAfter_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1149,6 +1181,14 @@ func (v *ConflictingNames_SetValue_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1406,6 +1446,10 @@ func (v *ConflictingNames_SetValue_Result) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -1618,6 +1662,14 @@ func (v *KeyValue_DeleteValue_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2031,6 +2083,10 @@ func (v *KeyValue_DeleteValue_Result) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -2039,6 +2095,14 @@ func (v *KeyValue_DeleteValue_Result) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2389,6 +2453,14 @@ func (v *KeyValue_GetManyValues_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2901,6 +2973,10 @@ func (v *KeyValue_GetManyValues_Result) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 1:
 			if fh.Type == wire.TStruct {
@@ -2909,6 +2985,14 @@ func (v *KeyValue_GetManyValues_Result) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -3197,6 +3281,14 @@ func (v *KeyValue_GetValue_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -3573,6 +3665,10 @@ func (v *KeyValue_GetValue_Result) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 1:
 			if fh.Type == wire.TStruct {
@@ -3581,6 +3677,14 @@ func (v *KeyValue_GetValue_Result) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -3872,6 +3976,10 @@ func (v *KeyValue_SetValue_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -3880,6 +3988,14 @@ func (v *KeyValue_SetValue_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -4165,6 +4281,10 @@ func (v *KeyValue_SetValue_Result) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -4406,6 +4526,10 @@ func (v *KeyValue_SetValueV2_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 				keyIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -4414,6 +4538,14 @@ func (v *KeyValue_SetValueV2_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 				valueIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -4692,6 +4824,10 @@ func (v *KeyValue_SetValueV2_Result) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -4848,6 +4984,10 @@ func (v *KeyValue_Size_Args) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -5147,6 +5287,14 @@ func (v *KeyValue_Size_Result) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -5337,6 +5485,10 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) Decode(sr stream.R
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -5562,6 +5714,10 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) Decode(sr stream
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -976,127 +976,67 @@ func (v *Bar) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TSet {
-				v.RequiredInt32ListField, err = _Set_I32_sliceType_Decode(sr)
-				if err != nil {
-					return err
-				}
-				requiredInt32ListFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TSet:
+			v.RequiredInt32ListField, err = _Set_I32_sliceType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TSet {
-				v.OptionalStringListField, err = _Set_String_sliceType_Decode(sr)
-				if err != nil {
-					return err
-				}
+			requiredInt32ListFieldIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TSet:
+			v.OptionalStringListField, err = _Set_String_sliceType_Decode(sr)
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TSet:
+			v.RequiredTypedefStringListField, err = _StringList_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TSet {
-				v.RequiredTypedefStringListField, err = _StringList_Decode(sr)
-				if err != nil {
-					return err
-				}
-				requiredTypedefStringListFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			requiredTypedefStringListFieldIsSet = true
+		case fh.ID == 4 && fh.Type == wire.TSet:
+			v.OptionalTypedefStringListField, err = _StringList_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TSet {
-				v.OptionalTypedefStringListField, err = _StringList_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TSet:
+			v.RequiredFooListField, err = _Set_Foo_sliceType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TSet {
-				v.RequiredFooListField, err = _Set_Foo_sliceType_Decode(sr)
-				if err != nil {
-					return err
-				}
-				requiredFooListFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			requiredFooListFieldIsSet = true
+		case fh.ID == 6 && fh.Type == wire.TSet:
+			v.OptionalFooListField, err = _Set_Foo_sliceType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TSet {
-				v.OptionalFooListField, err = _Set_Foo_sliceType_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 7 && fh.Type == wire.TSet:
+			v.RequiredTypedefFooListField, err = _FooList_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 7:
-			if fh.Type == wire.TSet {
-				v.RequiredTypedefFooListField, err = _FooList_Decode(sr)
-				if err != nil {
-					return err
-				}
-				requiredTypedefFooListFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			requiredTypedefFooListFieldIsSet = true
+		case fh.ID == 8 && fh.Type == wire.TSet:
+			v.OptionalTypedefFooListField, err = _FooList_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 8:
-			if fh.Type == wire.TSet {
-				v.OptionalTypedefFooListField, err = _FooList_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 9 && fh.Type == wire.TSet:
+			v.RequiredStringListListField, err = _Set_Set_String_sliceType_sliceType_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 9:
-			if fh.Type == wire.TSet {
-				v.RequiredStringListListField, err = _Set_Set_String_sliceType_sliceType_Decode(sr)
-				if err != nil {
-					return err
-				}
-				requiredStringListListFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			requiredStringListListFieldIsSet = true
+		case fh.ID == 10 && fh.Type == wire.TSet:
+			v.RequiredTypedefStringListListField, err = _StringListList_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 10:
-			if fh.Type == wire.TSet {
-				v.RequiredTypedefStringListListField, err = _StringListList_Decode(sr)
-				if err != nil {
-					return err
-				}
-				requiredTypedefStringListListFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
+			requiredTypedefStringListListFieldIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1636,19 +1576,13 @@ func (v *Foo) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.StringField, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				stringFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.StringField, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
+			stringFieldIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -984,6 +984,10 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 				requiredInt32ListFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TSet {
@@ -992,6 +996,10 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TSet {
@@ -1000,6 +1008,10 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 				requiredTypedefStringListFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TSet {
@@ -1008,6 +1020,10 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TSet {
@@ -1016,6 +1032,10 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 				requiredFooListFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TSet {
@@ -1024,6 +1044,10 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 7:
 			if fh.Type == wire.TSet {
@@ -1032,6 +1056,10 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 				requiredTypedefFooListFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 8:
 			if fh.Type == wire.TSet {
@@ -1040,6 +1068,10 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 9:
 			if fh.Type == wire.TSet {
@@ -1048,6 +1080,10 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 				requiredStringListListFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 10:
 			if fh.Type == wire.TSet {
@@ -1056,6 +1092,14 @@ func (v *Bar) Decode(sr stream.Reader) error {
 					return err
 				}
 				requiredTypedefStringListListFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1600,6 +1644,14 @@ func (v *Foo) Decode(sr stream.Reader) error {
 					return err
 				}
 				stringFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -138,19 +138,13 @@ func (v *ContactInfo) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.EmailAddress, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				emailAddressIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.EmailAddress, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
+			emailAddressIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1166,167 +1160,95 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TI32 {
-				var x int32
-				x, err = sr.ReadInt32()
-				v.RequiredPrimitive = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TI32:
+			var x int32
+			x, err = sr.ReadInt32()
+			v.RequiredPrimitive = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI32 {
-				var x int32
-				x, err = sr.ReadInt32()
-				v.OptionalPrimitive = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TI32:
+			var x int32
+			x, err = sr.ReadInt32()
+			v.OptionalPrimitive = &x
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TI32 {
-				var x enums.EnumDefault
-				x, err = _EnumDefault_Decode(sr)
-				v.RequiredEnum = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TI32:
+			var x enums.EnumDefault
+			x, err = _EnumDefault_Decode(sr)
+			v.RequiredEnum = &x
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TI32 {
-				var x enums.EnumDefault
-				x, err = _EnumDefault_Decode(sr)
-				v.OptionalEnum = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 4 && fh.Type == wire.TI32:
+			var x enums.EnumDefault
+			x, err = _EnumDefault_Decode(sr)
+			v.OptionalEnum = &x
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TList {
-				v.RequiredList, err = _List_String_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TList:
+			v.RequiredList, err = _List_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TList {
-				v.OptionalList, err = _List_Double_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 6 && fh.Type == wire.TList:
+			v.OptionalList, err = _List_Double_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 7:
-			if fh.Type == wire.TStruct {
-				v.RequiredStruct, err = _Frame_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 7 && fh.Type == wire.TStruct:
+			v.RequiredStruct, err = _Frame_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 8:
-			if fh.Type == wire.TStruct {
-				v.OptionalStruct, err = _Edge_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 8 && fh.Type == wire.TStruct:
+			v.OptionalStruct, err = _Edge_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 9:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.RequiredBoolDefaultTrue = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 9 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.RequiredBoolDefaultTrue = &x
+			if err != nil {
+				return err
 			}
-		case 10:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.OptionalBoolDefaultTrue = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 10 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.OptionalBoolDefaultTrue = &x
+			if err != nil {
+				return err
 			}
-		case 11:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.RequiredBoolDefaultFalse = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 11 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.RequiredBoolDefaultFalse = &x
+			if err != nil {
+				return err
 			}
-		case 12:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.OptionalBoolDefaultFalse = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 12 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.OptionalBoolDefaultFalse = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2040,31 +1962,19 @@ func (v *Edge) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.StartPoint, err = _Point_Decode(sr)
-				if err != nil {
-					return err
-				}
-				startPointIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.StartPoint, err = _Point_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.EndPoint, err = _Point_Decode(sr)
-				if err != nil {
-					return err
-				}
-				endPointIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			startPointIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.EndPoint, err = _Point_Decode(sr)
+			if err != nil {
+				return err
 			}
+			endPointIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2254,7 +2164,7 @@ func (v *EmptyStruct) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2488,31 +2398,19 @@ func (v *Frame) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.TopLeft, err = _Point_Decode(sr)
-				if err != nil {
-					return err
-				}
-				topLeftIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.TopLeft, err = _Point_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.Size, err = _Size_Decode(sr)
-				if err != nil {
-					return err
-				}
-				sizeIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			topLeftIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.Size, err = _Size_Decode(sr)
+			if err != nil {
+				return err
 			}
+			sizeIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2901,83 +2799,47 @@ func (v *GoTags) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Foo, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				FooIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Foo, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Bar = &x
-				if err != nil {
-					return err
-				}
+			FooIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Bar = &x
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TBinary:
+			v.FooBar, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TBinary {
-				v.FooBar, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				FooBarIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			FooBarIsSet = true
+		case fh.ID == 4 && fh.Type == wire.TBinary:
+			v.FooBarWithSpace, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TBinary {
-				v.FooBarWithSpace, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				FooBarWithSpaceIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			FooBarWithSpaceIsSet = true
+		case fh.ID == 5 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.FooBarWithOmitEmpty = &x
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.FooBarWithOmitEmpty = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 6 && fh.Type == wire.TBinary:
+			v.FooBarWithRequired, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TBinary {
-				v.FooBarWithRequired, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				FooBarWithRequiredIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
+			FooBarWithRequiredIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3394,19 +3256,13 @@ func (v *Graph) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.Edges, err = _List_Edge_Decode(sr)
-				if err != nil {
-					return err
-				}
-				edgesIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.Edges, err = _List_Edge_Decode(sr)
+			if err != nil {
+				return err
 			}
+			edgesIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3721,31 +3577,19 @@ func (v *Node) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TI32 {
-				v.Value, err = sr.ReadInt32()
-				if err != nil {
-					return err
-				}
-				valueIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TI32:
+			v.Value, err = sr.ReadInt32()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.Tail, err = _List_Decode(sr)
-				if err != nil {
-					return err
-				}
+			valueIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.Tail, err = _List_Decode(sr)
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4301,111 +4145,63 @@ func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.NotOmitEmptyString = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.NotOmitEmptyString = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.NotOmitEmptyInt = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.NotOmitEmptyInt = &x
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.NotOmitEmptyBool = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.NotOmitEmptyBool = &x
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TList {
-				v.NotOmitEmptyList, err = _List_String_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 4 && fh.Type == wire.TList:
+			v.NotOmitEmptyList, err = _List_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TMap {
-				v.NotOmitEmptyMap, err = _Map_String_String_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TMap:
+			v.NotOmitEmptyMap, err = _Map_String_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TList {
-				v.NotOmitEmptyListMixedWithOmitEmpty, err = _List_String_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 6 && fh.Type == wire.TList:
+			v.NotOmitEmptyListMixedWithOmitEmpty, err = _List_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 7:
-			if fh.Type == wire.TList {
-				v.NotOmitEmptyListMixedWithOmitEmptyV2, err = _List_String_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 7 && fh.Type == wire.TList:
+			v.NotOmitEmptyListMixedWithOmitEmptyV2, err = _List_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 8:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.OmitEmptyString = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 8 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.OmitEmptyString = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4844,31 +4640,19 @@ func (v *Omit) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Serialized, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				serializedIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Serialized, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.Hidden, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				hiddenIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			serializedIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.Hidden, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
+			hiddenIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5083,21 +4867,15 @@ func (v *PersonalInfo) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TI32 {
-				var x int32
-				x, err = sr.ReadInt32()
-				v.Age = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TI32:
+			var x int32
+			x, err = sr.ReadInt32()
+			v.Age = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5334,31 +5112,19 @@ func (v *Point) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TDouble {
-				v.X, err = sr.ReadDouble()
-				if err != nil {
-					return err
-				}
-				xIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TDouble:
+			v.X, err = sr.ReadDouble()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TDouble {
-				v.Y, err = sr.ReadDouble()
-				if err != nil {
-					return err
-				}
-				yIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			xIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TDouble:
+			v.Y, err = sr.ReadDouble()
+			if err != nil {
+				return err
 			}
+			yIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5791,117 +5557,69 @@ func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.BoolField = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.BoolField = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI8 {
-				var x int8
-				x, err = sr.ReadInt8()
-				v.ByteField = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TI8:
+			var x int8
+			x, err = sr.ReadInt8()
+			v.ByteField = &x
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TI16 {
-				var x int16
-				x, err = sr.ReadInt16()
-				v.Int16Field = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TI16:
+			var x int16
+			x, err = sr.ReadInt16()
+			v.Int16Field = &x
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TI32 {
-				var x int32
-				x, err = sr.ReadInt32()
-				v.Int32Field = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 4 && fh.Type == wire.TI32:
+			var x int32
+			x, err = sr.ReadInt32()
+			v.Int32Field = &x
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TI64 {
-				var x int64
-				x, err = sr.ReadInt64()
-				v.Int64Field = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TI64:
+			var x int64
+			x, err = sr.ReadInt64()
+			v.Int64Field = &x
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TDouble {
-				var x float64
-				x, err = sr.ReadDouble()
-				v.DoubleField = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 6 && fh.Type == wire.TDouble:
+			var x float64
+			x, err = sr.ReadDouble()
+			v.DoubleField = &x
+			if err != nil {
+				return err
 			}
-		case 7:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.StringField = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 7 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.StringField = &x
+			if err != nil {
+				return err
 			}
-		case 8:
-			if fh.Type == wire.TBinary {
-				v.BinaryField, err = sr.ReadBinary()
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 8 && fh.Type == wire.TBinary:
+			v.BinaryField, err = sr.ReadBinary()
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -6552,103 +6270,55 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBool {
-				v.BoolField, err = sr.ReadBool()
-				if err != nil {
-					return err
-				}
-				boolFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBool:
+			v.BoolField, err = sr.ReadBool()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI8 {
-				v.ByteField, err = sr.ReadInt8()
-				if err != nil {
-					return err
-				}
-				byteFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			boolFieldIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TI8:
+			v.ByteField, err = sr.ReadInt8()
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TI16 {
-				v.Int16Field, err = sr.ReadInt16()
-				if err != nil {
-					return err
-				}
-				int16FieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			byteFieldIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TI16:
+			v.Int16Field, err = sr.ReadInt16()
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TI32 {
-				v.Int32Field, err = sr.ReadInt32()
-				if err != nil {
-					return err
-				}
-				int32FieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			int16FieldIsSet = true
+		case fh.ID == 4 && fh.Type == wire.TI32:
+			v.Int32Field, err = sr.ReadInt32()
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TI64 {
-				v.Int64Field, err = sr.ReadInt64()
-				if err != nil {
-					return err
-				}
-				int64FieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			int32FieldIsSet = true
+		case fh.ID == 5 && fh.Type == wire.TI64:
+			v.Int64Field, err = sr.ReadInt64()
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TDouble {
-				v.DoubleField, err = sr.ReadDouble()
-				if err != nil {
-					return err
-				}
-				doubleFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			int64FieldIsSet = true
+		case fh.ID == 6 && fh.Type == wire.TDouble:
+			v.DoubleField, err = sr.ReadDouble()
+			if err != nil {
+				return err
 			}
-		case 7:
-			if fh.Type == wire.TBinary {
-				v.StringField, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				stringFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			doubleFieldIsSet = true
+		case fh.ID == 7 && fh.Type == wire.TBinary:
+			v.StringField, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 8:
-			if fh.Type == wire.TBinary {
-				v.BinaryField, err = sr.ReadBinary()
-				if err != nil {
-					return err
-				}
-				binaryFieldIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			stringFieldIsSet = true
+		case fh.ID == 8 && fh.Type == wire.TBinary:
+			v.BinaryField, err = sr.ReadBinary()
+			if err != nil {
+				return err
 			}
+			binaryFieldIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -7016,31 +6686,19 @@ func (v *Rename) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Default, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				DefaultIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Default, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.CamelCase, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				camelCaseIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			DefaultIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.CamelCase, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
+			camelCaseIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -7292,31 +6950,19 @@ func (v *Size) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TDouble {
-				v.Width, err = sr.ReadDouble()
-				if err != nil {
-					return err
-				}
-				widthIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TDouble:
+			v.Width, err = sr.ReadDouble()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TDouble {
-				v.Height, err = sr.ReadDouble()
-				if err != nil {
-					return err
-				}
-				heightIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			widthIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TDouble:
+			v.Height, err = sr.ReadDouble()
+			if err != nil {
+				return err
 			}
+			heightIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -7624,63 +7270,39 @@ func (v *StructLabels) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.IsRequired = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.IsRequired = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Foo = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Foo = &x
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Qux = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Qux = &x
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Quux = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 4 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Quux = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -8041,43 +7663,25 @@ func (v *User) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Name, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				nameIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Name, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.Contact, err = _ContactInfo_Decode(sr)
-				if err != nil {
-					return err
-				}
+			nameIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.Contact, err = _ContactInfo_Decode(sr)
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TStruct:
+			v.Personal, err = _PersonalInfo_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TStruct {
-				v.Personal, err = _PersonalInfo_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -8576,31 +8180,19 @@ func (v *ZapOptOutStruct) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Name, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				nameIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Name, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.Optout, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				optoutIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			nameIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.Optout, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
+			optoutIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -146,6 +146,14 @@ func (v *ContactInfo) Decode(sr stream.Reader) error {
 					return err
 				}
 				emailAddressIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1168,6 +1176,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI32 {
@@ -1178,6 +1190,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TI32 {
@@ -1188,6 +1204,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TI32 {
@@ -1198,6 +1218,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TList {
@@ -1206,6 +1230,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TList {
@@ -1214,6 +1242,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 7:
 			if fh.Type == wire.TStruct {
@@ -1222,6 +1254,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 8:
 			if fh.Type == wire.TStruct {
@@ -1230,6 +1266,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 9:
 			if fh.Type == wire.TBool {
@@ -1240,6 +1280,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 10:
 			if fh.Type == wire.TBool {
@@ -1250,6 +1294,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 11:
 			if fh.Type == wire.TBool {
@@ -1260,6 +1308,10 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 12:
 			if fh.Type == wire.TBool {
@@ -1270,6 +1322,14 @@ func (v *DefaultsStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1988,6 +2048,10 @@ func (v *Edge) Decode(sr stream.Reader) error {
 					return err
 				}
 				startPointIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -1996,6 +2060,14 @@ func (v *Edge) Decode(sr stream.Reader) error {
 					return err
 				}
 				endPointIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2183,6 +2255,10 @@ func (v *EmptyStruct) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -2420,6 +2496,10 @@ func (v *Frame) Decode(sr stream.Reader) error {
 					return err
 				}
 				topLeftIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -2428,6 +2508,14 @@ func (v *Frame) Decode(sr stream.Reader) error {
 					return err
 				}
 				sizeIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2821,6 +2909,10 @@ func (v *GoTags) Decode(sr stream.Reader) error {
 					return err
 				}
 				FooIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -2831,6 +2923,10 @@ func (v *GoTags) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TBinary {
@@ -2839,6 +2935,10 @@ func (v *GoTags) Decode(sr stream.Reader) error {
 					return err
 				}
 				FooBarIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TBinary {
@@ -2847,6 +2947,10 @@ func (v *GoTags) Decode(sr stream.Reader) error {
 					return err
 				}
 				FooBarWithSpaceIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TBinary {
@@ -2857,6 +2961,10 @@ func (v *GoTags) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TBinary {
@@ -2865,6 +2973,14 @@ func (v *GoTags) Decode(sr stream.Reader) error {
 					return err
 				}
 				FooBarWithRequiredIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -3286,6 +3402,14 @@ func (v *Graph) Decode(sr stream.Reader) error {
 					return err
 				}
 				edgesIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -3605,6 +3729,10 @@ func (v *Node) Decode(sr stream.Reader) error {
 					return err
 				}
 				valueIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -3613,6 +3741,14 @@ func (v *Node) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -4175,6 +4311,10 @@ func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -4185,6 +4325,10 @@ func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TBinary {
@@ -4195,6 +4339,10 @@ func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TList {
@@ -4203,6 +4351,10 @@ func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TMap {
@@ -4211,6 +4363,10 @@ func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TList {
@@ -4219,6 +4375,10 @@ func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 7:
 			if fh.Type == wire.TList {
@@ -4227,6 +4387,10 @@ func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 8:
 			if fh.Type == wire.TBinary {
@@ -4237,6 +4401,14 @@ func (v *NotOmitEmpty) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -4680,6 +4852,10 @@ func (v *Omit) Decode(sr stream.Reader) error {
 					return err
 				}
 				serializedIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -4688,6 +4864,14 @@ func (v *Omit) Decode(sr stream.Reader) error {
 					return err
 				}
 				hiddenIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -4909,6 +5093,14 @@ func (v *PersonalInfo) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -5150,6 +5342,10 @@ func (v *Point) Decode(sr stream.Reader) error {
 					return err
 				}
 				xIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TDouble {
@@ -5158,6 +5354,14 @@ func (v *Point) Decode(sr stream.Reader) error {
 					return err
 				}
 				yIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -5597,6 +5801,10 @@ func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI8 {
@@ -5607,6 +5815,10 @@ func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TI16 {
@@ -5617,6 +5829,10 @@ func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TI32 {
@@ -5627,6 +5843,10 @@ func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TI64 {
@@ -5637,6 +5857,10 @@ func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TDouble {
@@ -5647,6 +5871,10 @@ func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 7:
 			if fh.Type == wire.TBinary {
@@ -5657,6 +5885,10 @@ func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 8:
 			if fh.Type == wire.TBinary {
@@ -5665,6 +5897,14 @@ func (v *PrimitiveOptionalStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -6320,6 +6560,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				boolFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI8 {
@@ -6328,6 +6572,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				byteFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TI16 {
@@ -6336,6 +6584,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				int16FieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TI32 {
@@ -6344,6 +6596,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				int32FieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TI64 {
@@ -6352,6 +6608,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				int64FieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TDouble {
@@ -6360,6 +6620,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				doubleFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 7:
 			if fh.Type == wire.TBinary {
@@ -6368,6 +6632,10 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				stringFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 8:
 			if fh.Type == wire.TBinary {
@@ -6376,6 +6644,14 @@ func (v *PrimitiveRequiredStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				binaryFieldIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -6748,6 +7024,10 @@ func (v *Rename) Decode(sr stream.Reader) error {
 					return err
 				}
 				DefaultIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -6756,6 +7036,14 @@ func (v *Rename) Decode(sr stream.Reader) error {
 					return err
 				}
 				camelCaseIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -7012,6 +7300,10 @@ func (v *Size) Decode(sr stream.Reader) error {
 					return err
 				}
 				widthIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TDouble {
@@ -7020,6 +7312,14 @@ func (v *Size) Decode(sr stream.Reader) error {
 					return err
 				}
 				heightIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -7334,6 +7634,10 @@ func (v *StructLabels) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -7344,6 +7648,10 @@ func (v *StructLabels) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TBinary {
@@ -7354,6 +7662,10 @@ func (v *StructLabels) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TBinary {
@@ -7364,6 +7676,14 @@ func (v *StructLabels) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -7729,6 +8049,10 @@ func (v *User) Decode(sr stream.Reader) error {
 					return err
 				}
 				nameIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -7737,6 +8061,10 @@ func (v *User) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TStruct {
@@ -7745,6 +8073,14 @@ func (v *User) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -8248,6 +8584,10 @@ func (v *ZapOptOutStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				nameIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -8256,6 +8596,14 @@ func (v *ZapOptOutStruct) Decode(sr stream.Reader) error {
 					return err
 				}
 				optoutIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -353,21 +353,15 @@ func (v *DefaultPrimitiveTypedef) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				var x State
-				x, err = _State_Decode(sr)
-				v.State = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			var x State
+			x, err = _State_Decode(sr)
+			v.State = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -955,33 +949,21 @@ func (v *Event) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.UUID, err = _UUID_Decode(sr)
-				if err != nil {
-					return err
-				}
-				uuidIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.UUID, err = _UUID_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI64 {
-				var x Timestamp
-				x, err = _Timestamp_Decode(sr)
-				v.Time = &x
-				if err != nil {
-					return err
-				}
+			uuidIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TI64:
+			var x Timestamp
+			x, err = _Timestamp_Decode(sr)
+			v.Time = &x
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2427,43 +2409,25 @@ func (v *Transition) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.FromState, err = _State_Decode(sr)
-				if err != nil {
-					return err
-				}
-				fromStateIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.FromState, err = _State_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.ToState, err = _State_Decode(sr)
-				if err != nil {
-					return err
-				}
-				toStateIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			fromStateIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.ToState, err = _State_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TList {
-				v.Events, err = _EventGroup_Decode(sr)
-				if err != nil {
-					return err
-				}
+			toStateIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TList:
+			v.Events, err = _EventGroup_Decode(sr)
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2723,19 +2687,13 @@ func (v *TransitiveTypedefField) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.DefUUID, err = _MyUUID_Decode(sr)
-				if err != nil {
-					return err
-				}
-				defUUIDIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.DefUUID, err = _MyUUID_Decode(sr)
+			if err != nil {
+				return err
 			}
+			defUUIDIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3013,31 +2971,19 @@ func (v *I128) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TI64 {
-				v.High, err = sr.ReadInt64()
-				if err != nil {
-					return err
-				}
-				highIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TI64:
+			v.High, err = sr.ReadInt64()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI64 {
-				v.Low, err = sr.ReadInt64()
-				if err != nil {
-					return err
-				}
-				lowIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			highIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TI64:
+			v.Low, err = sr.ReadInt64()
+			if err != nil {
+				return err
 			}
+			lowIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -363,6 +363,14 @@ func (v *DefaultPrimitiveTypedef) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -955,6 +963,10 @@ func (v *Event) Decode(sr stream.Reader) error {
 					return err
 				}
 				uuidIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI64 {
@@ -965,6 +977,14 @@ func (v *Event) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2415,6 +2435,10 @@ func (v *Transition) Decode(sr stream.Reader) error {
 					return err
 				}
 				fromStateIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -2423,6 +2447,10 @@ func (v *Transition) Decode(sr stream.Reader) error {
 					return err
 				}
 				toStateIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TList {
@@ -2431,6 +2459,14 @@ func (v *Transition) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2695,6 +2731,14 @@ func (v *TransitiveTypedefField) Decode(sr stream.Reader) error {
 					return err
 				}
 				defUUIDIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2977,6 +3021,10 @@ func (v *I128) Decode(sr stream.Reader) error {
 					return err
 				}
 				highIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI64 {
@@ -2985,6 +3033,14 @@ func (v *I128) Decode(sr stream.Reader) error {
 					return err
 				}
 				lowIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -549,73 +549,43 @@ func (v *ArbitraryValue) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.BoolValue = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.BoolValue = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI64 {
-				var x int64
-				x, err = sr.ReadInt64()
-				v.Int64Value = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TI64:
+			var x int64
+			x, err = sr.ReadInt64()
+			v.Int64Value = &x
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.StringValue = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.StringValue = &x
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TList {
-				v.ListValue, err = _List_ArbitraryValue_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 4 && fh.Type == wire.TList:
+			v.ListValue, err = _List_ArbitraryValue_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TMap {
-				v.MapValue, err = _Map_String_ArbitraryValue_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TMap:
+			v.MapValue, err = _Map_String_ArbitraryValue_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1089,33 +1059,21 @@ func (v *Document) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Pdf, err = _PDF_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Pdf, err = _PDF_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.PlainText = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.PlainText = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1318,7 +1276,7 @@ func (v *EmptyUnion) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -559,6 +559,10 @@ func (v *ArbitraryValue) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI64 {
@@ -569,6 +573,10 @@ func (v *ArbitraryValue) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TBinary {
@@ -579,6 +587,10 @@ func (v *ArbitraryValue) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TList {
@@ -587,6 +599,10 @@ func (v *ArbitraryValue) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TMap {
@@ -595,6 +611,14 @@ func (v *ArbitraryValue) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1073,6 +1097,10 @@ func (v *Document) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -1083,6 +1111,14 @@ func (v *Document) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1283,6 +1319,10 @@ func (v *EmptyUnion) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -244,31 +244,19 @@ func (v *UUIDConflict) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.LocalUUID, err = _UUID_Decode(sr)
-				if err != nil {
-					return err
-				}
-				localUUIDIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.LocalUUID, err = _UUID_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.ImportedUUID, err = _UUID_1_Decode(sr)
-				if err != nil {
-					return err
-				}
-				importedUUIDIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			localUUIDIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.ImportedUUID, err = _UUID_1_Decode(sr)
+			if err != nil {
+				return err
 			}
+			importedUUIDIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -252,6 +252,10 @@ func (v *UUIDConflict) Decode(sr stream.Reader) error {
 					return err
 				}
 				localUUIDIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -260,6 +264,14 @@ func (v *UUIDConflict) Decode(sr stream.Reader) error {
 					return err
 				}
 				importedUUIDIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -762,14 +762,16 @@ func TestStructFromWireUnrecognizedField(t *testing.T) {
 				buf bytes.Buffer
 			)
 
-			protocol.Binary.Encode(tt.give, &buf)
+			require.NoError(t, binary.Default.Encode(tt.give, &buf))
 
-			sr := protocol.BinaryStreamer.Reader(bytes.NewReader(buf.Bytes()))
+			sr := binary.Default.Reader(bytes.NewReader(buf.Bytes()))
+			defer sr.Close()
 			err := o.Decode(sr)
 			if tt.wantError != "" {
 				if assert.Error(t, err, tt.desc) {
 					assert.Contains(t, err.Error(), tt.wantError)
 				}
+				return
 			} else {
 				if assert.NoError(t, err, tt.desc) {
 					assert.Equal(t, tt.want, o)
@@ -850,14 +852,16 @@ func TestUnionFromWireInconsistencies(t *testing.T) {
 				buf bytes.Buffer
 			)
 
-			protocol.Binary.Encode(tt.input, &buf)
+			require.NoError(t, binary.Default.Encode(tt.input, &buf))
 
-			sr := protocol.BinaryStreamer.Reader(bytes.NewReader(buf.Bytes()))
+			sr := binary.Default.Reader(bytes.NewReader(buf.Bytes()))
+			defer sr.Close()
 			err := o.Decode(sr)
 			if tt.success != nil {
 				if assert.NoError(t, err, tt.desc) {
 					assert.Equal(t, tt.success, &o, tt.desc)
 				}
+				return
 			} else {
 				if assert.Error(t, err, tt.desc) {
 					assert.Contains(t, err.Error(), tt.failure, tt.desc)

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -524,6 +524,10 @@ func (v *TApplicationException) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI32 {
@@ -534,6 +538,14 @@ func (v *TApplicationException) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -514,35 +514,23 @@ func (v *TApplicationException) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.Message = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.Message = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI32 {
-				var x ExceptionType
-				x, err = _ExceptionType_Decode(sr)
-				v.Type = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TI32:
+			var x ExceptionType
+			x, err = _ExceptionType_Decode(sr)
+			v.Type = &x
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -396,43 +396,25 @@ func (v *Argument) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Name, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				nameIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Name, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.Type, err = _Type_Decode(sr)
-				if err != nil {
-					return err
-				}
-				typeIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			nameIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.Type, err = _Type_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TMap {
-				v.Annotations, err = _Map_String_String_Decode(sr)
-				if err != nil {
-					return err
-				}
+			typeIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TMap:
+			v.Annotations, err = _Map_String_String_Decode(sr)
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -1216,93 +1198,51 @@ func (v *Function) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Name, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				nameIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Name, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.ThriftName, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				thriftNameIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			nameIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.ThriftName, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TList {
-				v.Arguments, err = _List_Argument_Decode(sr)
-				if err != nil {
-					return err
-				}
-				argumentsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			thriftNameIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TList:
+			v.Arguments, err = _List_Argument_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TStruct {
-				v.ReturnType, err = _Type_Decode(sr)
-				if err != nil {
-					return err
-				}
+			argumentsIsSet = true
+		case fh.ID == 4 && fh.Type == wire.TStruct:
+			v.ReturnType, err = _Type_Decode(sr)
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TList:
+			v.Exceptions, err = _List_Argument_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TList {
-				v.Exceptions, err = _List_Argument_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 6 && fh.Type == wire.TBool:
+			var x bool
+			x, err = sr.ReadBool()
+			v.OneWay = &x
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TBool {
-				var x bool
-				x, err = sr.ReadBool()
-				v.OneWay = &x
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 7 && fh.Type == wire.TMap:
+			v.Annotations, err = _Map_String_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 7:
-			if fh.Type == wire.TMap {
-				v.Annotations, err = _Map_String_String_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -2369,79 +2309,43 @@ func (v *GenerateServiceRequest) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TList {
-				v.RootServices, err = _List_ServiceID_Decode(sr)
-				if err != nil {
-					return err
-				}
-				rootServicesIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TList:
+			v.RootServices, err = _List_ServiceID_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TMap {
-				v.Services, err = _Map_ServiceID_Service_Decode(sr)
-				if err != nil {
-					return err
-				}
-				servicesIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			rootServicesIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TMap:
+			v.Services, err = _Map_ServiceID_Service_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TMap {
-				v.Modules, err = _Map_ModuleID_Module_Decode(sr)
-				if err != nil {
-					return err
-				}
-				modulesIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			servicesIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TMap:
+			v.Modules, err = _Map_ModuleID_Module_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TBinary {
-				v.PackagePrefix, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				packagePrefixIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			modulesIsSet = true
+		case fh.ID == 4 && fh.Type == wire.TBinary:
+			v.PackagePrefix, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TBinary {
-				v.ThriftRoot, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				thriftRootIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			packagePrefixIsSet = true
+		case fh.ID == 5 && fh.Type == wire.TBinary:
+			v.ThriftRoot, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TList {
-				v.RootModules, err = _List_ModuleID_Decode(sr)
-				if err != nil {
-					return err
-				}
+			thriftRootIsSet = true
+		case fh.ID == 6 && fh.Type == wire.TList:
+			v.RootModules, err = _List_ModuleID_Decode(sr)
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3025,19 +2929,13 @@ func (v *GenerateServiceResponse) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TMap {
-				v.Files, err = _Map_String_Binary_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TMap:
+			v.Files, err = _Map_String_Binary_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3234,7 +3132,7 @@ func (v *HandshakeRequest) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -3623,57 +3521,33 @@ func (v *HandshakeResponse) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Name, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				nameIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Name, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TI32 {
-				v.APIVersion, err = sr.ReadInt32()
-				if err != nil {
-					return err
-				}
-				apiVersionIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			nameIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TI32:
+			v.APIVersion, err = sr.ReadInt32()
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TList {
-				v.Features, err = _List_Feature_Decode(sr)
-				if err != nil {
-					return err
-				}
-				featuresIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			apiVersionIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TList:
+			v.Features, err = _List_Feature_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TBinary {
-				var x string
-				x, err = sr.ReadString()
-				v.LibraryVersion = &x
-				if err != nil {
-					return err
-				}
+			featuresIsSet = true
+		case fh.ID == 4 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.LibraryVersion = &x
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4049,43 +3923,25 @@ func (v *Module) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.ImportPath, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				importPathIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.ImportPath, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.Directory, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				directoryIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			importPathIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.Directory, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TBinary {
-				v.ThriftFilePath, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				thriftFilePathIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			directoryIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TBinary:
+			v.ThriftFilePath, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
+			thriftFilePathIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -4657,81 +4513,45 @@ func (v *Service) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 7:
-			if fh.Type == wire.TBinary {
-				v.Name, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				nameIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 7 && fh.Type == wire.TBinary:
+			v.Name, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.ThriftName, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				thriftNameIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			nameIsSet = true
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.ThriftName, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TI32 {
-				var x ServiceID
-				x, err = _ServiceID_Decode(sr)
-				v.ParentID = &x
-				if err != nil {
-					return err
-				}
+			thriftNameIsSet = true
+		case fh.ID == 4 && fh.Type == wire.TI32:
+			var x ServiceID
+			x, err = _ServiceID_Decode(sr)
+			v.ParentID = &x
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TList:
+			v.Functions, err = _List_Function_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TList {
-				v.Functions, err = _List_Function_Decode(sr)
-				if err != nil {
-					return err
-				}
-				functionsIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			functionsIsSet = true
+		case fh.ID == 6 && fh.Type == wire.TI32:
+			v.ModuleID, err = _ModuleID_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TI32 {
-				v.ModuleID, err = _ModuleID_Decode(sr)
-				if err != nil {
-					return err
-				}
-				moduleIDIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			moduleIDIsSet = true
+		case fh.ID == 8 && fh.Type == wire.TMap:
+			v.Annotations, err = _Map_String_String_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 8:
-			if fh.Type == wire.TMap {
-				v.Annotations, err = _Map_String_String_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5660,81 +5480,45 @@ func (v *Type) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TI32 {
-				var x SimpleType
-				x, err = _SimpleType_Decode(sr)
-				v.SimpleType = &x
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TI32:
+			var x SimpleType
+			x, err = _SimpleType_Decode(sr)
+			v.SimpleType = &x
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.SliceType, err = _Type_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.SliceType, err = _Type_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TStruct {
-				v.KeyValueSliceType, err = _TypePair_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 3 && fh.Type == wire.TStruct:
+			v.KeyValueSliceType, err = _TypePair_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 4:
-			if fh.Type == wire.TStruct {
-				v.MapType, err = _TypePair_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 4 && fh.Type == wire.TStruct:
+			v.MapType, err = _TypePair_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 5:
-			if fh.Type == wire.TStruct {
-				v.ReferenceType, err = _TypeReference_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 5 && fh.Type == wire.TStruct:
+			v.ReferenceType, err = _TypeReference_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 6:
-			if fh.Type == wire.TStruct {
-				v.PointerType, err = _Type_Decode(sr)
-				if err != nil {
-					return err
-				}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		case fh.ID == 6 && fh.Type == wire.TStruct:
+			v.PointerType, err = _Type_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -6140,31 +5924,19 @@ func (v *TypePair) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.Left, err = _Type_Decode(sr)
-				if err != nil {
-					return err
-				}
-				leftIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.Left, err = _Type_Decode(sr)
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TStruct {
-				v.Right, err = _Type_Decode(sr)
-				if err != nil {
-					return err
-				}
-				rightIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			leftIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.Right, err = _Type_Decode(sr)
+			if err != nil {
+				return err
 			}
+			rightIsSet = true
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -6472,43 +6244,25 @@ func (v *TypeReference) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TBinary {
-				v.Name, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				nameIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TBinary:
+			v.Name, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 2:
-			if fh.Type == wire.TBinary {
-				v.ImportPath, err = sr.ReadString()
-				if err != nil {
-					return err
-				}
-				importPathIsSet = true
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+			nameIsSet = true
+		case fh.ID == 2 && fh.Type == wire.TBinary:
+			v.ImportPath, err = sr.ReadString()
+			if err != nil {
+				return err
 			}
-		case 3:
-			if fh.Type == wire.TMap {
-				v.Annotations, err = _Map_String_String_Decode(sr)
-				if err != nil {
-					return err
-				}
+			importPathIsSet = true
+		case fh.ID == 3 && fh.Type == wire.TMap:
+			v.Annotations, err = _Map_String_String_Decode(sr)
+			if err != nil {
+				return err
+			}
 
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
-			}
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -6727,7 +6481,7 @@ func (v *Plugin_Goodbye_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -6956,7 +6710,7 @@ func (v *Plugin_Goodbye_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
+		switch {
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -7161,19 +6915,13 @@ func (v *Plugin_Handshake_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.Request, err = _HandshakeRequest_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.Request, err = _HandshakeRequest_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -7508,19 +7256,13 @@ func (v *Plugin_Handshake_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 0:
-			if fh.Type == wire.TStruct {
-				v.Success, err = _HandshakeResponse_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 0 && fh.Type == wire.TStruct:
+			v.Success, err = _HandshakeResponse_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -7758,19 +7500,13 @@ func (v *ServiceGenerator_Generate_Args) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 1:
-			if fh.Type == wire.TStruct {
-				v.Request, err = _GenerateServiceRequest_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.Request, err = _GenerateServiceRequest_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -8105,19 +7841,13 @@ func (v *ServiceGenerator_Generate_Result) Decode(sr stream.Reader) error {
 	}
 
 	for ok {
-		switch fh.ID {
-		case 0:
-			if fh.Type == wire.TStruct {
-				v.Success, err = _GenerateServiceResponse_Decode(sr)
-				if err != nil {
-					return err
-				}
-
-			} else {
-				if err := sr.Skip(fh.Type); err != nil {
-					return err
-				}
+		switch {
+		case fh.ID == 0 && fh.Type == wire.TStruct:
+			v.Success, err = _GenerateServiceResponse_Decode(sr)
+			if err != nil {
+				return err
 			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -404,6 +404,10 @@ func (v *Argument) Decode(sr stream.Reader) error {
 					return err
 				}
 				nameIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -412,6 +416,10 @@ func (v *Argument) Decode(sr stream.Reader) error {
 					return err
 				}
 				typeIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TMap {
@@ -420,6 +428,14 @@ func (v *Argument) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -1208,6 +1224,10 @@ func (v *Function) Decode(sr stream.Reader) error {
 					return err
 				}
 				nameIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -1216,6 +1236,10 @@ func (v *Function) Decode(sr stream.Reader) error {
 					return err
 				}
 				thriftNameIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TList {
@@ -1224,6 +1248,10 @@ func (v *Function) Decode(sr stream.Reader) error {
 					return err
 				}
 				argumentsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TStruct {
@@ -1232,6 +1260,10 @@ func (v *Function) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TList {
@@ -1240,6 +1272,10 @@ func (v *Function) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TBool {
@@ -1250,6 +1286,10 @@ func (v *Function) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 7:
 			if fh.Type == wire.TMap {
@@ -1258,6 +1298,14 @@ func (v *Function) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2329,6 +2377,10 @@ func (v *GenerateServiceRequest) Decode(sr stream.Reader) error {
 					return err
 				}
 				rootServicesIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TMap {
@@ -2337,6 +2389,10 @@ func (v *GenerateServiceRequest) Decode(sr stream.Reader) error {
 					return err
 				}
 				servicesIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TMap {
@@ -2345,6 +2401,10 @@ func (v *GenerateServiceRequest) Decode(sr stream.Reader) error {
 					return err
 				}
 				modulesIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TBinary {
@@ -2353,6 +2413,10 @@ func (v *GenerateServiceRequest) Decode(sr stream.Reader) error {
 					return err
 				}
 				packagePrefixIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TBinary {
@@ -2361,6 +2425,10 @@ func (v *GenerateServiceRequest) Decode(sr stream.Reader) error {
 					return err
 				}
 				thriftRootIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TList {
@@ -2369,6 +2437,14 @@ func (v *GenerateServiceRequest) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -2957,6 +3033,14 @@ func (v *GenerateServiceResponse) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -3151,6 +3235,10 @@ func (v *HandshakeRequest) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -3543,6 +3631,10 @@ func (v *HandshakeResponse) Decode(sr stream.Reader) error {
 					return err
 				}
 				nameIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TI32 {
@@ -3551,6 +3643,10 @@ func (v *HandshakeResponse) Decode(sr stream.Reader) error {
 					return err
 				}
 				apiVersionIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TList {
@@ -3559,6 +3655,10 @@ func (v *HandshakeResponse) Decode(sr stream.Reader) error {
 					return err
 				}
 				featuresIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TBinary {
@@ -3569,6 +3669,14 @@ func (v *HandshakeResponse) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -3949,6 +4057,10 @@ func (v *Module) Decode(sr stream.Reader) error {
 					return err
 				}
 				importPathIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -3957,6 +4069,10 @@ func (v *Module) Decode(sr stream.Reader) error {
 					return err
 				}
 				directoryIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TBinary {
@@ -3965,6 +4081,14 @@ func (v *Module) Decode(sr stream.Reader) error {
 					return err
 				}
 				thriftFilePathIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -4541,6 +4665,10 @@ func (v *Service) Decode(sr stream.Reader) error {
 					return err
 				}
 				nameIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 1:
 			if fh.Type == wire.TBinary {
@@ -4549,6 +4677,10 @@ func (v *Service) Decode(sr stream.Reader) error {
 					return err
 				}
 				thriftNameIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TI32 {
@@ -4559,6 +4691,10 @@ func (v *Service) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TList {
@@ -4567,6 +4703,10 @@ func (v *Service) Decode(sr stream.Reader) error {
 					return err
 				}
 				functionsIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TI32 {
@@ -4575,6 +4715,10 @@ func (v *Service) Decode(sr stream.Reader) error {
 					return err
 				}
 				moduleIDIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 8:
 			if fh.Type == wire.TMap {
@@ -4583,6 +4727,14 @@ func (v *Service) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -5518,6 +5670,10 @@ func (v *Type) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -5526,6 +5682,10 @@ func (v *Type) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TStruct {
@@ -5534,6 +5694,10 @@ func (v *Type) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 4:
 			if fh.Type == wire.TStruct {
@@ -5542,6 +5706,10 @@ func (v *Type) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 5:
 			if fh.Type == wire.TStruct {
@@ -5550,6 +5718,10 @@ func (v *Type) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 6:
 			if fh.Type == wire.TStruct {
@@ -5558,6 +5730,14 @@ func (v *Type) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -5968,6 +6148,10 @@ func (v *TypePair) Decode(sr stream.Reader) error {
 					return err
 				}
 				leftIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TStruct {
@@ -5976,6 +6160,14 @@ func (v *TypePair) Decode(sr stream.Reader) error {
 					return err
 				}
 				rightIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -6288,6 +6480,10 @@ func (v *TypeReference) Decode(sr stream.Reader) error {
 					return err
 				}
 				nameIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 2:
 			if fh.Type == wire.TBinary {
@@ -6296,6 +6492,10 @@ func (v *TypeReference) Decode(sr stream.Reader) error {
 					return err
 				}
 				importPathIsSet = true
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
 			}
 		case 3:
 			if fh.Type == wire.TMap {
@@ -6304,6 +6504,14 @@ func (v *TypeReference) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -6520,6 +6728,10 @@ func (v *Plugin_Goodbye_Args) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -6745,6 +6957,10 @@ func (v *Plugin_Goodbye_Result) Decode(sr stream.Reader) error {
 
 	for ok {
 		switch fh.ID {
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
+			}
 		}
 
 		if err := sr.ReadFieldEnd(); err != nil {
@@ -6953,6 +7169,14 @@ func (v *Plugin_Handshake_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -7292,6 +7516,14 @@ func (v *Plugin_Handshake_Result) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -7534,6 +7766,14 @@ func (v *ServiceGenerator_Generate_Args) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 
@@ -7873,6 +8113,14 @@ func (v *ServiceGenerator_Generate_Result) Decode(sr stream.Reader) error {
 					return err
 				}
 
+			} else {
+				if err := sr.Skip(fh.Type); err != nil {
+					return err
+				}
+			}
+		default:
+			if err := sr.Skip(fh.Type); err != nil {
+				return err
 			}
 		}
 


### PR DESCRIPTION
In the Wire-based implementation of reading the raw Thrift protocol, the reader
greedily reads over all of the fields in the structs, populating a Wire
intermediary format.  This format is then validated and parsed by the generated
code, populating the appropriate Thrift object with the proper values
associated with the corresponding field ID.

In the stream-based implementation, validation and parsing of the raw Thrift
protocol is done as the bytes are read.  Since unrecognized fields were not
skipped over, this caused issues in future reads as there is now data that
doesn't match the expected Thrift type.

Skip over fields that are unrecognized by the streaming reader and skip fields
that don't match the type expected by the Thrift definition.