### PR TITLE
Add a flag to thriftbreak to output results as JSON.

### DIFF
--- a/cmd/thriftbreak/main.go
+++ b/cmd/thriftbreak/main.go
@@ -21,6 +21,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -38,6 +39,7 @@ func main() {
 func run(args []string) error {
 	flag := flag.NewFlagSet("thriftbreak", flag.ContinueOnError)
 	gitRepo := flag.String("C", "", "location of git repository. Defaults to current directory.")
+	jsonOut := flag.Bool("json", false, "output as JSON")
 	if err := flag.Parse(args); err != nil {
 		return err
 	}
@@ -57,8 +59,18 @@ func run(args []string) error {
 	}
 
 	lints := pass.Lints()
+	var out string
 	for _, l := range lints {
-		fmt.Println(l.String())
+		if *jsonOut {
+			bytes, err := json.Marshal(l)
+			if err != nil {
+				return fmt.Errorf("failed to marshal error: %v", err)
+			}
+			out = string(bytes)
+		} else {
+			out = l.String()
+		}
+		fmt.Println(out)
 	}
 	if len(lints) > 0 {
 		return fmt.Errorf("found %d issues", len(lints))

--- a/cmd/thriftbreak/main.go
+++ b/cmd/thriftbreak/main.go
@@ -39,9 +39,9 @@ func main() {
 	}
 }
 
+// readableOutput prints every lint error on a separate line.
 func readableOutput(w io.Writer) func(compare.Diagnostic) error {
 	return func(diagnostic compare.Diagnostic) error {
-		// fmt.Println(diagnostic.String())
 		if _, err := fmt.Fprintln(w, diagnostic.String()); err != nil {
 			return fmt.Errorf("failed to output a lint error: %v", err)
 		}
@@ -50,6 +50,7 @@ func readableOutput(w io.Writer) func(compare.Diagnostic) error {
 	}
 }
 
+// jsonOutput prints out every lint error in JSON format.
 func jsonOutput(w io.Writer) func(compare.Diagnostic) error {
 	enc := json.NewEncoder(w)
 

--- a/cmd/thriftbreak/main_test.go
+++ b/cmd/thriftbreak/main_test.go
@@ -152,37 +152,3 @@ func TestJsonPrinter(t *testing.T) {
 		})
 	}
 }
-
-func TestJsonPrinterErrors(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		desc   string
-		want   string
-		writer func(io.Writer) func(compare.Diagnostic) error
-	}{
-		{
-			desc:   "json writer",
-			want:   "{\"File\":\"foo.thrift\",\"Message\":\"error\"}\n",
-			writer: jsonOutput,
-		},
-		{
-			desc:   "readable writer",
-			want:   "foo.thrift:error\n",
-			writer: readableOutput,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-			var b bytes.Buffer
-			w := tt.writer(&b)
-			err := w(compare.Diagnostic{
-				File:    "foo.thrift",
-				Message: "error",
-			})
-			require.Error(t, err)
-			assert.Equal(t, tt.want, b.String())
-		})
-	}
-}

--- a/cmd/thriftbreak/main_test.go
+++ b/cmd/thriftbreak/main_test.go
@@ -72,7 +72,7 @@ func TestThriftBreakIntegration(t *testing.T) {
 				"test/v2.thrift": `service Bar {}`,
 				"test/c.thrift":  `service Baz {}`,
 				"test/d.thrift": `include "../v1.thrift"
-		service Qux {}`,                         // d.thrift will be deleted below.
+		service Qux {}`, // d.thrift will be deleted below.
 				"somefile.go": `service Quux{}`, // a .go file, not a .thrift.
 			}
 			// For c.thrift we are also checking to make sure includes work as expected.

--- a/cmd/thriftbreak/main_test.go
+++ b/cmd/thriftbreak/main_test.go
@@ -71,7 +71,7 @@ func TestThriftBreakIntegration(t *testing.T) {
 		"test/v2.thrift": `service Bar {}`,
 		"test/c.thrift":  `service Baz {}`,
 		"test/d.thrift": `include "../v1.thrift"
-		service Qux {}`,                 // d.thrift will be deleted below.
+		service Qux {}`, // d.thrift will be deleted below.
 		"somefile.go": `service Quux{}`, // a .go file, not a .thrift.
 	}
 	// For c.thrift we are also checking to make sure includes work as expected.


### PR DESCRIPTION
Adding `--json` flag to thriftbreak to output results as JSON. This enables integration with tools like Phabricator.

Ref GO-938