### PR TITLE
Run more tests using the streaming implementation

### DIFF
--- a/gen/container_test.go
+++ b/gen/container_test.go
@@ -1381,21 +1381,40 @@ func TestEmptyContainersRoundTrip(t *testing.T) {
 			MapOfIntsToDoubles: make(map[int64]float64),
 		}
 
-		b, err := json.Marshal(give)
-		require.NoError(t, err, "failed to encode to JSON")
+		t.Run("JSON", func(t *testing.T) {
+			b, err := json.Marshal(give)
+			require.NoError(t, err, "failed to encode to JSON")
 
-		var decoded tc.PrimitiveContainersRequired
-		require.NoError(t, json.Unmarshal(b, &decoded), "failed to decode JSON")
+			var decoded tc.PrimitiveContainersRequired
+			require.NoError(t, json.Unmarshal(b, &decoded), "failed to decode JSON")
 
-		assert.Equal(t, give, decoded)
+			assert.Equal(t, give, decoded)
+		})
 
-		v, err := decoded.ToWire()
-		require.NoError(t, err, "failed to convert to wire.Value")
+		t.Run("Wire", func(t *testing.T) {
+			v, err := give.ToWire()
+			require.NoError(t, err, "failed to convert to wire.Value")
 
-		var got tc.PrimitiveContainersRequired
-		require.NoError(t, got.FromWire(v), "failed to convert from wire.Value")
+			var got tc.PrimitiveContainersRequired
+			require.NoError(t, got.FromWire(v), "failed to convert from wire.Value")
 
-		assert.Equal(t, give, got)
+			assert.Equal(t, give, got)
+		})
+
+		t.Run("Stream", func(t *testing.T) {
+			var buff bytes.Buffer
+			sw := binary.Default.Writer(&buff)
+			defer sw.Close()
+			require.NoError(t, give.Encode(sw))
+
+			sr := binary.Default.Reader(bytes.NewReader(buff.Bytes()))
+			defer sr.Close()
+
+			var got tc.PrimitiveContainersRequired
+			require.NoError(t, got.Decode(sr))
+
+			assert.Equal(t, give, got)
+		})
 	})
 
 	t.Run("optional", func(t *testing.T) {
@@ -1405,26 +1424,49 @@ func TestEmptyContainersRoundTrip(t *testing.T) {
 			MapOfIntToString: make(map[int32]string),
 		}
 
-		b, err := json.Marshal(give)
-		require.NoError(t, err, "failed to encode to JSON")
+		t.Run("JSON", func(t *testing.T) {
+			b, err := json.Marshal(give)
+			require.NoError(t, err, "failed to encode to JSON")
 
-		var decoded tc.PrimitiveContainers
-		require.NoError(t, json.Unmarshal(b, &decoded), "failed to decode JSON")
+			var decoded tc.PrimitiveContainers
+			require.NoError(t, json.Unmarshal(b, &decoded), "failed to decode JSON")
 
-		// We check individual fields because a full assert.Equal could mismatch
-		// on nil vs empty slice.
-		assert.Empty(t, decoded.ListOfInts)
-		assert.Empty(t, decoded.SetOfStrings)
-		assert.Empty(t, decoded.MapOfIntToString)
+			// We check individual fields because a full assert.Equal could mismatch
+			// on nil vs empty slice.
+			assert.Empty(t, decoded.ListOfInts)
+			assert.Empty(t, decoded.SetOfStrings)
+			assert.Empty(t, decoded.MapOfIntToString)
 
-		v, err := decoded.ToWire()
-		require.NoError(t, err, "failed to convert to wire.Value")
+		})
 
-		var got tc.PrimitiveContainers
-		require.NoError(t, got.FromWire(v), "failed to convert from wire.Value")
+		t.Run("JSON", func(t *testing.T) {
+			v, err := give.ToWire()
+			require.NoError(t, err, "failed to convert to wire.Value")
 
-		assert.Empty(t, got.ListOfInts)
-		assert.Empty(t, got.SetOfStrings)
-		assert.Empty(t, got.MapOfIntToString)
+			var got tc.PrimitiveContainers
+			require.NoError(t, got.FromWire(v), "failed to convert from wire.Value")
+
+			assert.Empty(t, got.ListOfInts)
+			assert.Empty(t, got.SetOfStrings)
+			assert.Empty(t, got.MapOfIntToString)
+		})
+
+		t.Run("stream", func(t *testing.T) {
+			var buff bytes.Buffer
+			sw := binary.Default.Writer(&buff)
+			defer sw.Close()
+			require.NoError(t, give.Encode(sw))
+
+			sr := binary.Default.Reader(bytes.NewReader(buff.Bytes()))
+			defer sr.Close()
+
+			var got tc.PrimitiveContainers
+			require.NoError(t, got.Decode(sr))
+
+			assert.Empty(t, got.ListOfInts)
+			assert.Empty(t, got.SetOfStrings)
+			assert.Empty(t, got.MapOfIntToString)
+
+		})
 	})
 }

