### PR TITLE
optimize String() on a typedef if the underlying type is a string

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -236,6 +236,7 @@ func (g *generator) TextTemplate(s string, data interface{}, opts ...TemplateOpt
 		"setUsesMap":       setUsesMap,
 		"isListType":       isListType,
 		"isPrimitiveType":  isPrimitiveType,
+		"isStringType":     isStringType,
 		"isStructType":     isStructType,
 		"newNamespace":     g.Namespace.Child,
 		"newVar":           g.Namespace.Child().NewName,

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -537,7 +537,7 @@ func (v Key) ToWire() (wire.Value, error) {
 // String returns a readable string representation of Key.
 func (v Key) String() string {
 	x := (string)(v)
-	return fmt.Sprint(x)
+	return x
 }
 
 func (v Key) Encode(sw stream.Writer) error {

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -1934,7 +1934,7 @@ func (v State) ToWire() (wire.Value, error) {
 // String returns a readable string representation of State.
 func (v State) String() string {
 	x := (string)(v)
-	return fmt.Sprint(x)
+	return x
 }
 
 func (v State) Encode(sw stream.Writer) error {

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -33,7 +33,7 @@ func (v UUID) ToWire() (wire.Value, error) {
 // String returns a readable string representation of UUID.
 func (v UUID) String() string {
 	x := (string)(v)
-	return fmt.Sprint(x)
+	return x
 }
 
 func (v UUID) Encode(sw stream.Writer) error {

--- a/gen/type.go
+++ b/gen/type.go
@@ -74,6 +74,13 @@ func isPrimitiveType(spec compile.TypeSpec) bool {
 	return isEnum
 }
 
+// isStringType returns true if the given type is a string type
+func isStringType(spec compile.TypeSpec) bool {
+	spec = compile.RootTypeSpec(spec)
+	_, ok := spec.(*compile.StringSpec)
+	return ok
+}
+
 // isReferenceType checks if the given TypeSpec represents a reference type.
 //
 // Sets, maps, lists, and slices are reference types.

--- a/gen/typedef.go
+++ b/gen/typedef.go
@@ -112,7 +112,11 @@ func typedef(g Generator, spec *compile.TypedefSpec) error {
 		// String returns a readable string representation of <typeName .>.
 		func (<$v> <$typedefType>) String() string {
 			<$x> := (<typeReference .Target>)(<$v>)
-			return <$fmt>.Sprint(<$x>)
+			<if isStringType .Target ->
+				return <$x>
+			<- else ->
+				return <$fmt>.Sprint(<$x>)
+			<- end>
 		}
 
 		func (<$v> <$typedefType>) Encode(<$sw> <$stream>.Writer) error {


### PR DESCRIPTION
If the underlying type for a defined type is a string, then the Stringer interface implementation can be optimized by returning the string after type conversion. 

```
type UUID string
func (v UUID) String() string {
        x := (string)(v)
        return fmt.Sprint(x)
 }
```
to 

```
func (v UUID) String() string {
        x := (string)(v)
        return x
 }
 ```