### PR TITLE
gen/test: Merge thriftType and streamingThriftType

### DIFF
--- a/gen/container_test.go
+++ b/gen/container_test.go
@@ -1338,16 +1338,13 @@ func TestContainerValidate(t *testing.T) {
 		})
 
 		t.Run(tt.desc+"/streaming", func(t *testing.T) {
-			stt, ok := tt.value.(streamingThriftType)
-			require.True(t, ok)
-
 			var buf bytes.Buffer
 			sw := binary.Default.Writer(&buf)
 			defer func() {
 				assert.NoError(t, sw.Close())
 			}()
 
-			err := stt.Encode(sw)
+			err := tt.value.Encode(sw)
 			require.Error(t, err)
 			assert.Equal(t, tt.wantError, err.Error())
 		})

--- a/gen/quick_test.go
+++ b/gen/quick_test.go
@@ -785,22 +785,16 @@ func (q *quickSuite) testThriftRoundTripStreaming(t *testing.T, give, defaults t
 	want := populateDefaults(give, defaults)
 	shouldCheckForMutation := defaults != nil && !assert.ObjectsAreEqual(want, give)
 
-	sGive, ok := give.(streamingThriftType)
-	require.True(t, ok, "given thrift type must satisfy streaming requirements")
-
-	sWant, ok := want.(streamingThriftType)
-	require.True(t, ok, "default thrift type must satisfy streaming requirements")
-
 	sw := binary.NewStreamWriter(&buf)
-	require.NoError(t, sGive.Encode(sw), "failed to streaming encode %v", sGive)
+	require.NoError(t, give.Encode(sw), "failed to streaming encode %v", give)
 	require.NoError(t, sw.Close())
 
-	gType := reflect.TypeOf(sGive)
+	gType := reflect.TypeOf(give)
 	if gType.Kind() == reflect.Ptr {
 		gType = gType.Elem()
 	}
 
-	got := reflect.New(gType).Interface().(streamingThriftType)
+	got := reflect.New(gType).Interface().(thriftType)
 
 	sr := binary.NewStreamReader(&buf)
 	require.NoError(t, got.Decode(sr), "failed to streaming decode from %v", buf)
@@ -809,7 +803,7 @@ func (q *quickSuite) testThriftRoundTripStreaming(t *testing.T, give, defaults t
 	assert.Equal(t, want, got)
 	if shouldCheckForMutation {
 		// assert that give has not been mutated to the want object during the ToWire call
-		assert.NotEqual(t, sWant, sGive)
+		assert.NotEqual(t, want, give)
 	}
 }
 

--- a/gen/roundtrip_test.go
+++ b/gen/roundtrip_test.go
@@ -110,9 +110,7 @@ func testRoundTripCombos(t *testing.T, x thriftType, v wire.Value, msg string) {
 
 			if streaming.encode {
 				w := binary.NewStreamWriter(&buff)
-				give, ok := x.(streamingThriftType)
-				require.True(t, ok)
-				require.NoError(t, give.Encode(w), "%v: failed to stream encode", msg)
+				require.NoError(t, x.Encode(w), "%v: failed to stream encode", msg)
 				require.NoError(t, w.Close())
 			} else {
 				w, err := x.ToWire()
@@ -123,9 +121,8 @@ func testRoundTripCombos(t *testing.T, x thriftType, v wire.Value, msg string) {
 
 			if streaming.decode {
 				reader := streamer.Reader(bytes.NewReader(buff.Bytes()))
-				gotX, ok := reflect.New(xType).Interface().(streamingThriftType)
-				require.True(t, ok)
 
+				gotX := reflect.New(xType).Interface().(thriftType)
 				require.NoError(t, gotX.Decode(reader), "streaming decode")
 				assert.Equal(t, x, gotX)
 			} else {

--- a/gen/service_test.go
+++ b/gen/service_test.go
@@ -43,8 +43,7 @@ import (
 type serviceType interface {
 	fmt.Stringer
 	envelope.Enveloper
-
-	FromWire(wire.Value) error
+	thriftType
 }
 
 func TestServiceArgsAndResult(t *testing.T) {

--- a/gen/util_for_test.go
+++ b/gen/util_for_test.go
@@ -37,14 +37,6 @@ type thriftType interface {
 
 	ToWire() (wire.Value, error)
 	FromWire(wire.Value) error
-}
-
-// streamingThriftType is implemented by all generated types that know how to
-// write and read themselves to the Thrift Protocol, skipping over the
-// intermediary wire.Type
-type streamingThriftType interface {
-	thriftType
-
 	Encode(stream.Writer) error
 	Decode(stream.Reader) error
 }


### PR DESCRIPTION
Now that all generated types support streaming, there's no reason to
separate thriftType and streamingThriftType.