--- a/gen/enum_test.go
+++ b/gen/enum_test.go
@@ -160,10 +160,18 @@ func TestEnumWithDuplicateValuesWire(t *testing.T) {
 }
 
 func TestUnknownEnumValue(t *testing.T) {
+	wv := wire.NewValueI32(42)
+
 	var e te.EnumDefault
-	if assert.NoError(t, e.FromWire(wire.NewValueI32(42))) {
+	if assert.NoError(t, e.FromWire(wv)) {
 		assert.Equal(t, te.EnumDefault(42), e)
 	}
+
+	var se te.EnumDefault
+	if assert.NoError(t, streamDecodeWireType(t, wv, &se)) {
+		assert.Equal(t, te.EnumDefault(42), se)
+	}
+
 }
 
 func TestOptionalEnum(t *testing.T) {

--- a/gen/list_test.go
+++ b/gen/list_test.go
@@ -143,17 +143,28 @@ func TestListRequiredFromWire(t *testing.T) {
 		got := new(tc.ListOfRequiredPrimitives)
 		require.NoError(t, got.FromWire(give), "failed to decode")
 		require.Equal(t, want, got)
-		_, ok := assertBinaryRoundTrip(t, give, t.Name())
-		assert.True(t, ok, "failed round trip")
+
+		testRoundTripCombos(t, want, give, "")
 	})
 
 	// Error if required list is missing in the wire representation.
 	t.Run("absent list field results in an error", func(t *testing.T) {
 		give := wire.NewValueStruct(wire.Struct{})
-		x := new(tc.ListOfRequiredPrimitives)
-		err := x.FromWire(give)
-		require.Error(t, err, "failed to decode")
-		assert.Equal(t, "field ListOfStrings of ListOfRequiredPrimitives is required", err.Error())
+
+		t.Run("FromWire", func(t *testing.T) {
+			x := new(tc.ListOfRequiredPrimitives)
+			err := x.FromWire(give)
+			require.Error(t, err, "failed to fromwire")
+			assert.Equal(t, "field ListOfStrings of ListOfRequiredPrimitives is required", err.Error())
+		})
+
+		t.Run("StreamDecode", func(t *testing.T) {
+			x := new(tc.ListOfRequiredPrimitives)
+			err := streamDecodeWireType(t, give, x)
+			require.Error(t, err, "failed to stream decode")
+			assert.Equal(t, "field ListOfStrings of ListOfRequiredPrimitives is required", err.Error())
+		})
+
 	})
 }
 

--- a/gen/list_test.go
+++ b/gen/list_test.go
@@ -231,9 +231,8 @@ func TestListOptionalFromWire(t *testing.T) {
 			x := new(tc.ListOfOptionalPrimitives)
 			require.NoError(t, x.FromWire(tt.give), tt.desc)
 			assert.Equal(t, tt.want, x.ListOfStrings)
-			_, ok := assertBinaryRoundTrip(t, tt.give, tt.desc)
-			assert.True(t, ok, "failed round trip")
 
+			testRoundTripCombos(t, x, tt.give, "" /* test desc, not needed because already in a t.Run */)
 		})
 	}
 }

--- a/gen/list_test.go
+++ b/gen/list_test.go
@@ -21,11 +21,13 @@
 package gen
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tc "go.uber.org/thriftrw/gen/internal/tests/containers"
+	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/wire"
 )
 
@@ -89,17 +91,40 @@ func TestListRequiredToWire(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			w, err := tt.give.ToWire()
-			require.NoError(t, err, "failed to serialize: %v", tt.give)
-			require.True(t, wire.ValuesAreEqual(tt.want, w))
-			assert.True(t, tt.give.Equals(tt.give))
-			// Round trip them all.
-			got, ok := assertBinaryRoundTrip(t, w, tt.desc)
-			require.True(t, ok, "failed round trip")
-			// Allocate a new instance to deserialize from Thrift representation.
-			x := new(tc.ListOfRequiredPrimitives)
-			require.NoError(t, x.FromWire(got))
-			assert.Equal(t, tt.wantList, x.ListOfStrings)
+			t.Run("Wire", func(t *testing.T) {
+				w, err := tt.give.ToWire()
+				require.NoError(t, err, "failed to serialize: %v", tt.give)
+				require.True(t, wire.ValuesAreEqual(tt.want, w))
+				assert.True(t, tt.give.Equals(tt.give))
+				// Round trip them all.
+				got, ok := assertBinaryRoundTrip(t, w, tt.desc)
+				require.True(t, ok, "failed round trip")
+				// Allocate a new instance to deserialize from Thrift representation.
+				x := new(tc.ListOfRequiredPrimitives)
+				require.NoError(t, x.FromWire(got))
+				assert.Equal(t, tt.wantList, x.ListOfStrings)
+			})
+
+			t.Run("Stream", func(t *testing.T) {
+				var buff bytes.Buffer
+				sw := binary.Default.Writer(&buff)
+				defer sw.Close()
+
+				require.NoError(t, tt.give.Encode(sw))
+
+				sr := binary.Default.Reader(bytes.NewReader(buff.Bytes()))
+				defer sr.Close()
+
+				x := new(tc.ListOfRequiredPrimitives)
+				require.NoError(t, x.Decode(sr))
+				assert.Equal(t, tt.wantList, x.ListOfStrings)
+			})
+
+			t.Run("StreamFromWire", func(t *testing.T) {
+				x := new(tc.ListOfRequiredPrimitives)
+				require.NoError(t, streamDecodeWireType(t, tt.want, x))
+				assert.Equal(t, tt.wantList, x.ListOfStrings)
+			})
 		})
 	}
 }

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -21,7 +21,6 @@
 package gen
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -36,7 +35,6 @@ import (
 	ts "go.uber.org/thriftrw/gen/internal/tests/structs"
 	td "go.uber.org/thriftrw/gen/internal/tests/typedefs"
 	tu "go.uber.org/thriftrw/gen/internal/tests/unions"
-	"go.uber.org/thriftrw/protocol/binary"
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/thriftrw/wire"
 	"go.uber.org/zap/zapcore"
@@ -596,11 +594,21 @@ func TestPrimitiveRequiredMissingFields(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		var s ts.PrimitiveRequiredStruct
-		err := s.FromWire(tt.v)
-		if assert.Error(t, err, tt.desc) {
-			assert.Contains(t, err.Error(), tt.wantError, tt.desc)
-		}
+		t.Run(tt.desc+"/wire", func(t *testing.T) {
+			var s ts.PrimitiveRequiredStruct
+			err := s.FromWire(tt.v)
+			if assert.Error(t, err, tt.desc) {
+				assert.Contains(t, err.Error(), tt.wantError, tt.desc)
+			}
+		})
+
+		t.Run(tt.desc+"/streaming", func(t *testing.T) {
+			var s ts.PrimitiveRequiredStruct
+			err := streamDecodeWireType(t, tt.v, &s)
+			if assert.Error(t, err, tt.desc) {
+				assert.Contains(t, err.Error(), tt.wantError, tt.desc)
+			}
+		})
 	}
 }
 
@@ -757,18 +765,8 @@ func TestStructFromWireUnrecognizedField(t *testing.T) {
 		})
 
 		t.Run(tt.desc+"/streaming", func(t *testing.T) {
-			var (
-				o   ts.ContactInfo
-				buf bytes.Buffer
-			)
-
-			require.NoError(t, binary.Default.Encode(tt.give, &buf))
-
-			r := bytes.NewReader(buf.Bytes())
-			sr := binary.Default.Reader(r)
-			defer sr.Close()
-
-			err := o.Decode(sr)
+			var o ts.ContactInfo
+			err := streamDecodeWireType(t, tt.give, &o)
 			if tt.wantError != "" {
 				if assert.Error(t, err, tt.desc) {
 					assert.Contains(t, err.Error(), tt.wantError)
@@ -778,8 +776,6 @@ func TestStructFromWireUnrecognizedField(t *testing.T) {
 					assert.Equal(t, tt.want, o)
 				}
 			}
-
-			assert.Zero(t, r.Len(), "expected to be at end of read")
 		})
 	}
 }
@@ -831,7 +827,7 @@ func TestUnionFromWireInconsistencies(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.desc+"/streaming", func(t *testing.T) {
+		t.Run(tt.desc+"/wire", func(t *testing.T) {
 			var o tu.Document
 			err := o.FromWire(tt.input)
 			if tt.success != nil {
@@ -846,18 +842,8 @@ func TestUnionFromWireInconsistencies(t *testing.T) {
 		})
 
 		t.Run(tt.desc+"/streaming", func(t *testing.T) {
-			var (
-				o   tu.Document
-				buf bytes.Buffer
-			)
-
-			require.NoError(t, binary.Default.Encode(tt.input, &buf))
-
-			r := bytes.NewReader(buf.Bytes())
-			sr := binary.Default.Reader(r)
-			defer sr.Close()
-
-			err := o.Decode(sr)
+			var o tu.Document
+			err := streamDecodeWireType(t, tt.input, &o)
 			if tt.success != nil {
 				if assert.NoError(t, err, tt.desc) {
 					assert.Equal(t, tt.success, &o, tt.desc)
@@ -867,8 +853,6 @@ func TestUnionFromWireInconsistencies(t *testing.T) {
 					assert.Contains(t, err.Error(), tt.failure, tt.desc)
 				}
 			}
-
-			assert.Zero(t, r.Len(), "expected to be at end of read")
 		})
 	}
 }
@@ -1097,6 +1081,11 @@ func TestStructWithDefaults(t *testing.T) {
 		var gotFromWire ts.DefaultsStruct
 		if err := gotFromWire.FromWire(tt.giveWire); assert.NoError(t, err) {
 			assert.Equal(t, tt.wantFromWire, &gotFromWire)
+		}
+
+		var sGotFromWire ts.DefaultsStruct
+		if err := streamDecodeWireType(t, tt.giveWire, &sGotFromWire); assert.NoError(t, err) {
+			assert.Equal(t, tt.wantFromWire, &sGotFromWire)
 		}
 	}
 }
@@ -2075,6 +2064,10 @@ func TestEmptyPrimitivesRoundTrip(t *testing.T) {
 		var got ts.PrimitiveRequiredStruct
 		require.NoError(t, got.FromWire(v), "failed to convert from wire.Value")
 		assert.Equal(t, give, got)
+
+		var sGot ts.PrimitiveRequiredStruct
+		require.NoError(t, streamDecodeWireType(t, v, &sGot), "failed to stream deserialize")
+		assert.Equal(t, give, sGot)
 	})
 
 	t.Run("optional", func(t *testing.T) {
@@ -2103,6 +2096,10 @@ func TestEmptyPrimitivesRoundTrip(t *testing.T) {
 		var got ts.PrimitiveOptionalStruct
 		require.NoError(t, got.FromWire(v), "failed to convert from wire.Value")
 		assert.Equal(t, give, got)
+
+		var sGot ts.PrimitiveOptionalStruct
+		require.NoError(t, streamDecodeWireType(t, v, &sGot), "failed to stream deserialize")
+		assert.Equal(t, give, sGot)
 	})
 }
 

--- a/gen/util_for_test.go
+++ b/gen/util_for_test.go
@@ -58,11 +58,12 @@ func streamDecodeWireType(t *testing.T, wv wire.Value, tt thriftType) error {
 		assert.NoError(t, sr.Close())
 	}()
 
-	// Only IO errors would cause Decode to error early - since we shouldn't
-	// expect any of those, the full contents of the raw bytes should be read out.
-	defer func() {
+	err := tt.Decode(sr)
+	if err == nil {
+		// We expect to read the entire payload only if it was a valid
+		// request. Invalid requests may return early because, say, one
+		// of the fields failed to decode because it was invalid.
 		assert.Zero(t, r.Len(), "expected to be end of read")
-	}()
-
-	return tt.Decode(sr)
+	}
+	return err
 }


### PR DESCRIPTION
In the places where a `FromWire(...)` is invoked, call the corresponding streaming
`Decode(...)` to check the populated Thrift object.

- [x] collision_test
    - [x] TestStruct
    - [x] TestWithDefault
- [x] container_test
    - [x] TestCollectionsOfPrimitives
    - [x] TestEnumContainers
    - [x] TestListOfStructs
    - [x] TestCrazyTown
    - [x] TestContainerValidate
    - [x] TestEmptyContainersRoundTrip
- [x] service_test
    - [x] TestServiceArgsAndResult
    - [x] TestServiceTypesEnveloper
    - [x] TestArgsAndResultValidation
- [x] struct_test
    - [x] TestStructRoundTripAndString
    - [x] TestPrimitiveRequiredMissingFields
    - [x] TestBasicException
    - [x] TestCollisionException
    - [x] TestStructFromWireUnrecognizedField
    - [x] TestUnionFromWireInconsistencies
    - [x] TestStructWithDefaults
    - [x] TestStructValidation
    - [x] TestEmptyPrimitivesRoundTrip
- [x] typedef_test
    - [x] TestTypedefI64
    - [x] TestTypedefString
    - [x] TestTypedefBinary
    - [x] TestTypedefStruct
    - [x] TestTypedefContainer
    - [x] TestUnhashableSetAlias
    - [x] TestUnhashableMapKeyAlias
    - [x] TestBinarySet
    - [x] TestTypedefAnnotatedSetToSlice
- [x] list_test
    - [x] TestListRequiredToWire
    - [x] TestListRequiredFromWire
    - [x] TestRoundtripOptionalListFields
    - [x] TestListOptionalFromWire
- [x] enum_test
    - [x] TestEnumDefaultWire
    - [x] TestEnumWithDuplicateValuesWire
    - [x] TestUnknownEnumValue
    - [x] TestOptionalEnum
