### PR TITLE
idl: Capture parsed comments

### DIFF
--- a/idl/config.go
+++ b/idl/config.go
@@ -37,6 +37,7 @@ func (c *Config) Parse(s []byte) (*ast.Program, error) {
 	result, errors := internal.Parse(s)
 	if c.Info != nil {
 		c.Info.nodePositions = result.NodePositions
+		c.Info.comments = result.Comments
 	}
 	return result.Program, newParseError(errors)
 }

--- a/idl/config_test.go
+++ b/idl/config_test.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/thriftrw/ast"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParse(t *testing.T) {
@@ -45,6 +46,26 @@ func TestInfoPos(t *testing.T) {
 		if assert.IsType(t, &ast.Constant{}, prog.Definitions[0]) {
 			cv := prog.Definitions[0].(*ast.Constant).Value
 			assert.Equal(t, ast.Position{Line: 1, Column: 16}, c.Info.Pos(cv))
+		}
+	}
+}
+
+func TestComment(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{`# Line Comment `, "Line Comment"},
+		{`// Line Comment `, "Line Comment"},
+	}
+
+	for _, tt := range tests {
+		c := &Config{Info: &Info{}}
+		_, err := c.Parse([]byte(tt.in))
+		if assert.NoError(t, err) {
+			s, ok := c.Info.Comment(1)
+			require.True(t, ok)
+			assert.Equal(t, tt.out, s)
 		}
 	}
 }

--- a/idl/info.go
+++ b/idl/info.go
@@ -28,6 +28,7 @@ import (
 // Info contains additional information about the parsed document.
 type Info struct {
 	nodePositions internal.NodePositions
+	comments      internal.Comments
 }
 
 // Pos returns a Node's position in the parsed document.
@@ -36,4 +37,10 @@ func (i *Info) Pos(n ast.Node) ast.Position {
 		return pos
 	}
 	return i.nodePositions[n]
+}
+
+// Comment attempts to return a line comment string for the requested line.
+func (i *Info) Comment(line int) (string, bool) {
+	s, ok := i.comments[line]
+	return s, ok
 }

--- a/idl/internal/lex.go
+++ b/idl/internal/lex.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"go.uber.org/thriftrw/ast"
 )
@@ -50,6 +51,7 @@ type lexer struct {
 	lastDocstring       string
 	linesSinceDocstring int
 
+	comments      Comments
 	nodePositions NodePositions
 
 	errors      []ParseError
@@ -63,6 +65,7 @@ type lexer struct {
 func newLexer(data []byte) *lexer {
 	lex := &lexer{
 		line:          1,
+		comments:      make(Comments, 0),
 		nodePositions: make(NodePositions, 0),
 		parseFailed:   false,
 		data:          data,
@@ -141,16 +144,16 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st_case_16
 		case 25:
 			goto st_case_25
-		case 17:
-			goto st_case_17
 		case 26:
 			goto st_case_26
+		case 17:
+			goto st_case_17
 		case 27:
 			goto st_case_27
-		case 18:
-			goto st_case_18
 		case 28:
 			goto st_case_28
+		case 18:
+			goto st_case_18
 		case 29:
 			goto st_case_29
 		case 30:
@@ -925,6 +928,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st_case_414
 		case 415:
 			goto st_case_415
+		case 416:
+			goto st_case_416
 		}
 		goto st_out
 	tr2:
@@ -1256,7 +1261,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 					goto _out
 				}
 			}
-		case 37:
+		case 38:
 			{
 				(lex.p) = (lex.te) - 1
 
@@ -1279,7 +1284,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 					goto _out
 				}
 			}
-		case 38:
+		case 39:
 			{
 				(lex.p) = (lex.te) - 1
 
@@ -1296,7 +1301,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 					goto _out
 				}
 			}
-		case 40:
+		case 41:
 			{
 				(lex.p) = (lex.te) - 1
 
@@ -1307,7 +1312,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 					goto _out
 				}
 			}
-		case 41:
+		case 42:
 			{
 				(lex.p) = (lex.te) - 1
 
@@ -1374,7 +1379,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		lex.te = (lex.p) + 1
 
 		goto st19
-	tr30:
+	tr31:
 		lex.te = (lex.p) + 1
 		{
 			tok = int(lex.data[lex.ts])
@@ -1385,12 +1390,14 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr58:
+	tr59:
 		lex.te = (lex.p)
 		(lex.p)--
-
+		{
+			lex.Comment(string(lex.data[lex.ts+1 : lex.te]))
+		}
 		goto st19
-	tr59:
+	tr60:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1414,7 +1421,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr62:
+	tr63:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1432,12 +1439,19 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr63:
+	tr64:
 		lex.te = (lex.p)
 		(lex.p)--
 
 		goto st19
 	tr65:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lex.Comment(string(lex.data[lex.ts+2 : lex.te]))
+		}
+		goto st19
+	tr67:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1450,7 +1464,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr71:
+	tr73:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1462,7 +1476,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr132:
+	tr134:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1474,7 +1488,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr137:
+	tr139:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1486,7 +1500,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr144:
+	tr146:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1498,7 +1512,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr160:
+	tr162:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1510,7 +1524,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr174:
+	tr176:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1522,7 +1536,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr192:
+	tr194:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1534,7 +1548,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr221:
+	tr223:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1546,7 +1560,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr232:
+	tr234:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1558,7 +1572,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr239:
+	tr241:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1570,7 +1584,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr250:
+	tr252:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1582,7 +1596,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr276:
+	tr278:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1594,7 +1608,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr280:
+	tr282:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1606,7 +1620,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr284:
+	tr286:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1618,7 +1632,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr287:
+	tr289:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1630,7 +1644,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr304:
+	tr306:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1642,7 +1656,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr323:
+	tr325:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1654,7 +1668,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr329:
+	tr331:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1666,7 +1680,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr343:
+	tr345:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1678,7 +1692,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr353:
+	tr355:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1690,7 +1704,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr362:
+	tr364:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1702,7 +1716,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr395:
+	tr397:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1714,7 +1728,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr410:
+	tr412:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1726,7 +1740,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr413:
+	tr415:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1738,7 +1752,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr422:
+	tr424:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1750,7 +1764,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr427:
+	tr429:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1762,7 +1776,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr444:
+	tr446:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1774,7 +1788,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr454:
+	tr456:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1786,7 +1800,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr462:
+	tr464:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1798,7 +1812,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr473:
+	tr475:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1810,7 +1824,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			}
 		}
 		goto st19
-	tr485:
+	tr487:
 		lex.te = (lex.p)
 		(lex.p)--
 		{
@@ -1853,63 +1867,63 @@ func (lex *lexer) Lex(out *yySymType) int {
 		case 47:
 			goto st8
 		case 48:
-			goto tr33
-		case 66:
 			goto tr34
-		case 69:
+		case 66:
 			goto tr35
-		case 91:
-			goto tr30
-		case 93:
-			goto tr30
-		case 95:
+		case 69:
 			goto tr36
-		case 97:
+		case 91:
+			goto tr31
+		case 93:
+			goto tr31
+		case 95:
 			goto tr37
-		case 98:
+		case 97:
 			goto tr38
-		case 99:
+		case 98:
 			goto tr39
-		case 100:
+		case 99:
 			goto tr40
-		case 101:
+		case 100:
 			goto tr41
-		case 102:
+		case 101:
 			goto tr42
-		case 103:
+		case 102:
 			goto tr43
-		case 105:
+		case 103:
 			goto tr44
-		case 108:
+		case 105:
 			goto tr45
-		case 109:
+		case 108:
 			goto tr46
-		case 110:
+		case 109:
 			goto tr47
-		case 111:
+		case 110:
 			goto tr48
-		case 112:
+		case 111:
 			goto tr49
-		case 114:
+		case 112:
 			goto tr50
-		case 115:
+		case 114:
 			goto tr51
-		case 116:
+		case 115:
 			goto tr52
-		case 117:
+		case 116:
 			goto tr53
-		case 118:
+		case 117:
 			goto tr54
-		case 119:
+		case 118:
 			goto tr55
-		case 120:
+		case 119:
 			goto tr56
-		case 121:
+		case 120:
 			goto tr57
+		case 121:
+			goto tr58
 		case 123:
-			goto tr30
+			goto tr31
 		case 125:
-			goto tr30
+			goto tr31
 		}
 		switch {
 		case lex.data[(lex.p)] < 58:
@@ -1919,7 +1933,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 					goto tr6
 				}
 			case lex.data[(lex.p)] >= 40:
-				goto tr30
+				goto tr31
 			}
 		case lex.data[(lex.p)] > 62:
 			switch {
@@ -1931,7 +1945,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 				goto tr27
 			}
 		default:
-			goto tr30
+			goto tr31
 		}
 		goto st0
 	st_case_0:
@@ -1964,7 +1978,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_20:
 		if lex.data[(lex.p)] == 10 {
-			goto tr58
+			goto tr59
 		}
 		goto st20
 	st3:
@@ -1999,7 +2013,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 	tr6:
 		lex.te = (lex.p) + 1
 
-		lex.act = 37
+		lex.act = 38
 		goto st21
 	st21:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2008,7 +2022,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_21:
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto tr60
+			goto tr61
 		case 69:
 			goto st6
 		case 101:
@@ -2017,11 +2031,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr6
 		}
-		goto tr59
-	tr60:
+		goto tr60
+	tr61:
 		lex.te = (lex.p) + 1
 
-		lex.act = 38
+		lex.act = 39
 		goto st22
 	st22:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2035,9 +2049,9 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st6
 		}
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-			goto tr60
+			goto tr61
 		}
-		goto tr62
+		goto tr63
 	st6:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof6
@@ -2070,7 +2084,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto st23
 		}
-		goto tr62
+		goto tr63
 	st8:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof8
@@ -2080,7 +2094,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		case 42:
 			goto st9
 		case 47:
-			goto st20
+			goto st25
 		}
 		goto st0
 	st9:
@@ -2212,19 +2226,28 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto tr21
 		}
 		goto st15
-	tr33:
-		lex.te = (lex.p) + 1
-
-		lex.act = 37
-		goto st25
 	st25:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof25
 		}
 	st_case_25:
+		if lex.data[(lex.p)] == 10 {
+			goto tr65
+		}
+		goto st25
+	tr34:
+		lex.te = (lex.p) + 1
+
+		lex.act = 38
+		goto st26
+	st26:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof26
+		}
+	st_case_26:
 		switch lex.data[(lex.p)] {
 		case 46:
-			goto tr60
+			goto tr61
 		case 69:
 			goto st6
 		case 101:
@@ -2235,7 +2258,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr6
 		}
-		goto tr59
+		goto tr60
 	st17:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof17
@@ -2244,44 +2267,44 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch {
 		case lex.data[(lex.p)] < 65:
 			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto st26
+				goto st27
 			}
 		case lex.data[(lex.p)] > 70:
 			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
-				goto st26
+				goto st27
 			}
 		default:
-			goto st26
+			goto st27
 		}
 		goto tr25
-	st26:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof26
-		}
-	st_case_26:
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto st26
-			}
-		case lex.data[(lex.p)] > 70:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
-				goto st26
-			}
-		default:
-			goto st26
-		}
-		goto tr59
-	tr27:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st27
 	st27:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof27
 		}
 	st_case_27:
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto st27
+			}
+		case lex.data[(lex.p)] > 70:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 102 {
+				goto st27
+			}
+		default:
+			goto st27
+		}
+		goto tr60
+	tr27:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st28
+	st28:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof28
+		}
+	st_case_28:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
@@ -2300,7 +2323,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	st18:
 		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof18
@@ -2322,41 +2345,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto tr27
 		}
 		goto tr7
-	tr34:
+	tr35:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st28
-	st28:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof28
-		}
-	st_case_28:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 69:
-			goto tr67
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr67:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
+		lex.act = 42
 		goto st29
 	st29:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2366,38 +2358,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 71:
-			goto tr68
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr68:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st30
-	st30:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof30
-		}
-	st_case_30:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 73:
+		case 69:
 			goto tr69
 		case 95:
 			goto tr27
@@ -2414,11 +2375,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr69:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st30
+	st30:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof30
+		}
+	st_case_30:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 71:
+			goto tr70
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr70:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st31
 	st31:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2428,8 +2420,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 78:
-			goto tr70
+		case 73:
+			goto tr71
 		case 95:
 			goto tr27
 		}
@@ -2445,12 +2437,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr70:
+		goto tr67
+	tr71:
 		lex.te = (lex.p) + 1
 
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
+		lex.act = 42
 		goto st32
 	st32:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2458,16 +2449,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_32:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
 		case 46:
 			goto st18
+		case 78:
+			goto tr72
 		case 95:
 			goto tr27
 		}
@@ -2483,13 +2468,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr71
-	tr73:
+		goto tr67
+	tr72:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
+		lex.act = 41
 		goto st33
 	st33:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2498,30 +2482,15 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_33:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st33
+			goto st34
 		case 10:
-			goto tr73
+			goto tr75
 		case 13:
-			goto st33
+			goto st34
 		case 32:
-			goto st33
-		}
-		goto tr71
-	tr35:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st34
-	st34:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof34
-		}
-	st_case_34:
-		switch lex.data[(lex.p)] {
+			goto st34
 		case 46:
 			goto st18
-		case 78:
-			goto tr74
 		case 95:
 			goto tr27
 		}
@@ -2537,11 +2506,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr74:
+		goto tr73
+	tr75:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st34
+	st34:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof34
+		}
+	st_case_34:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st34
+		case 10:
+			goto tr75
+		case 13:
+			goto st34
+		case 32:
+			goto st34
+		}
+		goto tr73
+	tr36:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st35
 	st35:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2551,8 +2543,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 68:
-			goto tr70
+		case 78:
+			goto tr76
 		case 95:
 			goto tr27
 		}
@@ -2568,11 +2560,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr36:
+		goto tr67
+	tr76:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st36
 	st36:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2582,8 +2574,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
+		case 68:
+			goto tr72
 		case 95:
-			goto tr75
+			goto tr27
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -2597,11 +2591,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr75:
+		goto tr67
+	tr37:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st37
 	st37:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2611,20 +2605,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 67:
-			goto tr76
-		case 68:
-			goto tr77
-		case 70:
-			goto tr78
-		case 76:
-			goto tr79
-		case 77:
-			goto tr80
-		case 78:
-			goto tr81
 		case 95:
-			goto tr27
+			goto tr77
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -2638,11 +2620,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr76:
+		goto tr67
+	tr77:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st38
 	st38:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2652,8 +2634,18 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
+		case 67:
+			goto tr78
+		case 68:
+			goto tr79
+		case 70:
+			goto tr80
 		case 76:
+			goto tr81
+		case 77:
 			goto tr82
+		case 78:
+			goto tr83
 		case 95:
 			goto tr27
 		}
@@ -2669,11 +2661,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr82:
+		goto tr67
+	tr78:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st39
 	st39:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2683,38 +2675,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 65:
-			goto tr83
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 66:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr83:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st40
-	st40:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof40
-		}
-	st_case_40:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 83:
+		case 76:
 			goto tr84
 		case 95:
 			goto tr27
@@ -2731,11 +2692,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr84:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st40
+	st40:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof40
+		}
+	st_case_40:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 65:
+			goto tr85
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr85:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st41
 	st41:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2746,7 +2738,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		case 46:
 			goto st18
 		case 83:
-			goto tr85
+			goto tr86
 		case 95:
 			goto tr27
 		}
@@ -2762,11 +2754,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr85:
+		goto tr67
+	tr86:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st42
 	st42:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2776,65 +2768,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 95:
-			goto tr86
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr86:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st43
-	st43:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof43
-		}
-	st_case_43:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr77:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st44
-	st44:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof44
-		}
-	st_case_44:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 73:
+		case 83:
 			goto tr87
 		case 95:
 			goto tr27
@@ -2851,24 +2785,22 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr87:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st45
-	st45:
+		lex.act = 42
+		goto st43
+	st43:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof45
+			goto _test_eof43
 		}
-	st_case_45:
+	st_case_43:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 82:
-			goto tr85
 		case 95:
-			goto tr27
+			goto tr88
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -2882,23 +2814,50 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr78:
+		goto tr67
+	tr88:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st46
-	st46:
+		lex.act = 42
+		goto st44
+	st44:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof46
+			goto _test_eof44
 		}
-	st_case_46:
+	st_case_44:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr79:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st45
+	st45:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof45
+		}
+	st_case_45:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 73:
-			goto tr88
-		case 85:
 			goto tr89
 		case 95:
 			goto tr27
@@ -2915,11 +2874,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr88:
+		goto tr67
+	tr89:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st46
+	st46:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof46
+		}
+	st_case_46:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 82:
+			goto tr87
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr80:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st47
 	st47:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -2929,69 +2919,9 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 76:
+		case 73:
 			goto tr90
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr90:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st48
-	st48:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof48
-		}
-	st_case_48:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 69:
-			goto tr85
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr89:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st49
-	st49:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof49
-		}
-	st_case_49:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 78:
+		case 85:
 			goto tr91
 		case 95:
 			goto tr27
@@ -3008,21 +2938,21 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr91:
+		goto tr67
+	tr90:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st50
-	st50:
+		lex.act = 42
+		goto st48
+	st48:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof50
+			goto _test_eof48
 		}
-	st_case_50:
+	st_case_48:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 67:
+		case 76:
 			goto tr92
 		case 95:
 			goto tr27
@@ -3039,21 +2969,52 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr92:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st51
-	st51:
+		lex.act = 42
+		goto st49
+	st49:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof51
+			goto _test_eof49
 		}
-	st_case_51:
+	st_case_49:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 84:
+		case 69:
+			goto tr87
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr91:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st50
+	st50:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof50
+		}
+	st_case_50:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 78:
 			goto tr93
 		case 95:
 			goto tr27
@@ -3070,21 +3031,21 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr93:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st52
-	st52:
+		lex.act = 42
+		goto st51
+	st51:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof52
+			goto _test_eof51
 		}
-	st_case_52:
+	st_case_51:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 73:
+		case 67:
 			goto tr94
 		case 95:
 			goto tr27
@@ -3101,21 +3062,21 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr94:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st53
-	st53:
+		lex.act = 42
+		goto st52
+	st52:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof53
+			goto _test_eof52
 		}
-	st_case_53:
+	st_case_52:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 79:
+		case 84:
 			goto tr95
 		case 95:
 			goto tr27
@@ -3132,48 +3093,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr95:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st54
-	st54:
+		lex.act = 42
+		goto st53
+	st53:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof54
+			goto _test_eof53
 		}
-	st_case_54:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 78:
-			goto tr85
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr79:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st55
-	st55:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof55
-		}
-	st_case_55:
+	st_case_53:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
@@ -3194,52 +3124,21 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr96:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st56
-	st56:
+		lex.act = 42
+		goto st54
+	st54:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof56
+			goto _test_eof54
 		}
-	st_case_56:
+	st_case_54:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 78:
-			goto tr90
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr80:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st57
-	st57:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof57
-		}
-	st_case_57:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 69:
+		case 79:
 			goto tr97
 		case 95:
 			goto tr27
@@ -3256,21 +3155,52 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr97:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st58
-	st58:
+		lex.act = 42
+		goto st55
+	st55:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof58
+			goto _test_eof55
 		}
-	st_case_58:
+	st_case_55:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 84:
+		case 78:
+			goto tr87
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr81:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st56
+	st56:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof56
+		}
+	st_case_56:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 73:
 			goto tr98
 		case 95:
 			goto tr27
@@ -3287,21 +3217,52 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr98:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st59
-	st59:
+		lex.act = 42
+		goto st57
+	st57:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof59
+			goto _test_eof57
 		}
-	st_case_59:
+	st_case_57:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 72:
+		case 78:
+			goto tr92
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr82:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st58
+	st58:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof58
+		}
+	st_case_58:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 69:
 			goto tr99
 		case 95:
 			goto tr27
@@ -3318,21 +3279,21 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr99:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st60
-	st60:
+		lex.act = 42
+		goto st59
+	st59:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof60
+			goto _test_eof59
 		}
-	st_case_60:
+	st_case_59:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 79:
+		case 84:
 			goto tr100
 		case 95:
 			goto tr27
@@ -3349,22 +3310,22 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr100:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st61
-	st61:
+		lex.act = 42
+		goto st60
+	st60:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof61
+			goto _test_eof60
 		}
-	st_case_61:
+	st_case_60:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 68:
-			goto tr85
+		case 72:
+			goto tr101
 		case 95:
 			goto tr27
 		}
@@ -3380,52 +3341,21 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr81:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st62
-	st62:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof62
-		}
-	st_case_62:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 65:
-			goto tr101
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 66:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
+		goto tr67
 	tr101:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st63
-	st63:
+		lex.act = 42
+		goto st61
+	st61:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof63
+			goto _test_eof61
 		}
-	st_case_63:
+	st_case_61:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 77:
+		case 79:
 			goto tr102
 		case 95:
 			goto tr27
@@ -3442,22 +3372,22 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr102:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st64
-	st64:
+		lex.act = 42
+		goto st62
+	st62:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof64
+			goto _test_eof62
 		}
-	st_case_64:
+	st_case_62:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 69:
-			goto tr103
+		case 68:
+			goto tr87
 		case 95:
 			goto tr27
 		}
@@ -3473,21 +3403,52 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr103:
+		goto tr67
+	tr83:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st65
-	st65:
+		lex.act = 42
+		goto st63
+	st63:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof65
+			goto _test_eof63
 		}
-	st_case_65:
+	st_case_63:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 83:
+		case 65:
+			goto tr103
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr103:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st64
+	st64:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof64
+		}
+	st_case_64:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 77:
 			goto tr104
 		case 95:
 			goto tr27
@@ -3504,21 +3465,21 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr104:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st66
-	st66:
+		lex.act = 42
+		goto st65
+	st65:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof66
+			goto _test_eof65
 		}
-	st_case_66:
+	st_case_65:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 80:
+		case 69:
 			goto tr105
 		case 95:
 			goto tr27
@@ -3535,11 +3496,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr105:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st66
+	st66:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof66
+		}
+	st_case_66:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 83:
+			goto tr106
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr106:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st67
 	st67:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -3549,8 +3541,39 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
+		case 80:
+			goto tr107
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr107:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st68
+	st68:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof68
+		}
+	st_case_68:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
 		case 65:
-			goto tr106
+			goto tr108
 		case 95:
 			goto tr27
 		}
@@ -3566,42 +3589,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr106:
+		goto tr67
+	tr108:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st68
-	st68:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof68
-		}
-	st_case_68:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 67:
-			goto tr90
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr37:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
+		lex.act = 42
 		goto st69
 	st69:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -3611,18 +3603,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
+		case 67:
+			goto tr92
 		case 95:
 			goto tr27
-		case 98:
-			goto tr107
-		case 108:
-			goto tr108
-		case 110:
-			goto tr109
-		case 114:
-			goto tr110
-		case 115:
-			goto tr111
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -3636,11 +3620,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr107:
+		goto tr67
+	tr38:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st70
 	st70:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -3652,38 +3636,15 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 115:
+		case 98:
+			goto tr109
+		case 108:
+			goto tr110
+		case 110:
+			goto tr111
+		case 114:
 			goto tr112
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr112:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st71
-	st71:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof71
-		}
-	st_case_71:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 116:
+		case 115:
 			goto tr113
 		}
 		switch {
@@ -3698,23 +3659,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr113:
+		goto tr67
+	tr109:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st72
-	st72:
+		lex.act = 42
+		goto st71
+	st71:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof72
+			goto _test_eof71
 		}
-	st_case_72:
+	st_case_71:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 114:
+		case 115:
 			goto tr114
 		}
 		switch {
@@ -3729,11 +3690,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr114:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st72
+	st72:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof72
+		}
+	st_case_72:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 116:
+			goto tr115
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr115:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st73
 	st73:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -3745,38 +3737,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
-			goto tr115
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr115:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st74
-	st74:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof74
-		}
-	st_case_74:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 99:
+		case 114:
 			goto tr116
 		}
 		switch {
@@ -3791,86 +3752,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr116:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st75
-	st75:
+		lex.act = 42
+		goto st74
+	st74:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof75
+			goto _test_eof74
 		}
-	st_case_75:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 116:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr108:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st76
-	st76:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof76
-		}
-	st_case_76:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr117
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr117:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st77
-	st77:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof77
-		}
-	st_case_77:
+	st_case_74:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 97:
-			goto tr118
+			goto tr117
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -3884,85 +3783,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr118:
+		goto tr67
+	tr117:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st78
-	st78:
+		lex.act = 42
+		goto st75
+	st75:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof78
+			goto _test_eof75
 		}
-	st_case_78:
+	st_case_75:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 115:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr109:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st79
-	st79:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof79
-		}
-	st_case_79:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 100:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr110:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st80
-	st80:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof80
-		}
-	st_case_80:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 103:
+		case 99:
 			goto tr118
 		}
 		switch {
@@ -3977,32 +3814,54 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr111:
+		goto tr67
+	tr118:
 		lex.te = (lex.p) + 1
 
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
-		goto st81
-	st81:
+		lex.act = 42
+		goto st76
+	st76:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof81
+			goto _test_eof76
 		}
-	st_case_81:
+	st_case_76:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 115:
+		case 116:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr110:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st77
+	st77:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof77
+		}
+	st_case_77:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
 			goto tr119
 		}
 		switch {
@@ -4017,23 +3876,116 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr71
+		goto tr67
 	tr119:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st82
-	st82:
+		lex.act = 42
+		goto st78
+	st78:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof82
+			goto _test_eof78
 		}
-	st_case_82:
+	st_case_78:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 97:
+			goto tr120
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr120:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st79
+	st79:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof79
+		}
+	st_case_79:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 115:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr111:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st80
+	st80:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof80
+		}
+	st_case_80:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 100:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr112:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st81
+	st81:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof81
+		}
+	st_case_81:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 103:
 			goto tr120
 		}
 		switch {
@@ -4048,11 +4000,51 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr120:
+		goto tr67
+	tr113:
 		lex.te = (lex.p) + 1
 
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
 		lex.act = 41
+		goto st82
+	st82:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof82
+		}
+	st_case_82:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st34
+		case 10:
+			goto tr75
+		case 13:
+			goto st34
+		case 32:
+			goto st34
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 115:
+			goto tr121
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr73
+	tr121:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st83
 	st83:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -4064,8 +4056,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 114:
-			goto tr116
+		case 101:
+			goto tr122
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -4079,11 +4071,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr38:
+		goto tr67
+	tr122:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st84
 	st84:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -4095,856 +4087,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
-			goto tr121
-		case 105:
-			goto tr122
-		case 111:
-			goto tr123
 		case 114:
-			goto tr124
-		case 121:
-			goto tr125
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr121:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st85
-	st85:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof85
-		}
-	st_case_85:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 103:
-			goto tr126
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr126:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st86
-	st86:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof86
-		}
-	st_case_86:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr127
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr127:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st87
-	st87:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof87
-		}
-	st_case_87:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 110:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr122:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st88
-	st88:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof88
-		}
-	st_case_88:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 110:
-			goto tr128
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr128:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st89
-	st89:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof89
-		}
-	st_case_89:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr129
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr129:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st90
-	st90:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof90
-		}
-	st_case_90:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 114:
-			goto tr130
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr130:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st91
-	st91:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof91
-		}
-	st_case_91:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 121:
-			goto tr131
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr131:
-		lex.te = (lex.p) + 1
-
-		lex.act = 13
-		goto st92
-	st92:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof92
-		}
-	st_case_92:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st93
-		case 10:
-			goto tr134
-		case 13:
-			goto st93
-		case 32:
-			goto st93
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr132
-	tr134:
-
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
-		goto st93
-	st93:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof93
-		}
-	st_case_93:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st93
-		case 10:
-			goto tr134
-		case 13:
-			goto st93
-		case 32:
-			goto st93
-		}
-		goto tr132
-	tr123:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st94
-	st94:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof94
-		}
-	st_case_94:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 111:
-			goto tr135
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr135:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st95
-	st95:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof95
-		}
-	st_case_95:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 108:
-			goto tr136
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr136:
-		lex.te = (lex.p) + 1
-
-		lex.act = 5
-		goto st96
-	st96:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof96
-		}
-	st_case_96:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st97
-		case 10:
-			goto tr139
-		case 13:
-			goto st97
-		case 32:
-			goto st97
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr137
-	tr139:
-
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
-		goto st97
-	st97:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof97
-		}
-	st_case_97:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st97
-		case 10:
-			goto tr139
-		case 13:
-			goto st97
-		case 32:
-			goto st97
-		}
-		goto tr137
-	tr124:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st98
-	st98:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof98
-		}
-	st_case_98:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr140
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr140:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st99
-	st99:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof99
-		}
-	st_case_99:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr141
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr141:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st100
-	st100:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof100
-		}
-	st_case_100:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 107:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr125:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st101
-	st101:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof101
-		}
-	st_case_101:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 116:
-			goto tr142
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr142:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st102
-	st102:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof102
-		}
-	st_case_102:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr143
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr143:
-		lex.te = (lex.p) + 1
-
-		lex.act = 6
-		goto st103
-	st103:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof103
-		}
-	st_case_103:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st104
-		case 10:
-			goto tr146
-		case 13:
-			goto st104
-		case 32:
-			goto st104
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr144
-	tr146:
-
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
-		goto st104
-	st104:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof104
-		}
-	st_case_104:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st104
-		case 10:
-			goto tr146
-		case 13:
-			goto st104
-		case 32:
-			goto st104
-		}
-		goto tr144
-	tr39:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st105
-	st105:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof105
-		}
-	st_case_105:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr147
-		case 108:
-			goto tr148
-		case 111:
-			goto tr149
-		case 112:
-			goto tr150
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr147:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st106
-	st106:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof106
-		}
-	st_case_106:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 115:
-			goto tr151
-		case 116:
-			goto tr152
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr151:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st107
-	st107:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof107
-		}
-	st_case_107:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr152:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st108
-	st108:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof108
-		}
-	st_case_108:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 99:
-			goto tr153
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr153:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st109
-	st109:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof109
-		}
-	st_case_109:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 104:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr148:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st110
-	st110:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof110
-		}
-	st_case_110:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr154
-		case 111:
-			goto tr155
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr154:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st111
-	st111:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof111
-		}
-	st_case_111:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 115:
 			goto tr118
 		}
 		switch {
@@ -4959,24 +4102,32 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr155:
+		goto tr67
+	tr39:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st112
-	st112:
+		lex.act = 42
+		goto st85
+	st85:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof112
+			goto _test_eof85
 		}
-	st_case_112:
+	st_case_85:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
-			goto tr151
+		case 101:
+			goto tr123
+		case 105:
+			goto tr124
+		case 111:
+			goto tr125
+		case 114:
+			goto tr126
+		case 121:
+			goto tr127
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -4990,11 +4141,852 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
+	tr123:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st86
+	st86:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof86
+		}
+	st_case_86:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 103:
+			goto tr128
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr128:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st87
+	st87:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof87
+		}
+	st_case_87:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr129
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr129:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st88
+	st88:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof88
+		}
+	st_case_88:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr124:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st89
+	st89:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof89
+		}
+	st_case_89:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
+			goto tr130
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr130:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st90
+	st90:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof90
+		}
+	st_case_90:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr131
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr131:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st91
+	st91:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof91
+		}
+	st_case_91:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 114:
+			goto tr132
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr132:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st92
+	st92:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof92
+		}
+	st_case_92:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 121:
+			goto tr133
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr133:
+		lex.te = (lex.p) + 1
+
+		lex.act = 13
+		goto st93
+	st93:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof93
+		}
+	st_case_93:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st94
+		case 10:
+			goto tr136
+		case 13:
+			goto st94
+		case 32:
+			goto st94
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr134
+	tr136:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st94
+	st94:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof94
+		}
+	st_case_94:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st94
+		case 10:
+			goto tr136
+		case 13:
+			goto st94
+		case 32:
+			goto st94
+		}
+		goto tr134
+	tr125:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st95
+	st95:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof95
+		}
+	st_case_95:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 111:
+			goto tr137
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr137:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st96
+	st96:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof96
+		}
+	st_case_96:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 108:
+			goto tr138
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr138:
+		lex.te = (lex.p) + 1
+
+		lex.act = 5
+		goto st97
+	st97:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof97
+		}
+	st_case_97:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st98
+		case 10:
+			goto tr141
+		case 13:
+			goto st98
+		case 32:
+			goto st98
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr139
+	tr141:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st98
+	st98:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof98
+		}
+	st_case_98:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st98
+		case 10:
+			goto tr141
+		case 13:
+			goto st98
+		case 32:
+			goto st98
+		}
+		goto tr139
+	tr126:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st99
+	st99:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof99
+		}
+	st_case_99:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr142
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr142:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st100
+	st100:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof100
+		}
+	st_case_100:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr143
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr143:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st101
+	st101:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof101
+		}
+	st_case_101:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 107:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr127:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st102
+	st102:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof102
+		}
+	st_case_102:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 116:
+			goto tr144
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr144:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st103
+	st103:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof103
+		}
+	st_case_103:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr145
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr145:
+		lex.te = (lex.p) + 1
+
+		lex.act = 6
+		goto st104
+	st104:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof104
+		}
+	st_case_104:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st105
+		case 10:
+			goto tr148
+		case 13:
+			goto st105
+		case 32:
+			goto st105
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr146
+	tr148:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st105
+	st105:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof105
+		}
+	st_case_105:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st105
+		case 10:
+			goto tr148
+		case 13:
+			goto st105
+		case 32:
+			goto st105
+		}
+		goto tr146
+	tr40:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st106
+	st106:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof106
+		}
+	st_case_106:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr149
+		case 108:
+			goto tr150
+		case 111:
+			goto tr151
+		case 112:
+			goto tr152
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
 	tr149:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st107
+	st107:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof107
+		}
+	st_case_107:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 115:
+			goto tr153
+		case 116:
+			goto tr154
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr153:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st108
+	st108:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof108
+		}
+	st_case_108:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr154:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st109
+	st109:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof109
+		}
+	st_case_109:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 99:
+			goto tr155
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr155:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st110
+	st110:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof110
+		}
+	st_case_110:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 104:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr150:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st111
+	st111:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof111
+		}
+	st_case_111:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr156
+		case 111:
+			goto tr157
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr156:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st112
+	st112:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof112
+		}
+	st_case_112:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 115:
+			goto tr120
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr157:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st113
 	st113:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -5007,7 +4999,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 		case 95:
 			goto tr27
 		case 110:
-			goto tr156
+			goto tr153
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -5021,11 +5013,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr156:
+		goto tr67
+	tr151:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st114
 	st114:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -5037,9 +5029,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 115:
-			goto tr157
-		case 116:
+		case 110:
 			goto tr158
 		}
 		switch {
@@ -5054,11 +5044,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr157:
+		goto tr67
+	tr158:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st115
 	st115:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -5070,8 +5060,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
+		case 115:
 			goto tr159
+		case 116:
+			goto tr160
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -5085,11 +5077,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr159:
 		lex.te = (lex.p) + 1
 
-		lex.act = 26
+		lex.act = 42
 		goto st116
 	st116:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -5097,18 +5089,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_116:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st117
-		case 10:
-			goto tr162
-		case 13:
-			goto st117
-		case 32:
-			goto st117
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 116:
+			goto tr161
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -5122,13 +5108,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr160
-	tr162:
+		goto tr67
+	tr161:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
+		lex.act = 26
 		goto st117
 	st117:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -5137,32 +5121,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_117:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st117
+			goto st118
 		case 10:
-			goto tr162
+			goto tr164
 		case 13:
-			goto st117
+			goto st118
 		case 32:
-			goto st117
-		}
-		goto tr160
-	tr158:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st118
-	st118:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof118
-		}
-	st_case_118:
-		switch lex.data[(lex.p)] {
+			goto st118
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
-			goto tr163
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -5176,11 +5145,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr163:
+		goto tr162
+	tr164:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st118
+	st118:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof118
+		}
+	st_case_118:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st118
+		case 10:
+			goto tr164
+		case 13:
+			goto st118
+		case 32:
+			goto st118
+		}
+		goto tr162
+	tr160:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st119
 	st119:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -5192,69 +5184,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
-			goto tr164
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr164:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st120
-	st120:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof120
-		}
-	st_case_120:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 117:
-			goto tr151
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr150:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st121
-	st121:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof121
-		}
-	st_case_121:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 112:
+		case 105:
 			goto tr165
 		}
 		switch {
@@ -5269,21 +5199,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr165:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st122
-	st122:
+		lex.act = 42
+		goto st120
+	st120:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof122
+			goto _test_eof120
 		}
-	st_case_122:
+	st_case_120:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
+			goto tr27
+		case 110:
 			goto tr166
 		}
 		switch {
@@ -5298,23 +5230,54 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr166:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st123
-	st123:
+		lex.act = 42
+		goto st121
+	st121:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof123
+			goto _test_eof121
 		}
-	st_case_123:
+	st_case_121:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
+		case 117:
+			goto tr153
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr152:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st122
+	st122:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof122
+		}
+	st_case_122:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 112:
 			goto tr167
 		}
 		switch {
@@ -5329,23 +5292,21 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr167:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st124
-	st124:
+		lex.act = 42
+		goto st123
+	st123:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof124
+			goto _test_eof123
 		}
-	st_case_124:
+	st_case_123:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
-			goto tr27
-		case 110:
 			goto tr168
 		}
 		switch {
@@ -5360,23 +5321,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr168:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st125
-	st125:
+		lex.act = 42
+		goto st124
+	st124:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof125
+			goto _test_eof124
 		}
-	st_case_125:
+	st_case_124:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
+		case 105:
 			goto tr169
 		}
 		switch {
@@ -5391,23 +5352,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr169:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st126
-	st126:
+		lex.act = 42
+		goto st125
+	st125:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof126
+			goto _test_eof125
 		}
-	st_case_126:
+	st_case_125:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 108:
+		case 110:
 			goto tr170
 		}
 		switch {
@@ -5422,23 +5383,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr170:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st127
-	st127:
+		lex.act = 42
+		goto st126
+	st126:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof127
+			goto _test_eof126
 		}
-	st_case_127:
+	st_case_126:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 117:
+		case 99:
 			goto tr171
 		}
 		switch {
@@ -5453,23 +5414,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr171:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st128
-	st128:
+		lex.act = 42
+		goto st127
+	st127:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof128
+			goto _test_eof127
 		}
-	st_case_128:
+	st_case_127:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 100:
+		case 108:
 			goto tr172
 		}
 		switch {
@@ -5484,23 +5445,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr172:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st129
-	st129:
+		lex.act = 42
+		goto st128
+	st128:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof129
+			goto _test_eof128
 		}
-	st_case_129:
+	st_case_128:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 117:
 			goto tr173
 		}
 		switch {
@@ -5515,30 +5476,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr173:
 		lex.te = (lex.p) + 1
 
-		lex.act = 2
-		goto st130
-	st130:
+		lex.act = 42
+		goto st129
+	st129:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof130
+			goto _test_eof129
 		}
-	st_case_130:
+	st_case_129:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st131
-		case 10:
-			goto tr176
-		case 13:
-			goto st131
-		case 32:
-			goto st131
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 100:
+			goto tr174
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -5552,13 +5507,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr174
-	tr176:
+		goto tr67
+	tr174:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
+		lex.act = 42
+		goto st130
+	st130:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof130
+		}
+	st_case_130:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr175
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr175:
+		lex.te = (lex.p) + 1
 
+		lex.act = 2
 		goto st131
 	st131:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -5567,36 +5551,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_131:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st131
+			goto st132
 		case 10:
-			goto tr176
+			goto tr178
 		case 13:
-			goto st131
+			goto st132
 		case 32:
-			goto st131
-		}
-		goto tr174
-	tr40:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st132
-	st132:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof132
-		}
-	st_case_132:
-		switch lex.data[(lex.p)] {
+			goto st132
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
-			goto tr177
-		case 111:
-			goto tr178
-		case 121:
-			goto tr179
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -5610,11 +5575,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr177:
+		goto tr176
+	tr178:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st132
+	st132:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof132
+		}
+	st_case_132:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st132
+		case 10:
+			goto tr178
+		case 13:
+			goto st132
+		case 32:
+			goto st132
+		}
+		goto tr176
+	tr41:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st133
 	st133:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -5626,11 +5614,977 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
+		case 101:
+			goto tr179
+		case 111:
 			goto tr180
-		case 102:
+		case 121:
 			goto tr181
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr179:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st134
+	st134:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof134
+		}
+	st_case_134:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 99:
+			goto tr182
+		case 102:
+			goto tr183
 		case 108:
+			goto tr184
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr182:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st135
+	st135:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof135
+		}
+	st_case_135:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 108:
+			goto tr185
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr185:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st136
+	st136:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof136
+		}
+	st_case_136:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr186
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr186:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st137
+	st137:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof137
+		}
+	st_case_137:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 114:
+			goto tr153
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr183:
+		lex.te = (lex.p) + 1
+
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
+		lex.act = 41
+		goto st138
+	st138:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof138
+		}
+	st_case_138:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st34
+		case 10:
+			goto tr75
+		case 13:
+			goto st34
+		case 32:
+			goto st34
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr187
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr73
+	tr187:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st139
+	st139:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof139
+		}
+	st_case_139:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 117:
+			goto tr188
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr188:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st140
+	st140:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof140
+		}
+	st_case_140:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 108:
+			goto tr118
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr184:
+		lex.te = (lex.p) + 1
+
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
+		lex.act = 41
+		goto st141
+	st141:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof141
+		}
+	st_case_141:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st34
+		case 10:
+			goto tr75
+		case 13:
+			goto st34
+		case 32:
+			goto st34
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr189
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr73
+	tr189:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st142
+	st142:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof142
+		}
+	st_case_142:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 116:
+			goto tr153
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr180:
+		lex.te = (lex.p) + 1
+
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
+		lex.act = 41
+		goto st143
+	st143:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof143
+		}
+	st_case_143:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st34
+		case 10:
+			goto tr75
+		case 13:
+			goto st34
+		case 32:
+			goto st34
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 117:
+			goto tr190
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr73
+	tr190:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st144
+	st144:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof144
+		}
+	st_case_144:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 98:
+			goto tr191
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr191:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st145
+	st145:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof145
+		}
+	st_case_145:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 108:
+			goto tr192
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr192:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st146
+	st146:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof146
+		}
+	st_case_146:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr193
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr193:
+		lex.te = (lex.p) + 1
+
+		lex.act = 11
+		goto st147
+	st147:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof147
+		}
+	st_case_147:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st148
+		case 10:
+			goto tr196
+		case 13:
+			goto st148
+		case 32:
+			goto st148
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr194
+	tr196:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st148
+	st148:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof148
+		}
+	st_case_148:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st148
+		case 10:
+			goto tr196
+		case 13:
+			goto st148
+		case 32:
+			goto st148
+		}
+		goto tr194
+	tr181:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st149
+	st149:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof149
+		}
+	st_case_149:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
+			goto tr197
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr197:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st150
+	st150:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof150
+		}
+	st_case_150:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr198
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr198:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st151
+	st151:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof151
+		}
+	st_case_151:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 109:
+			goto tr199
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr199:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st152
+	st152:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof152
+		}
+	st_case_152:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr200
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr200:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st153
+	st153:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof153
+		}
+	st_case_153:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 99:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr42:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st154
+	st154:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof154
+		}
+	st_case_154:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 108:
+			goto tr201
+		case 110:
+			goto tr202
+		case 120:
+			goto tr203
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr201:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st155
+	st155:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof155
+		}
+	st_case_155:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr204
+		case 115:
+			goto tr205
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr204:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st156
+	st156:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof156
+		}
+	st_case_156:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 102:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr205:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st157
+	st157:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof157
+		}
+	st_case_157:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr206
+		case 105:
+			goto tr204
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr206:
+		lex.te = (lex.p) + 1
+
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
+		lex.act = 41
+		goto st158
+	st158:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof158
+		}
+	st_case_158:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st34
+		case 10:
+			goto tr75
+		case 13:
+			goto st34
+		case 32:
+			goto st34
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr204
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr73
+	tr202:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st159
+	st159:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof159
+		}
+	st_case_159:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 100:
+			goto tr207
+		case 115:
+			goto tr208
+		case 117:
+			goto tr209
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr207:
+		lex.te = (lex.p) + 1
+
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
+		lex.act = 41
+		goto st160
+	st160:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof160
+		}
+	st_case_160:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st34
+		case 10:
+			goto tr75
+		case 13:
+			goto st34
+		case 32:
+			goto st34
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 100:
+			goto tr210
+		case 102:
+			goto tr211
+		case 105:
+			goto tr204
+		case 115:
+			goto tr212
+		case 119:
+			goto tr213
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr73
+	tr210:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st161
+	st161:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof161
+		}
+	st_case_161:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr214
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr214:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st162
+	st162:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof162
+		}
+	st_case_162:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 99:
 			goto tr182
 		}
 		switch {
@@ -5645,24 +6599,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr180:
+		goto tr67
+	tr211:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st134
-	st134:
+		lex.act = 42
+		goto st163
+	st163:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof134
+			goto _test_eof163
 		}
-	st_case_134:
+	st_case_163:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 108:
-			goto tr183
+		case 111:
+			goto tr215
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -5676,55 +6630,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr183:
+		goto tr67
+	tr215:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st135
-	st135:
+		lex.act = 42
+		goto st164
+	st164:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof135
+			goto _test_eof164
 		}
-	st_case_135:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr184
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr184:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st136
-	st136:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof136
-		}
-	st_case_136:
+	st_case_164:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 114:
-			goto tr151
+			goto tr216
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -5738,33 +6661,64 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr181:
+		goto tr67
+	tr216:
 		lex.te = (lex.p) + 1
 
 		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
-		goto st137
-	st137:
+		lex.act = 41
+		goto st165
+	st165:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof137
+			goto _test_eof165
 		}
-	st_case_137:
+	st_case_165:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st33
+			goto st34
 		case 10:
-			goto tr73
+			goto tr75
 		case 13:
-			goto st33
+			goto st34
 		case 32:
-			goto st33
+			goto st34
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr217
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr73
+	tr217:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st166
+	st166:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof166
+		}
+	st_case_166:
+		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 97:
-			goto tr185
+			goto tr154
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -5778,17 +6732,203 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr71
-	tr185:
+		goto tr67
+	tr212:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st138
-	st138:
+		lex.act = 42
+		goto st167
+	st167:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof138
+			goto _test_eof167
 		}
-	st_case_138:
+	st_case_167:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 119:
+			goto tr218
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr218:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st168
+	st168:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof168
+		}
+	st_case_168:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr219
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr219:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st169
+	st169:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof169
+		}
+	st_case_169:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 116:
+			goto tr154
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr213:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st170
+	st170:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof170
+		}
+	st_case_170:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 104:
+			goto tr220
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr220:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st171
+	st171:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof171
+		}
+	st_case_171:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr221
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr221:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st172
+	st172:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof172
+		}
+	st_case_172:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 108:
+			goto tr153
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr208:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st173
+	st173:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof173
+		}
+	st_case_173:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
@@ -5809,1159 +6949,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr186:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st139
-	st139:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof139
-		}
-	st_case_139:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 108:
-			goto tr116
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr182:
-		lex.te = (lex.p) + 1
-
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
-		goto st140
-	st140:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof140
-		}
-	st_case_140:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr187
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr71
-	tr187:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st141
-	st141:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof141
-		}
-	st_case_141:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 116:
-			goto tr151
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr178:
-		lex.te = (lex.p) + 1
-
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
-		goto st142
-	st142:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof142
-		}
-	st_case_142:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 117:
-			goto tr188
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr71
-	tr188:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st143
-	st143:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof143
-		}
-	st_case_143:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 98:
-			goto tr189
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr189:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st144
-	st144:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof144
-		}
-	st_case_144:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 108:
-			goto tr190
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr190:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st145
-	st145:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof145
-		}
-	st_case_145:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr191
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr191:
-		lex.te = (lex.p) + 1
-
-		lex.act = 11
-		goto st146
-	st146:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof146
-		}
-	st_case_146:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st147
-		case 10:
-			goto tr194
-		case 13:
-			goto st147
-		case 32:
-			goto st147
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr192
-	tr194:
-
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
-		goto st147
-	st147:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof147
-		}
-	st_case_147:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st147
-		case 10:
-			goto tr194
-		case 13:
-			goto st147
-		case 32:
-			goto st147
-		}
-		goto tr192
-	tr179:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st148
-	st148:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof148
-		}
-	st_case_148:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 110:
-			goto tr195
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr195:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st149
-	st149:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof149
-		}
-	st_case_149:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr196
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr196:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st150
-	st150:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof150
-		}
-	st_case_150:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 109:
-			goto tr197
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr197:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st151
-	st151:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof151
-		}
-	st_case_151:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr198
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr198:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st152
-	st152:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof152
-		}
-	st_case_152:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 99:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr41:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st153
-	st153:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof153
-		}
-	st_case_153:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 108:
-			goto tr199
-		case 110:
-			goto tr200
-		case 120:
-			goto tr201
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr199:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st154
-	st154:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof154
-		}
-	st_case_154:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr202
-		case 115:
-			goto tr203
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr202:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st155
-	st155:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof155
-		}
-	st_case_155:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 102:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr203:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st156
-	st156:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof156
-		}
-	st_case_156:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr204
-		case 105:
-			goto tr202
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr204:
-		lex.te = (lex.p) + 1
-
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
-		goto st157
-	st157:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof157
-		}
-	st_case_157:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr202
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr71
-	tr200:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st158
-	st158:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof158
-		}
-	st_case_158:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 100:
-			goto tr205
-		case 115:
-			goto tr206
-		case 117:
-			goto tr207
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr205:
-		lex.te = (lex.p) + 1
-
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
-		goto st159
-	st159:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof159
-		}
-	st_case_159:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 100:
-			goto tr208
-		case 102:
-			goto tr209
-		case 105:
-			goto tr202
-		case 115:
-			goto tr210
-		case 119:
-			goto tr211
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr71
-	tr208:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st160
-	st160:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof160
-		}
-	st_case_160:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr212
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr212:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st161
-	st161:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof161
-		}
-	st_case_161:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 99:
-			goto tr180
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
+		goto tr67
 	tr209:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st162
-	st162:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof162
-		}
-	st_case_162:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 111:
-			goto tr213
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr213:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st163
-	st163:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof163
-		}
-	st_case_163:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 114:
-			goto tr214
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr214:
-		lex.te = (lex.p) + 1
-
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
-		goto st164
-	st164:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof164
-		}
-	st_case_164:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr215
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr71
-	tr215:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st165
-	st165:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof165
-		}
-	st_case_165:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr152
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr210:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st166
-	st166:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof166
-		}
-	st_case_166:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 119:
-			goto tr216
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr216:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st167
-	st167:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof167
-		}
-	st_case_167:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr217
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr217:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st168
-	st168:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof168
-		}
-	st_case_168:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 116:
-			goto tr152
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr211:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st169
-	st169:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof169
-		}
-	st_case_169:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 104:
-			goto tr218
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr218:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st170
-	st170:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof170
-		}
-	st_case_170:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr219
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr219:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st171
-	st171:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof171
-		}
-	st_case_171:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 108:
-			goto tr151
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr206:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st172
-	st172:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof172
-		}
-	st_case_172:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 117:
-			goto tr184
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr207:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st173
-	st173:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof173
-		}
-	st_case_173:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 109:
-			goto tr220
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr220:
-		lex.te = (lex.p) + 1
-
-		lex.act = 25
+		lex.act = 42
 		goto st174
 	st174:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -6969,18 +6961,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_174:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st175
-		case 10:
-			goto tr223
-		case 13:
-			goto st175
-		case 32:
-			goto st175
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 109:
+			goto tr222
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -6994,13 +6980,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr221
-	tr223:
+		goto tr67
+	tr222:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
+		lex.act = 25
 		goto st175
 	st175:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7009,36 +6993,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_175:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st175
+			goto st176
 		case 10:
-			goto tr223
+			goto tr225
 		case 13:
-			goto st175
+			goto st176
 		case 32:
-			goto st175
-		}
-		goto tr221
-	tr201:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st176
-	st176:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof176
-		}
-	st_case_176:
-		switch lex.data[(lex.p)] {
+			goto st176
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
-			goto tr224
-		case 101:
-			goto tr198
-		case 116:
-			goto tr225
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -7052,11 +7017,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr224:
+		goto tr223
+	tr225:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st176
+	st176:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof176
+		}
+	st_case_176:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st176
+		case 10:
+			goto tr225
+		case 13:
+			goto st176
+		case 32:
+			goto st176
+		}
+		goto tr223
+	tr203:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st177
 	st177:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7068,38 +7056,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 99:
 			goto tr226
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr226:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st178
-	st178:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof178
-		}
-	st_case_178:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 112:
+		case 101:
+			goto tr200
+		case 116:
 			goto tr227
 		}
 		switch {
@@ -7114,23 +7075,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr227:
+		goto tr67
+	tr226:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st179
-	st179:
+		lex.act = 42
+		goto st178
+	st178:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof179
+			goto _test_eof178
 		}
-	st_case_179:
+	st_case_178:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
+		case 101:
 			goto tr228
 		}
 		switch {
@@ -7145,32 +7106,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr228:
 		lex.te = (lex.p) + 1
 
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
-		goto st180
-	st180:
+		lex.act = 42
+		goto st179
+	st179:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof180
+			goto _test_eof179
 		}
-	st_case_180:
+	st_case_179:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
+		case 112:
 			goto tr229
 		}
 		switch {
@@ -7185,23 +7137,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr71
+		goto tr67
 	tr229:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st181
-	st181:
+		lex.act = 42
+		goto st180
+	st180:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof181
+			goto _test_eof180
 		}
-	st_case_181:
+	st_case_180:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 111:
+		case 116:
 			goto tr230
 		}
 		switch {
@@ -7216,23 +7168,32 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr230:
 		lex.te = (lex.p) + 1
 
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
 		lex.act = 41
-		goto st182
-	st182:
+		goto st181
+	st181:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof182
+			goto _test_eof181
 		}
-	st_case_182:
+	st_case_181:
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st34
+		case 10:
+			goto tr75
+		case 13:
+			goto st34
+		case 32:
+			goto st34
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
+		case 105:
 			goto tr231
 		}
 		switch {
@@ -7247,30 +7208,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr73
 	tr231:
 		lex.te = (lex.p) + 1
 
-		lex.act = 21
-		goto st183
-	st183:
+		lex.act = 42
+		goto st182
+	st182:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof183
+			goto _test_eof182
 		}
-	st_case_183:
+	st_case_182:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st184
-		case 10:
-			goto tr234
-		case 13:
-			goto st184
-		case 32:
-			goto st184
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 111:
+			goto tr232
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -7284,13 +7239,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr232
-	tr234:
+		goto tr67
+	tr232:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
+		lex.act = 42
+		goto st183
+	st183:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof183
+		}
+	st_case_183:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
+			goto tr233
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr233:
+		lex.te = (lex.p) + 1
 
+		lex.act = 21
 		goto st184
 	st184:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7299,32 +7283,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_184:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st184
+			goto st185
 		case 10:
-			goto tr234
+			goto tr236
 		case 13:
-			goto st184
+			goto st185
 		case 32:
-			goto st184
-		}
-		goto tr232
-	tr225:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st185
-	st185:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof185
-		}
-	st_case_185:
-		switch lex.data[(lex.p)] {
+			goto st185
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
-			goto tr235
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -7338,11 +7307,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr235:
+		goto tr234
+	tr236:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st185
+	st185:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof185
+		}
+	st_case_185:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st185
+		case 10:
+			goto tr236
+		case 13:
+			goto st185
+		case 32:
+			goto st185
+		}
+		goto tr234
+	tr227:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st186
 	st186:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7354,38 +7346,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
-			goto tr236
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr236:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st187
-	st187:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof187
-		}
-	st_case_187:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 100:
+		case 101:
 			goto tr237
 		}
 		switch {
@@ -7400,23 +7361,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr237:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st188
-	st188:
+		lex.act = 42
+		goto st187
+	st187:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof188
+			goto _test_eof187
 		}
-	st_case_188:
+	st_case_187:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 115:
+		case 110:
 			goto tr238
 		}
 		switch {
@@ -7431,11 +7392,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr238:
 		lex.te = (lex.p) + 1
 
-		lex.act = 22
+		lex.act = 42
+		goto st188
+	st188:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof188
+		}
+	st_case_188:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 100:
+			goto tr239
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr239:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st189
 	st189:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7443,14 +7435,45 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_189:
 		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 115:
+			goto tr240
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr240:
+		lex.te = (lex.p) + 1
+
+		lex.act = 22
+		goto st190
+	st190:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof190
+		}
+	st_case_190:
+		switch lex.data[(lex.p)] {
 		case 9:
-			goto st190
+			goto st191
 		case 10:
-			goto tr241
+			goto tr243
 		case 13:
-			goto st190
+			goto st191
 		case 32:
-			goto st190
+			goto st191
 		case 46:
 			goto st18
 		case 95:
@@ -7468,34 +7491,13 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr239
-	tr241:
+		goto tr241
+	tr243:
 
 		lex.line++
 		lex.lineStart = lex.p + 1
 		lex.linesSinceDocstring++
 
-		goto st190
-	st190:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof190
-		}
-	st_case_190:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st190
-		case 10:
-			goto tr241
-		case 13:
-			goto st190
-		case 32:
-			goto st190
-		}
-		goto tr239
-	tr42:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
 		goto st191
 	st191:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7503,22 +7505,43 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_191:
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st191
+		case 10:
+			goto tr243
+		case 13:
+			goto st191
+		case 32:
+			goto st191
+		}
+		goto tr241
+	tr43:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st192
+	st192:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof192
+		}
+	st_case_192:
+		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 97:
-			goto tr242
-		case 105:
-			goto tr243
-		case 108:
 			goto tr244
-		case 111:
-			goto tr213
-		case 114:
+		case 105:
 			goto tr245
-		case 117:
+		case 108:
 			goto tr246
+		case 111:
+			goto tr215
+		case 114:
+			goto tr247
+		case 117:
+			goto tr248
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -7532,42 +7555,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr242:
+		goto tr67
+	tr244:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st192
-	st192:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof192
-		}
-	st_case_192:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 108:
-			goto tr247
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr247:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
+		lex.act = 42
 		goto st193
 	st193:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7579,38 +7571,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 115:
-			goto tr248
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr248:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st194
-	st194:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof194
-		}
-	st_case_194:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
+		case 108:
 			goto tr249
 		}
 		switch {
@@ -7625,30 +7586,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr249:
 		lex.te = (lex.p) + 1
 
-		lex.act = 30
-		goto st195
-	st195:
+		lex.act = 42
+		goto st194
+	st194:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof195
+			goto _test_eof194
 		}
-	st_case_195:
+	st_case_194:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st196
-		case 10:
-			goto tr252
-		case 13:
-			goto st196
-		case 32:
-			goto st196
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 115:
+			goto tr250
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -7662,13 +7617,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr250
-	tr252:
+		goto tr67
+	tr250:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
+		lex.act = 42
+		goto st195
+	st195:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof195
+		}
+	st_case_195:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr251
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr251:
+		lex.te = (lex.p) + 1
 
+		lex.act = 30
 		goto st196
 	st196:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7677,32 +7661,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_196:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st196
+			goto st197
 		case 10:
-			goto tr252
+			goto tr254
 		case 13:
-			goto st196
+			goto st197
 		case 32:
-			goto st196
-		}
-		goto tr250
-	tr243:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st197
-	st197:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof197
-		}
-	st_case_197:
-		switch lex.data[(lex.p)] {
+			goto st197
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
-			goto tr253
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -7716,11 +7685,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr253:
+		goto tr252
+	tr254:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st197
+	st197:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof197
+		}
+	st_case_197:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st197
+		case 10:
+			goto tr254
+		case 13:
+			goto st197
+		case 32:
+			goto st197
+		}
+		goto tr252
+	tr245:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st198
 	st198:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7732,38 +7724,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
-			goto tr254
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr254:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st199
-	st199:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof199
-		}
-	st_case_199:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 108:
+		case 110:
 			goto tr255
 		}
 		switch {
@@ -7778,11 +7739,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr255:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st199
+	st199:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof199
+		}
+	st_case_199:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr256
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr256:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st200
 	st200:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -7795,68 +7787,6 @@ func (lex *lexer) Lex(out *yySymType) int {
 		case 95:
 			goto tr27
 		case 108:
-			goto tr256
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr256:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st201
-	st201:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof201
-		}
-	st_case_201:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 121:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr244:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st202
-	st202:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof202
-		}
-	st_case_202:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 111:
 			goto tr257
 		}
 		switch {
@@ -7871,54 +7801,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr257:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st203
-	st203:
+		lex.act = 42
+		goto st201
+	st201:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof203
+			goto _test_eof201
 		}
-	st_case_203:
+	st_case_201:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
-			goto tr116
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr245:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st204
-	st204:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof204
-		}
-	st_case_204:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 111:
+		case 108:
 			goto tr258
 		}
 		switch {
@@ -7933,24 +7832,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr258:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st205
-	st205:
+		lex.act = 42
+		goto st202
+	st202:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof205
+			goto _test_eof202
 		}
-	st_case_205:
+	st_case_202:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 109:
-			goto tr70
+		case 121:
+			goto tr72
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -7964,23 +7863,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr246:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st206
-	st206:
+		lex.act = 42
+		goto st203
+	st203:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof206
+			goto _test_eof203
 		}
-	st_case_206:
+	st_case_203:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
+		case 111:
 			goto tr259
 		}
 		switch {
@@ -7995,23 +7894,54 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr259:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st207
-	st207:
+		lex.act = 42
+		goto st204
+	st204:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof207
+			goto _test_eof204
 		}
-	st_case_207:
+	st_case_204:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
+		case 97:
+			goto tr118
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr247:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st205
+	st205:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof205
+		}
+	st_case_205:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 111:
 			goto tr260
 		}
 		switch {
@@ -8026,23 +7956,54 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr260:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st208
-	st208:
+		lex.act = 42
+		goto st206
+	st206:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof208
+			goto _test_eof206
 		}
-	st_case_208:
+	st_case_206:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
+		case 109:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr248:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st207
+	st207:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof207
+		}
+	st_case_207:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
 			goto tr261
 		}
 		switch {
@@ -8057,23 +8018,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr261:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st209
-	st209:
+		lex.act = 42
+		goto st208
+	st208:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof209
+			goto _test_eof208
 		}
-	st_case_209:
+	st_case_208:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
+		case 99:
 			goto tr262
 		}
 		switch {
@@ -8088,24 +8049,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr262:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st210
-	st210:
+		lex.act = 42
+		goto st209
+	st209:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof210
+			goto _test_eof209
 		}
-	st_case_210:
+	st_case_209:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 111:
-			goto tr127
+		case 116:
+			goto tr263
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8119,25 +8080,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr43:
+		goto tr67
+	tr263:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st211
-	st211:
+		lex.act = 42
+		goto st210
+	st210:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof211
+			goto _test_eof210
 		}
-	st_case_211:
+	st_case_210:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 108:
-			goto tr263
-		case 111:
+		case 105:
 			goto tr264
 		}
 		switch {
@@ -8152,24 +8111,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr263:
+		goto tr67
+	tr264:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st212
-	st212:
+		lex.act = 42
+		goto st211
+	st211:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof212
+			goto _test_eof211
 		}
-	st_case_212:
+	st_case_211:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 111:
-			goto tr265
+			goto tr129
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8183,23 +8142,25 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr265:
+		goto tr67
+	tr44:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st213
-	st213:
+		lex.act = 42
+		goto st212
+	st212:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof213
+			goto _test_eof212
 		}
-	st_case_213:
+	st_case_212:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 98:
+		case 108:
+			goto tr265
+		case 111:
 			goto tr266
 		}
 		switch {
@@ -8214,55 +8175,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr266:
+		goto tr67
+	tr265:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st214
-	st214:
+		lex.act = 42
+		goto st213
+	st213:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof214
+			goto _test_eof213
 		}
-	st_case_214:
+	st_case_213:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
+		case 111:
 			goto tr267
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr267:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st215
-	st215:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof215
-		}
-	st_case_215:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 108:
-			goto tr70
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8276,23 +8206,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr264:
+		goto tr67
+	tr267:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st216
-	st216:
+		lex.act = 42
+		goto st214
+	st214:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof216
+			goto _test_eof214
 		}
-	st_case_216:
+	st_case_214:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
+		case 98:
 			goto tr268
 		}
 		switch {
@@ -8307,11 +8237,73 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr268:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st215
+	st215:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof215
+		}
+	st_case_215:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr269
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr269:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st216
+	st216:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof216
+		}
+	st_case_216:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 108:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr266:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st217
 	st217:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8323,8 +8315,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 111:
-			goto tr70
+		case 116:
+			goto tr270
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8338,11 +8330,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr44:
+		goto tr67
+	tr270:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st218
 	st218:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8352,24 +8344,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
-		case 49:
-			goto tr269
-		case 51:
-			goto tr270
-		case 54:
-			goto tr271
-		case 56:
-			goto tr272
 		case 95:
 			goto tr27
-		case 102:
-			goto tr70
-		case 109:
-			goto tr273
-		case 110:
-			goto tr274
-		case 115:
-			goto tr70
+		case 111:
+			goto tr72
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8383,11 +8361,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr269:
+		goto tr67
+	tr45:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st219
 	st219:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8397,10 +8375,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
+		case 49:
+			goto tr271
+		case 51:
+			goto tr272
 		case 54:
-			goto tr275
+			goto tr273
+		case 56:
+			goto tr274
 		case 95:
 			goto tr27
+		case 102:
+			goto tr72
+		case 109:
+			goto tr275
+		case 110:
+			goto tr276
+		case 115:
+			goto tr72
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8414,11 +8406,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr275:
+		goto tr67
+	tr271:
 		lex.te = (lex.p) + 1
 
-		lex.act = 8
+		lex.act = 42
 		goto st220
 	st220:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8426,16 +8418,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_220:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st221
-		case 10:
-			goto tr278
-		case 13:
-			goto st221
-		case 32:
-			goto st221
 		case 46:
 			goto st18
+		case 54:
+			goto tr277
 		case 95:
 			goto tr27
 		}
@@ -8451,13 +8437,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr276
-	tr278:
+		goto tr67
+	tr277:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
+		lex.act = 8
 		goto st221
 	st221:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8466,19 +8450,37 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_221:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st221
+			goto st222
 		case 10:
-			goto tr278
+			goto tr280
 		case 13:
-			goto st221
+			goto st222
 		case 32:
-			goto st221
+			goto st222
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
 		}
-		goto tr276
-	tr270:
-		lex.te = (lex.p) + 1
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr278
+	tr280:
 
-		lex.act = 41
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
 		goto st222
 	st222:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8486,30 +8488,20 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_222:
 		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 50:
-			goto tr279
-		case 95:
-			goto tr27
+		case 9:
+			goto st222
+		case 10:
+			goto tr280
+		case 13:
+			goto st222
+		case 32:
+			goto st222
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr279:
+		goto tr278
+	tr272:
 		lex.te = (lex.p) + 1
 
-		lex.act = 9
+		lex.act = 42
 		goto st223
 	st223:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8517,16 +8509,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_223:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st224
-		case 10:
-			goto tr282
-		case 13:
-			goto st224
-		case 32:
-			goto st224
 		case 46:
 			goto st18
+		case 50:
+			goto tr281
 		case 95:
 			goto tr27
 		}
@@ -8542,13 +8528,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr280
-	tr282:
+		goto tr67
+	tr281:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
+		lex.act = 9
 		goto st224
 	st224:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8557,19 +8541,37 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_224:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st224
+			goto st225
 		case 10:
-			goto tr282
+			goto tr284
 		case 13:
-			goto st224
+			goto st225
 		case 32:
-			goto st224
+			goto st225
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
 		}
-		goto tr280
-	tr271:
-		lex.te = (lex.p) + 1
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr282
+	tr284:
 
-		lex.act = 41
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
 		goto st225
 	st225:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8577,30 +8579,20 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_225:
 		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 52:
-			goto tr283
-		case 95:
-			goto tr27
+		case 9:
+			goto st225
+		case 10:
+			goto tr284
+		case 13:
+			goto st225
+		case 32:
+			goto st225
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr283:
+		goto tr282
+	tr273:
 		lex.te = (lex.p) + 1
 
-		lex.act = 10
+		lex.act = 42
 		goto st226
 	st226:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8608,16 +8600,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_226:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st227
-		case 10:
-			goto tr286
-		case 13:
-			goto st227
-		case 32:
-			goto st227
 		case 46:
 			goto st18
+		case 52:
+			goto tr285
 		case 95:
 			goto tr27
 		}
@@ -8633,13 +8619,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr284
-	tr286:
+		goto tr67
+	tr285:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
+		lex.act = 10
 		goto st227
 	st227:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8648,19 +8632,37 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_227:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st227
+			goto st228
 		case 10:
-			goto tr286
+			goto tr288
 		case 13:
-			goto st227
+			goto st228
 		case 32:
-			goto st227
+			goto st228
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
 		}
-		goto tr284
-	tr272:
-		lex.te = (lex.p) + 1
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr286
+	tr288:
 
-		lex.act = 7
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
 		goto st228
 	st228:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8669,37 +8671,19 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_228:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st229
+			goto st228
 		case 10:
-			goto tr289
+			goto tr288
 		case 13:
-			goto st229
+			goto st228
 		case 32:
-			goto st229
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
+			goto st228
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr287
-	tr289:
+		goto tr286
+	tr274:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
+		lex.act = 7
 		goto st229
 	st229:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8708,32 +8692,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_229:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st229
+			goto st230
 		case 10:
-			goto tr289
+			goto tr291
 		case 13:
-			goto st229
+			goto st230
 		case 32:
-			goto st229
-		}
-		goto tr287
-	tr273:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st230
-	st230:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof230
-		}
-	st_case_230:
-		switch lex.data[(lex.p)] {
+			goto st230
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 112:
-			goto tr290
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8747,11 +8716,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr290:
+		goto tr289
+	tr291:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st230
+	st230:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof230
+		}
+	st_case_230:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st230
+		case 10:
+			goto tr291
+		case 13:
+			goto st230
+		case 32:
+			goto st230
+		}
+		goto tr289
+	tr275:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st231
 	st231:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8763,40 +8755,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 108:
-			goto tr291
-		case 111:
-			goto tr120
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr291:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st232
-	st232:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof232
-		}
-	st_case_232:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
+		case 112:
 			goto tr292
 		}
 		switch {
@@ -8811,24 +8770,26 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr292:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st233
-	st233:
+		lex.act = 42
+		goto st232
+	st232:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof233
+			goto _test_eof232
 		}
-	st_case_233:
+	st_case_232:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 109:
+		case 108:
 			goto tr293
+		case 111:
+			goto tr122
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8842,17 +8803,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr293:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st234
-	st234:
+		lex.act = 42
+		goto st233
+	st233:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof234
+			goto _test_eof233
 		}
-	st_case_234:
+	st_case_233:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
@@ -8873,23 +8834,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr294:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st235
-	st235:
+		lex.act = 42
+		goto st234
+	st234:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof235
+			goto _test_eof234
 		}
-	st_case_235:
+	st_case_234:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
+		case 109:
 			goto tr295
 		}
 		switch {
@@ -8904,11 +8865,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr295:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st235
+	st235:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof235
+		}
+	st_case_235:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr296
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr296:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st236
 	st236:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8920,8 +8912,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
-			goto tr118
+		case 110:
+			goto tr297
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8935,12 +8927,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr274:
+		goto tr67
+	tr297:
 		lex.te = (lex.p) + 1
 
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
+		lex.act = 42
 		goto st237
 	st237:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -8948,26 +8939,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_237:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
-			goto tr296
-		case 108:
-			goto tr297
-		case 115:
-			goto tr298
 		case 116:
-			goto tr299
+			goto tr120
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -8981,10 +8958,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr71
-	tr296:
+		goto tr67
+	tr276:
 		lex.te = (lex.p) + 1
 
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
 		lex.act = 41
 		goto st238
 	st238:
@@ -8993,42 +8971,25 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_238:
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st34
+		case 10:
+			goto tr75
+		case 13:
+			goto st34
+		case 32:
+			goto st34
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 99:
+			goto tr298
 		case 108:
+			goto tr299
+		case 115:
 			goto tr300
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr300:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st239
-	st239:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof239
-		}
-	st_case_239:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 117:
+		case 116:
 			goto tr301
 		}
 		switch {
@@ -9043,23 +9004,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr301:
+		goto tr73
+	tr298:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st240
-	st240:
+		lex.act = 42
+		goto st239
+	st239:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof240
+			goto _test_eof239
 		}
-	st_case_240:
+	st_case_239:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 100:
+		case 108:
 			goto tr302
 		}
 		switch {
@@ -9074,23 +9035,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr302:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st241
-	st241:
+		lex.act = 42
+		goto st240
+	st240:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof241
+			goto _test_eof240
 		}
-	st_case_241:
+	st_case_240:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 117:
 			goto tr303
 		}
 		switch {
@@ -9105,30 +9066,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr303:
 		lex.te = (lex.p) + 1
 
-		lex.act = 1
-		goto st242
-	st242:
+		lex.act = 42
+		goto st241
+	st241:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof242
+			goto _test_eof241
 		}
-	st_case_242:
+	st_case_241:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st243
-		case 10:
-			goto tr306
-		case 13:
-			goto st243
-		case 32:
-			goto st243
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 100:
+			goto tr304
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -9142,13 +9097,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr304
-	tr306:
+		goto tr67
+	tr304:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
+		lex.act = 42
+		goto st242
+	st242:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof242
+		}
+	st_case_242:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr305
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr305:
+		lex.te = (lex.p) + 1
 
+		lex.act = 1
 		goto st243
 	st243:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -9157,32 +9141,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_243:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st243
+			goto st244
 		case 10:
-			goto tr306
+			goto tr308
 		case 13:
-			goto st243
+			goto st244
 		case 32:
-			goto st243
-		}
-		goto tr304
-	tr297:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st244
-	st244:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof244
-		}
-	st_case_244:
-		switch lex.data[(lex.p)] {
+			goto st244
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
-			goto tr155
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -9196,11 +9165,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr298:
+		goto tr306
+	tr308:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st244
+	st244:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof244
+		}
+	st_case_244:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st244
+		case 10:
+			goto tr308
+		case 13:
+			goto st244
+		case 32:
+			goto st244
+		}
+		goto tr306
+	tr299:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st245
 	st245:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -9212,8 +9204,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
-			goto tr307
+		case 105:
+			goto tr157
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -9227,11 +9219,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr307:
+		goto tr67
+	tr300:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st246
 	st246:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -9243,38 +9235,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
-			goto tr308
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr308:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st247
-	st247:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof247
-		}
-	st_case_247:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 110:
+		case 116:
 			goto tr309
 		}
 		switch {
@@ -9289,11 +9250,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr309:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st247
+	st247:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof247
+		}
+	st_case_247:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr310
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr310:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st248
 	st248:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -9305,38 +9297,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
-			goto tr310
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr310:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st249
-	st249:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof249
-		}
-	st_case_249:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
+		case 110:
 			goto tr311
 		}
 		switch {
@@ -9351,54 +9312,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr311:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st250
-	st250:
+		lex.act = 42
+		goto st249
+	st249:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof250
+			goto _test_eof249
 		}
-	st_case_250:
+	st_case_249:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 111:
-			goto tr202
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr299:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st251
-	st251:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof251
-		}
-	st_case_251:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
+		case 99:
 			goto tr312
 		}
 		switch {
@@ -9413,23 +9343,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr312:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st252
-	st252:
+		lex.act = 42
+		goto st250
+	st250:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof252
+			goto _test_eof250
 		}
-	st_case_252:
+	st_case_250:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 114:
+		case 101:
 			goto tr313
 		}
 		switch {
@@ -9444,23 +9374,54 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr313:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st253
-	st253:
+		lex.act = 42
+		goto st251
+	st251:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof253
+			goto _test_eof251
 		}
-	st_case_253:
+	st_case_251:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 102:
+		case 111:
+			goto tr204
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr301:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st252
+	st252:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof252
+		}
+	st_case_252:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
 			goto tr314
 		}
 		switch {
@@ -9475,55 +9436,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr314:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st254
-	st254:
+		lex.act = 42
+		goto st253
+	st253:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof254
+			goto _test_eof253
 		}
-	st_case_254:
+	st_case_253:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
+		case 114:
 			goto tr315
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr315:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st255
-	st255:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof255
-		}
-	st_case_255:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 99:
-			goto tr151
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -9537,25 +9467,54 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr45:
+		goto tr67
+	tr315:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st256
-	st256:
+		lex.act = 42
+		goto st254
+	st254:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof256
+			goto _test_eof254
 		}
-	st_case_256:
+	st_case_254:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 102:
+			goto tr316
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr316:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st255
+	st255:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof255
+		}
+	st_case_255:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 97:
-			goto tr316
-		case 105:
 			goto tr317
 		}
 		switch {
@@ -9570,11 +9529,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr316:
+		goto tr67
+	tr317:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st256
+	st256:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof256
+		}
+	st_case_256:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 99:
+			goto tr153
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr46:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st257
 	st257:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -9586,8 +9576,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 109:
+		case 97:
 			goto tr318
+		case 105:
+			goto tr319
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -9595,17 +9587,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 				goto tr27
 			}
 		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr27
 			}
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr318:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st258
 	st258:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -9617,38 +9609,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 98:
-			goto tr319
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr319:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st259
-	st259:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof259
-		}
-	st_case_259:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 100:
+		case 109:
 			goto tr320
 		}
 		switch {
@@ -9663,54 +9624,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr320:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st260
-	st260:
+		lex.act = 42
+		goto st259
+	st259:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof260
+			goto _test_eof259
 		}
-	st_case_260:
+	st_case_259:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr317:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st261
-	st261:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof261
-		}
-	st_case_261:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 115:
+		case 98:
 			goto tr321
 		}
 		switch {
@@ -9725,23 +9655,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr321:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st262
-	st262:
+		lex.act = 42
+		goto st260
+	st260:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof262
+			goto _test_eof260
 		}
-	st_case_262:
+	st_case_260:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
+		case 100:
 			goto tr322
 		}
 		switch {
@@ -9756,11 +9686,73 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr322:
 		lex.te = (lex.p) + 1
 
-		lex.act = 15
+		lex.act = 42
+		goto st261
+	st261:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof261
+		}
+	st_case_261:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr319:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st262
+	st262:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof262
+		}
+	st_case_262:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 115:
+			goto tr323
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr323:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st263
 	st263:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -9768,14 +9760,45 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_263:
 		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 116:
+			goto tr324
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr324:
+		lex.te = (lex.p) + 1
+
+		lex.act = 15
+		goto st264
+	st264:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof264
+		}
+	st_case_264:
+		switch lex.data[(lex.p)] {
 		case 9:
-			goto st264
+			goto st265
 		case 10:
-			goto tr325
+			goto tr327
 		case 13:
-			goto st264
+			goto st265
 		case 32:
-			goto st264
+			goto st265
 		case 46:
 			goto st18
 		case 95:
@@ -9793,34 +9816,13 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr323
-	tr325:
+		goto tr325
+	tr327:
 
 		lex.line++
 		lex.lineStart = lex.p + 1
 		lex.linesSinceDocstring++
 
-		goto st264
-	st264:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof264
-		}
-	st_case_264:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st264
-		case 10:
-			goto tr325
-		case 13:
-			goto st264
-		case 32:
-			goto st264
-		}
-		goto tr323
-	tr46:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
 		goto st265
 	st265:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -9828,32 +9830,20 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_265:
 		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr326
-		case 111:
+		case 9:
+			goto st265
+		case 10:
 			goto tr327
+		case 13:
+			goto st265
+		case 32:
+			goto st265
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr326:
+		goto tr325
+	tr47:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st266
 	st266:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -9865,167 +9855,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 112:
-			goto tr328
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr328:
-		lex.te = (lex.p) + 1
-
-		lex.act = 14
-		goto st267
-	st267:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof267
-		}
-	st_case_267:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st268
-		case 10:
-			goto tr331
-		case 13:
-			goto st268
-		case 32:
-			goto st268
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr329
-	tr331:
-
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
-		goto st268
-	st268:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof268
-		}
-	st_case_268:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st268
-		case 10:
-			goto tr331
-		case 13:
-			goto st268
-		case 32:
-			goto st268
-		}
-		goto tr329
-	tr327:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st269
-	st269:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof269
-		}
-	st_case_269:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 100:
-			goto tr332
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr332:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st270
-	st270:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof270
-		}
-	st_case_270:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 117:
-			goto tr219
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr47:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st271
-	st271:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof271
-		}
-	st_case_271:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
 		case 97:
-			goto tr333
-		case 101:
-			goto tr334
-		case 105:
-			goto tr267
+			goto tr328
 		case 111:
-			goto tr116
+			goto tr329
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -10039,11 +9872,164 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr333:
+		goto tr67
+	tr328:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st267
+	st267:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof267
+		}
+	st_case_267:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 112:
+			goto tr330
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr330:
+		lex.te = (lex.p) + 1
+
+		lex.act = 14
+		goto st268
+	st268:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof268
+		}
+	st_case_268:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st269
+		case 10:
+			goto tr333
+		case 13:
+			goto st269
+		case 32:
+			goto st269
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr331
+	tr333:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st269
+	st269:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof269
+		}
+	st_case_269:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st269
+		case 10:
+			goto tr333
+		case 13:
+			goto st269
+		case 32:
+			goto st269
+		}
+		goto tr331
+	tr329:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st270
+	st270:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof270
+		}
+	st_case_270:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 100:
+			goto tr334
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr334:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st271
+	st271:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof271
+		}
+	st_case_271:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 117:
+			goto tr221
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr48:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st272
 	st272:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10055,10 +10041,14 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 109:
+		case 97:
 			goto tr335
-		case 116:
+		case 101:
 			goto tr336
+		case 105:
+			goto tr269
+		case 111:
+			goto tr118
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -10066,17 +10056,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 				goto tr27
 			}
 		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr27
 			}
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr335:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st273
 	st273:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10088,38 +10078,9 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 109:
 			goto tr337
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr337:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st274
-	st274:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof274
-		}
-	st_case_274:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 115:
+		case 116:
 			goto tr338
 		}
 		switch {
@@ -10134,23 +10095,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr338:
+		goto tr67
+	tr337:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st275
-	st275:
+		lex.act = 42
+		goto st274
+	st274:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof275
+			goto _test_eof274
 		}
-	st_case_275:
+	st_case_274:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 112:
+		case 101:
 			goto tr339
 		}
 		switch {
@@ -10165,11 +10126,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr339:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st275
+	st275:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof275
+		}
+	st_case_275:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 115:
+			goto tr340
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr340:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st276
 	st276:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10181,38 +10173,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
-			goto tr340
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr340:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st277
-	st277:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof277
-		}
-	st_case_277:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 99:
+		case 112:
 			goto tr341
 		}
 		switch {
@@ -10227,307 +10188,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr341:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st278
-	st278:
+		lex.act = 42
+		goto st277
+	st277:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof278
+			goto _test_eof277
 		}
-	st_case_278:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr342
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr342:
-		lex.te = (lex.p) + 1
-
-		lex.act = 3
-		goto st279
-	st279:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof279
-		}
-	st_case_279:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st280
-		case 10:
-			goto tr345
-		case 13:
-			goto st280
-		case 32:
-			goto st280
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr343
-	tr345:
-
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
-		goto st280
-	st280:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof280
-		}
-	st_case_280:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st280
-		case 10:
-			goto tr345
-		case 13:
-			goto st280
-		case 32:
-			goto st280
-		}
-		goto tr343
-	tr336:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st281
-	st281:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof281
-		}
-	st_case_281:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr346
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr346:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st282
-	st282:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof282
-		}
-	st_case_282:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 118:
-			goto tr151
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr334:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st283
-	st283:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof283
-		}
-	st_case_283:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 119:
-			goto tr70
-		case 120:
-			goto tr116
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr48:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st284
-	st284:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof284
-		}
-	st_case_284:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 110:
-			goto tr347
-		case 112:
-			goto tr348
-		case 114:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr347:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st285
-	st285:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof285
-		}
-	st_case_285:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr349
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr349:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st286
-	st286:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof286
-		}
-	st_case_286:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 119:
-			goto tr350
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr350:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st287
-	st287:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof287
-		}
-	st_case_287:
+	st_case_277:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 97:
-			goto tr351
+			goto tr342
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -10541,23 +10219,306 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr351:
+		goto tr67
+	tr342:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st288
-	st288:
+		lex.act = 42
+		goto st278
+	st278:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof288
+			goto _test_eof278
 		}
-	st_case_288:
+	st_case_278:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 121:
+		case 99:
+			goto tr343
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr343:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st279
+	st279:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof279
+		}
+	st_case_279:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr344
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr344:
+		lex.te = (lex.p) + 1
+
+		lex.act = 3
+		goto st280
+	st280:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof280
+		}
+	st_case_280:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st281
+		case 10:
+			goto tr347
+		case 13:
+			goto st281
+		case 32:
+			goto st281
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr345
+	tr347:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st281
+	st281:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof281
+		}
+	st_case_281:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st281
+		case 10:
+			goto tr347
+		case 13:
+			goto st281
+		case 32:
+			goto st281
+		}
+		goto tr345
+	tr338:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st282
+	st282:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof282
+		}
+	st_case_282:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr348
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr348:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st283
+	st283:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof283
+		}
+	st_case_283:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 118:
+			goto tr153
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr336:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st284
+	st284:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof284
+		}
+	st_case_284:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 119:
+			goto tr72
+		case 120:
+			goto tr118
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr49:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st285
+	st285:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof285
+		}
+	st_case_285:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
+			goto tr349
+		case 112:
+			goto tr350
+		case 114:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr349:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st286
+	st286:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof286
+		}
+	st_case_286:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr351
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr351:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st287
+	st287:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof287
+		}
+	st_case_287:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 119:
 			goto tr352
 		}
 		switch {
@@ -10572,11 +10533,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr352:
 		lex.te = (lex.p) + 1
 
-		lex.act = 17
+		lex.act = 42
+		goto st288
+	st288:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof288
+		}
+	st_case_288:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr353
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr353:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st289
 	st289:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10584,18 +10576,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_289:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st290
-		case 10:
-			goto tr355
-		case 13:
-			goto st290
-		case 32:
-			goto st290
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 121:
+			goto tr354
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -10609,13 +10595,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr353
-	tr355:
+		goto tr67
+	tr354:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
+		lex.act = 17
 		goto st290
 	st290:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10624,32 +10608,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_290:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st290
+			goto st291
 		case 10:
-			goto tr355
+			goto tr357
 		case 13:
-			goto st290
+			goto st291
 		case 32:
-			goto st290
-		}
-		goto tr353
-	tr348:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st291
-	st291:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof291
-		}
-	st_case_291:
-		switch lex.data[(lex.p)] {
+			goto st291
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
-			goto tr356
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -10663,11 +10632,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr356:
+		goto tr355
+	tr357:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st291
+	st291:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof291
+		}
+	st_case_291:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st291
+		case 10:
+			goto tr357
+		case 13:
+			goto st291
+		case 32:
+			goto st291
+		}
+		goto tr355
+	tr350:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st292
 	st292:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10679,38 +10671,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
-			goto tr357
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr357:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st293
-	st293:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof293
-		}
-	st_case_293:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 111:
+		case 116:
 			goto tr358
 		}
 		switch {
@@ -10725,23 +10686,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr358:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st294
-	st294:
+		lex.act = 42
+		goto st293
+	st293:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof294
+			goto _test_eof293
 		}
-	st_case_294:
+	st_case_293:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
+		case 105:
 			goto tr359
 		}
 		switch {
@@ -10756,11 +10717,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr359:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st294
+	st294:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof294
+		}
+	st_case_294:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 111:
+			goto tr360
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr360:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st295
 	st295:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10772,38 +10764,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
-			goto tr360
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr360:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st296
-	st296:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof296
-		}
-	st_case_296:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 108:
+		case 110:
 			goto tr361
 		}
 		switch {
@@ -10818,11 +10779,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr361:
 		lex.te = (lex.p) + 1
 
-		lex.act = 28
+		lex.act = 42
+		goto st296
+	st296:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof296
+		}
+	st_case_296:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr362
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr362:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st297
 	st297:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10830,14 +10822,45 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_297:
 		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 108:
+			goto tr363
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr363:
+		lex.te = (lex.p) + 1
+
+		lex.act = 28
+		goto st298
+	st298:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof298
+		}
+	st_case_298:
+		switch lex.data[(lex.p)] {
 		case 9:
-			goto st298
+			goto st299
 		case 10:
-			goto tr364
+			goto tr366
 		case 13:
-			goto st298
+			goto st299
 		case 32:
-			goto st298
+			goto st299
 		case 46:
 			goto st18
 		case 95:
@@ -10855,34 +10878,13 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr362
-	tr364:
+		goto tr364
+	tr366:
 
 		lex.line++
 		lex.lineStart = lex.p + 1
 		lex.linesSinceDocstring++
 
-		goto st298
-	st298:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof298
-		}
-	st_case_298:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st298
-		case 10:
-			goto tr364
-		case 13:
-			goto st298
-		case 32:
-			goto st298
-		}
-		goto tr362
-	tr49:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
 		goto st299
 	st299:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10890,34 +10892,20 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_299:
 		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr365
-		case 114:
+		case 9:
+			goto st299
+		case 10:
 			goto tr366
-		case 117:
-			goto tr367
+		case 13:
+			goto st299
+		case 32:
+			goto st299
 		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr365:
+		goto tr364
+	tr50:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st300
 	st300:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10929,10 +10917,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
+		case 97:
+			goto tr367
+		case 114:
 			goto tr368
-		case 115:
-			goto tr118
+		case 117:
+			goto tr369
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -10940,17 +10930,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 				goto tr27
 			}
 		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr27
 			}
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr368:
+		goto tr67
+	tr367:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st301
 	st301:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10962,8 +10952,10 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 107:
-			goto tr369
+		case 99:
+			goto tr370
+		case 115:
+			goto tr120
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -10977,11 +10969,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr369:
+		goto tr67
+	tr370:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st302
 	st302:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -10993,8 +10985,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 97:
-			goto tr370
+		case 107:
+			goto tr371
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11002,17 +10994,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 				goto tr27
 			}
 		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr27
 			}
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr370:
+		goto tr67
+	tr371:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st303
 	st303:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -11024,105 +11016,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 103:
-			goto tr151
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr366:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st304
-	st304:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof304
-		}
-	st_case_304:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr371
-		case 111:
-			goto tr372
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr371:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st305
-	st305:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof305
-		}
-	st_case_305:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 110:
-			goto tr116
-		case 118:
-			goto tr373
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr373:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st306
-	st306:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof306
-		}
-	st_case_306:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
 		case 97:
-			goto tr187
+			goto tr372
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11136,23 +11031,56 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr372:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st307
-	st307:
+		lex.act = 42
+		goto st304
+	st304:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof307
+			goto _test_eof304
 		}
-	st_case_307:
+	st_case_304:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
+		case 103:
+			goto tr153
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr368:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st305
+	st305:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof305
+		}
+	st_case_305:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr373
+		case 111:
 			goto tr374
 		}
 		switch {
@@ -11167,23 +11095,25 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr374:
+		goto tr67
+	tr373:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st308
-	st308:
+		lex.act = 42
+		goto st306
+	st306:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof308
+			goto _test_eof306
 		}
-	st_case_308:
+	st_case_306:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 110:
+			goto tr118
+		case 118:
 			goto tr375
 		}
 		switch {
@@ -11198,23 +11128,54 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr375:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st309
-	st309:
+		lex.act = 42
+		goto st307
+	st307:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof309
+			goto _test_eof307
 		}
-	st_case_309:
+	st_case_307:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
+		case 97:
+			goto tr189
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr374:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st308
+	st308:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof308
+		}
+	st_case_308:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 116:
 			goto tr376
 		}
 		switch {
@@ -11229,23 +11190,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr376:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st310
-	st310:
+		lex.act = 42
+		goto st309
+	st309:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof310
+			goto _test_eof309
 		}
-	st_case_310:
+	st_case_309:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
+		case 101:
 			goto tr377
 		}
 		switch {
@@ -11260,54 +11221,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr377:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st311
-	st311:
+		lex.act = 42
+		goto st310
+	st310:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof311
+			goto _test_eof310
 		}
-	st_case_311:
+	st_case_310:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
-			goto tr109
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr367:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st312
-	st312:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof312
-		}
-	st_case_312:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 98:
+		case 99:
 			goto tr378
 		}
 		switch {
@@ -11322,24 +11252,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr378:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st313
-	st313:
+		lex.act = 42
+		goto st311
+	st311:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof313
+			goto _test_eof311
 		}
-	st_case_313:
+	st_case_311:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 108:
-			goto tr197
+		case 116:
+			goto tr379
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11353,11 +11283,73 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr50:
+		goto tr67
+	tr379:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st312
+	st312:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof312
+		}
+	st_case_312:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr111
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr369:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st313
+	st313:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof313
+		}
+	st_case_313:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 98:
+			goto tr380
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr380:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st314
 	st314:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -11369,10 +11361,41 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
+		case 108:
+			goto tr199
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr51:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st315
+	st315:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof315
+		}
+	st_case_315:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
 		case 97:
-			goto tr379
+			goto tr381
 		case 101:
-			goto tr380
+			goto tr382
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11386,42 +11409,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr379:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st315
-	st315:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof315
-		}
-	st_case_315:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr381
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
+		goto tr67
 	tr381:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st316
 	st316:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -11433,8 +11425,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 115:
-			goto tr151
+		case 105:
+			goto tr383
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11448,11 +11440,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr380:
+		goto tr67
+	tr383:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st317
 	st317:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -11464,16 +11456,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 100:
-			goto tr268
-		case 103:
-			goto tr382
-		case 113:
-			goto tr383
 		case 115:
-			goto tr384
-		case 116:
-			goto tr385
+			goto tr153
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11487,11 +11471,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr382:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st318
 	st318:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -11503,38 +11487,15 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
-			goto tr386
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr386:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st319
-	st319:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof319
-		}
-	st_case_319:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
+		case 100:
+			goto tr270
+		case 103:
+			goto tr384
+		case 113:
+			goto tr385
 		case 115:
+			goto tr386
+		case 116:
 			goto tr387
 		}
 		switch {
@@ -11549,23 +11510,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr387:
+		goto tr67
+	tr384:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st320
-	st320:
+		lex.act = 42
+		goto st319
+	st319:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof320
+			goto _test_eof319
 		}
-	st_case_320:
+	st_case_319:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
+		case 105:
 			goto tr388
 		}
 		switch {
@@ -11580,23 +11541,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr388:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st321
-	st321:
+		lex.act = 42
+		goto st320
+	st320:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof321
+			goto _test_eof320
 		}
-	st_case_321:
+	st_case_320:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 115:
 			goto tr389
 		}
 		switch {
@@ -11611,54 +11572,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr389:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st322
-	st322:
+		lex.act = 42
+		goto st321
+	st321:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof322
+			goto _test_eof321
 		}
-	st_case_322:
+	st_case_321:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 114:
-			goto tr70
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr383:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st323
-	st323:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof323
-		}
-	st_case_323:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 117:
+		case 116:
 			goto tr390
 		}
 		switch {
@@ -11673,23 +11603,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr390:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st324
-	st324:
+		lex.act = 42
+		goto st322
+	st322:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof324
+			goto _test_eof322
 		}
-	st_case_324:
+	st_case_322:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
+		case 101:
 			goto tr391
 		}
 		switch {
@@ -11704,23 +11634,54 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr391:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st325
-	st325:
+		lex.act = 42
+		goto st323
+	st323:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof325
+			goto _test_eof323
 		}
-	st_case_325:
+	st_case_323:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 114:
+			goto tr72
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr385:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st324
+	st324:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof324
+		}
+	st_case_324:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 117:
 			goto tr392
 		}
 		switch {
@@ -11735,23 +11696,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr392:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st326
-	st326:
+		lex.act = 42
+		goto st325
+	st325:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof326
+			goto _test_eof325
 		}
-	st_case_326:
+	st_case_325:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 105:
 			goto tr393
 		}
 		switch {
@@ -11766,23 +11727,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr393:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st327
-	st327:
+		lex.act = 42
+		goto st326
+	st326:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof327
+			goto _test_eof326
 		}
-	st_case_327:
+	st_case_326:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 100:
+		case 114:
 			goto tr394
 		}
 		switch {
@@ -11797,30 +11758,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr394:
 		lex.te = (lex.p) + 1
 
-		lex.act = 27
-		goto st328
-	st328:
+		lex.act = 42
+		goto st327
+	st327:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof328
+			goto _test_eof327
 		}
-	st_case_328:
+	st_case_327:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st329
-		case 10:
-			goto tr397
-		case 13:
-			goto st329
-		case 32:
-			goto st329
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 101:
+			goto tr395
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11834,13 +11789,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr395
-	tr397:
+		goto tr67
+	tr395:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
+		lex.act = 42
+		goto st328
+	st328:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof328
+		}
+	st_case_328:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 100:
+			goto tr396
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr396:
+		lex.te = (lex.p) + 1
 
+		lex.act = 27
 		goto st329
 	st329:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -11849,32 +11833,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_329:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st329
+			goto st330
 		case 10:
-			goto tr397
+			goto tr399
 		case 13:
-			goto st329
+			goto st330
 		case 32:
-			goto st329
-		}
-		goto tr395
-	tr384:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st330
-	st330:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof330
-		}
-	st_case_330:
-		switch lex.data[(lex.p)] {
+			goto st330
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
-			goto tr164
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11888,11 +11857,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr385:
+		goto tr397
+	tr399:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st330
+	st330:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof330
+		}
+	st_case_330:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st330
+		case 10:
+			goto tr399
+		case 13:
+			goto st330
+		case 32:
+			goto st330
+		}
+		goto tr397
+	tr386:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st331
 	st331:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -11904,10 +11896,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 114:
-			goto tr256
-		case 117:
-			goto tr398
+		case 99:
+			goto tr166
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11921,11 +11911,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr398:
+		goto tr67
+	tr387:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st332
 	st332:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -11938,7 +11928,9 @@ func (lex *lexer) Lex(out *yySymType) int {
 		case 95:
 			goto tr27
 		case 114:
-			goto tr127
+			goto tr258
+		case 117:
+			goto tr400
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11952,11 +11944,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr51:
+		goto tr67
+	tr400:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st333
 	st333:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -11968,18 +11960,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
-			goto tr399
-		case 105:
-			goto tr400
-		case 116:
-			goto tr401
-		case 117:
-			goto tr402
-		case 119:
-			goto tr216
-		case 121:
-			goto tr403
+		case 114:
+			goto tr129
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -11993,11 +11975,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr399:
+		goto tr67
+	tr52:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st334
 	st334:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12009,11 +11991,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 108:
-			goto tr202
-		case 114:
-			goto tr404
+		case 101:
+			goto tr401
+		case 105:
+			goto tr402
 		case 116:
+			goto tr403
+		case 117:
+			goto tr404
+		case 119:
+			goto tr218
+		case 121:
 			goto tr405
 		}
 		switch {
@@ -12028,11 +12016,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr404:
+		goto tr67
+	tr401:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st335
 	st335:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12044,38 +12032,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 118:
+		case 108:
+			goto tr204
+		case 114:
 			goto tr406
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr406:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st336
-	st336:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof336
-		}
-	st_case_336:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
+		case 116:
 			goto tr407
 		}
 		switch {
@@ -12090,23 +12051,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr407:
+		goto tr67
+	tr406:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st337
-	st337:
+		lex.act = 42
+		goto st336
+	st336:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof337
+			goto _test_eof336
 		}
-	st_case_337:
+	st_case_336:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
+		case 118:
 			goto tr408
 		}
 		switch {
@@ -12121,23 +12082,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr408:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st338
-	st338:
+		lex.act = 42
+		goto st337
+	st337:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof338
+			goto _test_eof337
 		}
-	st_case_338:
+	st_case_337:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 105:
 			goto tr409
 		}
 		switch {
@@ -12152,30 +12113,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr409:
 		lex.te = (lex.p) + 1
 
-		lex.act = 24
-		goto st339
-	st339:
+		lex.act = 42
+		goto st338
+	st338:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof339
+			goto _test_eof338
 		}
-	st_case_339:
+	st_case_338:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st340
-		case 10:
-			goto tr412
-		case 13:
-			goto st340
-		case 32:
-			goto st340
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 99:
+			goto tr410
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12189,13 +12144,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr410
-	tr412:
+		goto tr67
+	tr410:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
+		lex.act = 42
+		goto st339
+	st339:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof339
+		}
+	st_case_339:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr411
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr411:
+		lex.te = (lex.p) + 1
 
+		lex.act = 24
 		goto st340
 	st340:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12204,34 +12188,13 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_340:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st340
+			goto st341
 		case 10:
-			goto tr412
+			goto tr414
 		case 13:
-			goto st340
+			goto st341
 		case 32:
-			goto st340
-		}
-		goto tr410
-	tr405:
-		lex.te = (lex.p) + 1
-
-		lex.act = 16
-		goto st341
-	st341:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof341
-		}
-	st_case_341:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st342
-		case 10:
-			goto tr415
-		case 13:
-			goto st342
-		case 32:
-			goto st342
+			goto st341
 		case 46:
 			goto st18
 		case 95:
@@ -12249,13 +12212,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr413
-	tr415:
+		goto tr412
+	tr414:
 
 		lex.line++
 		lex.lineStart = lex.p + 1
 		lex.linesSinceDocstring++
 
+		goto st341
+	st341:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof341
+		}
+	st_case_341:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st341
+		case 10:
+			goto tr414
+		case 13:
+			goto st341
+		case 32:
+			goto st341
+		}
+		goto tr412
+	tr407:
+		lex.te = (lex.p) + 1
+
+		lex.act = 16
 		goto st342
 	st342:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12264,19 +12248,37 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_342:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st342
+			goto st343
 		case 10:
-			goto tr415
+			goto tr417
 		case 13:
-			goto st342
+			goto st343
 		case 32:
-			goto st342
+			goto st343
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
 		}
-		goto tr413
-	tr400:
-		lex.te = (lex.p) + 1
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr415
+	tr417:
 
-		lex.act = 41
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
 		goto st343
 	st343:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12284,12 +12286,33 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_343:
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st343
+		case 10:
+			goto tr417
+		case 13:
+			goto st343
+		case 32:
+			goto st343
+		}
+		goto tr415
+	tr402:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st344
+	st344:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof344
+		}
+	st_case_344:
+		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 122:
-			goto tr310
+			goto tr312
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12303,26 +12326,26 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr401:
+		goto tr67
+	tr403:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st344
-	st344:
+		lex.act = 42
+		goto st345
+	st345:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof344
+			goto _test_eof345
 		}
-	st_case_344:
+	st_case_345:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 97:
-			goto tr416
+			goto tr418
 		case 114:
-			goto tr417
+			goto tr419
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12336,42 +12359,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr416:
+		goto tr67
+	tr418:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st345
-	st345:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof345
-		}
-	st_case_345:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 116:
-			goto tr197
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr417:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
+		lex.act = 42
 		goto st346
 	st346:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12383,10 +12375,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
-			goto tr418
-		case 117:
-			goto tr419
+		case 116:
+			goto tr199
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12400,11 +12390,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr418:
+		goto tr67
+	tr419:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st347
 	st347:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12416,38 +12406,9 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
+		case 105:
 			goto tr420
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr420:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st348
-	st348:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof348
-		}
-	st_case_348:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 103:
+		case 117:
 			goto tr421
 		}
 		switch {
@@ -12462,30 +12423,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr421:
+		goto tr67
+	tr420:
 		lex.te = (lex.p) + 1
 
-		lex.act = 12
-		goto st349
-	st349:
+		lex.act = 42
+		goto st348
+	st348:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof349
+			goto _test_eof348
 		}
-	st_case_349:
+	st_case_348:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st350
-		case 10:
-			goto tr424
-		case 13:
-			goto st350
-		case 32:
-			goto st350
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 110:
+			goto tr422
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12499,13 +12454,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr422
-	tr424:
+		goto tr67
+	tr422:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
+		lex.act = 42
+		goto st349
+	st349:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof349
+		}
+	st_case_349:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 103:
+			goto tr423
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr423:
+		lex.te = (lex.p) + 1
 
+		lex.act = 12
 		goto st350
 	st350:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12514,32 +12498,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_350:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st350
+			goto st351
 		case 10:
-			goto tr424
+			goto tr426
 		case 13:
-			goto st350
+			goto st351
 		case 32:
-			goto st350
-		}
-		goto tr422
-	tr419:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st351
-	st351:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof351
-		}
-	st_case_351:
-		switch lex.data[(lex.p)] {
+			goto st351
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
-			goto tr425
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12553,11 +12522,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr425:
+		goto tr424
+	tr426:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st351
+	st351:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof351
+		}
+	st_case_351:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st351
+		case 10:
+			goto tr426
+		case 13:
+			goto st351
+		case 32:
+			goto st351
+		}
+		goto tr424
+	tr421:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st352
 	st352:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12569,8 +12561,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 116:
-			goto tr426
+		case 99:
+			goto tr427
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12584,11 +12576,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr426:
+		goto tr67
+	tr427:
 		lex.te = (lex.p) + 1
 
-		lex.act = 19
+		lex.act = 42
 		goto st353
 	st353:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12596,18 +12588,12 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_353:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st354
-		case 10:
-			goto tr429
-		case 13:
-			goto st354
-		case 32:
-			goto st354
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 116:
+			goto tr428
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12621,13 +12607,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr427
-	tr429:
+		goto tr67
+	tr428:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
+		lex.act = 19
 		goto st354
 	st354:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12636,32 +12620,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_354:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st354
+			goto st355
 		case 10:
-			goto tr429
+			goto tr431
 		case 13:
-			goto st354
+			goto st355
 		case 32:
-			goto st354
-		}
-		goto tr427
-	tr402:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st355
-	st355:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof355
-		}
-	st_case_355:
-		switch lex.data[(lex.p)] {
+			goto st355
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 112:
-			goto tr388
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12675,11 +12644,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr403:
+		goto tr429
+	tr431:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st355
+	st355:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof355
+		}
+	st_case_355:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st355
+		case 10:
+			goto tr431
+		case 13:
+			goto st355
+		case 32:
+			goto st355
+		}
+		goto tr429
+	tr404:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st356
 	st356:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12691,8 +12683,8 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
-			goto tr430
+		case 112:
+			goto tr390
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12706,11 +12698,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr430:
+		goto tr67
+	tr405:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st357
 	st357:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12722,38 +12714,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 99:
-			goto tr431
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr431:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st358
-	st358:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof358
-		}
-	st_case_358:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 104:
+		case 110:
 			goto tr432
 		}
 		switch {
@@ -12768,23 +12729,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr432:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st359
-	st359:
+		lex.act = 42
+		goto st358
+	st358:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof359
+			goto _test_eof358
 		}
-	st_case_359:
+	st_case_358:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 114:
+		case 99:
 			goto tr433
 		}
 		switch {
@@ -12799,23 +12760,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr433:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st360
-	st360:
+		lex.act = 42
+		goto st359
+	st359:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof360
+			goto _test_eof359
 		}
-	st_case_360:
+	st_case_359:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 111:
+		case 104:
 			goto tr434
 		}
 		switch {
@@ -12830,23 +12791,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr434:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st361
-	st361:
+		lex.act = 42
+		goto st360
+	st360:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof361
+			goto _test_eof360
 		}
-	st_case_361:
+	st_case_360:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
+		case 114:
 			goto tr435
 		}
 		switch {
@@ -12861,23 +12822,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr435:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st362
-	st362:
+		lex.act = 42
+		goto st361
+	st361:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof362
+			goto _test_eof361
 		}
-	st_case_362:
+	st_case_361:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 105:
+		case 111:
 			goto tr436
 		}
 		switch {
@@ -12892,11 +12853,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr436:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
+		goto st362
+	st362:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof362
+		}
+	st_case_362:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
+			goto tr437
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr437:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
 		goto st363
 	st363:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12908,8 +12900,39 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
+		case 105:
+			goto tr438
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr438:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st364
+	st364:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof364
+		}
+	st_case_364:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
 		case 122:
-			goto tr377
+			goto tr379
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -12923,46 +12946,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr52:
+		goto tr67
+	tr53:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st364
-	st364:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof364
-		}
-	st_case_364:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 104:
-			goto tr437
-		case 114:
-			goto tr438
-		case 121:
-			goto tr439
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr437:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
+		lex.act = 42
 		goto st365
 	st365:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -12974,42 +12962,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
-			goto tr127
-		case 105:
-			goto tr118
+		case 104:
+			goto tr439
 		case 114:
 			goto tr440
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr440:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st366
-	st366:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof366
-		}
-	st_case_366:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 111:
+		case 121:
 			goto tr441
 		}
 		switch {
@@ -13024,23 +12981,27 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr441:
+		goto tr67
+	tr439:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st367
-	st367:
+		lex.act = 42
+		goto st366
+	st366:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof367
+			goto _test_eof366
 		}
-	st_case_367:
+	st_case_366:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 119:
+		case 101:
+			goto tr129
+		case 105:
+			goto tr120
+		case 114:
 			goto tr442
 		}
 		switch {
@@ -13055,32 +13016,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr442:
 		lex.te = (lex.p) + 1
 
-		reservedKeyword = string(lex.data[lex.ts:lex.te])
-		lex.act = 40
-		goto st368
-	st368:
+		lex.act = 42
+		goto st367
+	st367:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof368
+			goto _test_eof367
 		}
-	st_case_368:
+	st_case_367:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st33
-		case 10:
-			goto tr73
-		case 13:
-			goto st33
-		case 32:
-			goto st33
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 115:
+		case 111:
 			goto tr443
 		}
 		switch {
@@ -13095,11 +13047,43 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr71
+		goto tr67
 	tr443:
 		lex.te = (lex.p) + 1
 
-		lex.act = 23
+		lex.act = 42
+		goto st368
+	st368:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof368
+		}
+	st_case_368:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 119:
+			goto tr444
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr444:
+		lex.te = (lex.p) + 1
+
+		reservedKeyword = string(lex.data[lex.ts:lex.te])
+		lex.act = 41
 		goto st369
 	st369:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -13108,13 +13092,52 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_369:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st370
+			goto st34
 		case 10:
-			goto tr446
+			goto tr75
 		case 13:
-			goto st370
+			goto st34
 		case 32:
-			goto st370
+			goto st34
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 115:
+			goto tr445
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr73
+	tr445:
+		lex.te = (lex.p) + 1
+
+		lex.act = 23
+		goto st370
+	st370:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof370
+		}
+	st_case_370:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st371
+		case 10:
+			goto tr448
+		case 13:
+			goto st371
+		case 32:
+			goto st371
 		case 46:
 			goto st18
 		case 95:
@@ -13132,34 +13155,13 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr444
-	tr446:
+		goto tr446
+	tr448:
 
 		lex.line++
 		lex.lineStart = lex.p + 1
 		lex.linesSinceDocstring++
 
-		goto st370
-	st370:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof370
-		}
-	st_case_370:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st370
-		case 10:
-			goto tr446
-		case 13:
-			goto st370
-		case 32:
-			goto st370
-		}
-		goto tr444
-	tr438:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
 		goto st371
 	st371:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -13167,16 +13169,37 @@ func (lex *lexer) Lex(out *yySymType) int {
 		}
 	st_case_371:
 		switch lex.data[(lex.p)] {
+		case 9:
+			goto st371
+		case 10:
+			goto tr448
+		case 13:
+			goto st371
+		case 32:
+			goto st371
+		}
+		goto tr446
+	tr440:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st372
+	st372:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof372
+		}
+	st_case_372:
+		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 97:
-			goto tr447
+			goto tr449
 		case 117:
-			goto tr448
+			goto tr450
 		case 121:
-			goto tr70
+			goto tr72
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -13190,42 +13213,11 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr447:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st372
-	st372:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof372
-		}
-	st_case_372:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 110:
-			goto tr449
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
+		goto tr67
 	tr449:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st373
 	st373:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -13237,38 +13229,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 115:
-			goto tr450
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr450:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st374
-	st374:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof374
-		}
-	st_case_374:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
+		case 110:
 			goto tr451
 		}
 		switch {
@@ -13283,23 +13244,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr451:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st375
-	st375:
+		lex.act = 42
+		goto st374
+	st374:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof375
+			goto _test_eof374
 		}
-	st_case_375:
+	st_case_374:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
+		case 115:
 			goto tr452
 		}
 		switch {
@@ -13314,54 +13275,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr452:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st376
-	st376:
+		lex.act = 42
+		goto st375
+	st375:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof376
+			goto _test_eof375
 		}
-	st_case_376:
+	st_case_375:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
-			goto tr116
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr448:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st377
-	st377:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof377
-		}
-	st_case_377:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
+		case 105:
 			goto tr453
 		}
 		switch {
@@ -13376,30 +13306,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr453:
 		lex.te = (lex.p) + 1
 
-		lex.act = 29
-		goto st378
-	st378:
+		lex.act = 42
+		goto st376
+	st376:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof378
+			goto _test_eof376
 		}
-	st_case_378:
+	st_case_376:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st379
-		case 10:
-			goto tr456
-		case 13:
-			goto st379
-		case 32:
-			goto st379
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 101:
+			goto tr454
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -13413,13 +13337,73 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr454
-	tr456:
+		goto tr67
+	tr454:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
+		lex.act = 42
+		goto st377
+	st377:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof377
+		}
+	st_case_377:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
+			goto tr118
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr450:
+		lex.te = (lex.p) + 1
 
+		lex.act = 42
+		goto st378
+	st378:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof378
+		}
+	st_case_378:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr455
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr455:
+		lex.te = (lex.p) + 1
+
+		lex.act = 29
 		goto st379
 	st379:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -13428,32 +13412,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_379:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st379
+			goto st380
 		case 10:
-			goto tr456
+			goto tr458
 		case 13:
-			goto st379
+			goto st380
 		case 32:
-			goto st379
-		}
-		goto tr454
-	tr439:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st380
-	st380:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof380
-		}
-	st_case_380:
-		switch lex.data[(lex.p)] {
+			goto st380
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 112:
-			goto tr457
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -13467,11 +13436,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr457:
+		goto tr456
+	tr458:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st380
+	st380:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof380
+		}
+	st_case_380:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st380
+		case 10:
+			goto tr458
+		case 13:
+			goto st380
+		case 32:
+			goto st380
+		}
+		goto tr456
+	tr441:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st381
 	st381:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -13483,38 +13475,7 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 101:
-			goto tr458
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr458:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st382
-	st382:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof382
-		}
-	st_case_382:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 100:
+		case 112:
 			goto tr459
 		}
 		switch {
@@ -13529,17 +13490,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr459:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st383
-	st383:
+		lex.act = 42
+		goto st382
+	st382:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof383
+			goto _test_eof382
 		}
-	st_case_383:
+	st_case_382:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
@@ -13560,23 +13521,23 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr460:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st384
-	st384:
+		lex.act = 42
+		goto st383
+	st383:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof384
+			goto _test_eof383
 		}
-	st_case_384:
+	st_case_383:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 102:
+		case 100:
 			goto tr461
 		}
 		switch {
@@ -13591,30 +13552,24 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
 	tr461:
 		lex.te = (lex.p) + 1
 
-		lex.act = 18
-		goto st385
-	st385:
+		lex.act = 42
+		goto st384
+	st384:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof385
+			goto _test_eof384
 		}
-	st_case_385:
+	st_case_384:
 		switch lex.data[(lex.p)] {
-		case 9:
-			goto st386
-		case 10:
-			goto tr464
-		case 13:
-			goto st386
-		case 32:
-			goto st386
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
+		case 101:
+			goto tr462
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -13628,13 +13583,42 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr462
-	tr464:
+		goto tr67
+	tr462:
+		lex.te = (lex.p) + 1
 
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
+		lex.act = 42
+		goto st385
+	st385:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof385
+		}
+	st_case_385:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 102:
+			goto tr463
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr463:
+		lex.te = (lex.p) + 1
 
+		lex.act = 18
 		goto st386
 	st386:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -13643,34 +13627,17 @@ func (lex *lexer) Lex(out *yySymType) int {
 	st_case_386:
 		switch lex.data[(lex.p)] {
 		case 9:
-			goto st386
+			goto st387
 		case 10:
-			goto tr464
+			goto tr466
 		case 13:
-			goto st386
+			goto st387
 		case 32:
-			goto st386
-		}
-		goto tr462
-	tr53:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st387
-	st387:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof387
-		}
-	st_case_387:
-		switch lex.data[(lex.p)] {
+			goto st387
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 110:
-			goto tr465
-		case 115:
-			goto tr151
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -13684,11 +13651,34 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr465:
+		goto tr464
+	tr466:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st387
+	st387:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof387
+		}
+	st_case_387:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st387
+		case 10:
+			goto tr466
+		case 13:
+			goto st387
+		case 32:
+			goto st387
+		}
+		goto tr464
+	tr54:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
+		lex.act = 42
 		goto st388
 	st388:
 		if (lex.p)++; (lex.p) == (lex.pe) {
@@ -13700,734 +13690,9 @@ func (lex *lexer) Lex(out *yySymType) int {
 			goto st18
 		case 95:
 			goto tr27
-		case 100:
-			goto tr466
-		case 105:
+		case 110:
 			goto tr467
-		case 108:
-			goto tr468
 		case 115:
-			goto tr469
-		case 116:
-			goto tr470
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr466:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st389
-	st389:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof389
-		}
-	st_case_389:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr202
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr467:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st390
-	st390:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof390
-		}
-	st_case_390:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 111:
-			goto tr471
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr471:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st391
-	st391:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof391
-		}
-	st_case_391:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 110:
-			goto tr472
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr472:
-		lex.te = (lex.p) + 1
-
-		lex.act = 20
-		goto st392
-	st392:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof392
-		}
-	st_case_392:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st393
-		case 10:
-			goto tr475
-		case 13:
-			goto st393
-		case 32:
-			goto st393
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr473
-	tr475:
-
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
-		goto st393
-	st393:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof393
-		}
-	st_case_393:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st393
-		case 10:
-			goto tr475
-		case 13:
-			goto st393
-		case 32:
-			goto st393
-		}
-		goto tr473
-	tr468:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st394
-	st394:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof394
-		}
-	st_case_394:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr154
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr469:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st395
-	st395:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof395
-		}
-	st_case_395:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr476
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr476:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st396
-	st396:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof396
-		}
-	st_case_396:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 103:
-			goto tr477
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr477:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st397
-	st397:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof397
-		}
-	st_case_397:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 110:
-			goto tr377
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr470:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st398
-	st398:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof398
-		}
-	st_case_398:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr267
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr54:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st399
-	st399:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof399
-		}
-	st_case_399:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr389
-		case 105:
-			goto tr478
-		case 111:
-			goto tr479
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr478:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st400
-	st400:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof400
-		}
-	st_case_400:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 114:
-			goto tr480
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr480:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st401
-	st401:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof401
-		}
-	st_case_401:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 116:
-			goto tr481
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr481:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st402
-	st402:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof402
-		}
-	st_case_402:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 117:
-			goto tr266
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr479:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st403
-	st403:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof403
-		}
-	st_case_403:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 105:
-			goto tr482
-		case 108:
-			goto tr483
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr482:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st404
-	st404:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof404
-		}
-	st_case_404:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 100:
-			goto tr484
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr484:
-		lex.te = (lex.p) + 1
-
-		lex.act = 4
-		goto st405
-	st405:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof405
-		}
-	st_case_405:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st406
-		case 10:
-			goto tr487
-		case 13:
-			goto st406
-		case 32:
-			goto st406
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr485
-	tr487:
-
-		lex.line++
-		lex.lineStart = lex.p + 1
-		lex.linesSinceDocstring++
-
-		goto st406
-	st406:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof406
-		}
-	st_case_406:
-		switch lex.data[(lex.p)] {
-		case 9:
-			goto st406
-		case 10:
-			goto tr487
-		case 13:
-			goto st406
-		case 32:
-			goto st406
-		}
-		goto tr485
-	tr483:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st407
-	st407:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof407
-		}
-	st_case_407:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 97:
-			goto tr488
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr488:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st408
-	st408:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof408
-		}
-	st_case_408:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 116:
-			goto tr218
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr55:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st409
-	st409:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof409
-		}
-	st_case_409:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 104:
-			goto tr489
-		case 105:
-			goto tr490
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr489:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st410
-	st410:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof410
-		}
-	st_case_410:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 101:
-			goto tr127
-		case 105:
-			goto tr219
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr490:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st411
-	st411:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof411
-		}
-	st_case_411:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
-		case 116:
 			goto tr153
 		}
 		switch {
@@ -14442,55 +13707,32 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr56:
+		goto tr67
+	tr467:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st412
-	st412:
+		lex.act = 42
+		goto st389
+	st389:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof412
+			goto _test_eof389
 		}
-	st_case_412:
+	st_case_389:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 111:
-			goto tr389
-		}
-		switch {
-		case lex.data[(lex.p)] < 65:
-			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
-				goto tr27
-			}
-		case lex.data[(lex.p)] > 90:
-			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
-				goto tr27
-			}
-		default:
-			goto tr27
-		}
-		goto tr65
-	tr57:
-		lex.te = (lex.p) + 1
-
-		lex.act = 41
-		goto st413
-	st413:
-		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof413
-		}
-	st_case_413:
-		switch lex.data[(lex.p)] {
-		case 46:
-			goto st18
-		case 95:
-			goto tr27
+		case 100:
+			goto tr468
 		case 105:
-			goto tr491
+			goto tr469
+		case 108:
+			goto tr470
+		case 115:
+			goto tr471
+		case 116:
+			goto tr472
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -14504,23 +13746,647 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr491:
+		goto tr67
+	tr468:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st414
-	st414:
+		lex.act = 42
+		goto st390
+	st390:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof414
+			goto _test_eof390
 		}
-	st_case_414:
+	st_case_390:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
 		case 101:
+			goto tr204
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr469:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st391
+	st391:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof391
+		}
+	st_case_391:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 111:
+			goto tr473
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr473:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st392
+	st392:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof392
+		}
+	st_case_392:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
+			goto tr474
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr474:
+		lex.te = (lex.p) + 1
+
+		lex.act = 20
+		goto st393
+	st393:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof393
+		}
+	st_case_393:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st394
+		case 10:
+			goto tr477
+		case 13:
+			goto st394
+		case 32:
+			goto st394
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr475
+	tr477:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st394
+	st394:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof394
+		}
+	st_case_394:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st394
+		case 10:
+			goto tr477
+		case 13:
+			goto st394
+		case 32:
+			goto st394
+		}
+		goto tr475
+	tr470:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st395
+	st395:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof395
+		}
+	st_case_395:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr156
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr471:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st396
+	st396:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof396
+		}
+	st_case_396:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr478
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr478:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st397
+	st397:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof397
+		}
+	st_case_397:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 103:
+			goto tr479
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr479:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st398
+	st398:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof398
+		}
+	st_case_398:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 110:
+			goto tr379
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr472:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st399
+	st399:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof399
+		}
+	st_case_399:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr269
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr55:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st400
+	st400:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof400
+		}
+	st_case_400:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr391
+		case 105:
+			goto tr480
+		case 111:
+			goto tr481
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr480:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st401
+	st401:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof401
+		}
+	st_case_401:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 114:
+			goto tr482
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr482:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st402
+	st402:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof402
+		}
+	st_case_402:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 116:
+			goto tr483
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr483:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st403
+	st403:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof403
+		}
+	st_case_403:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 117:
+			goto tr268
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr481:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st404
+	st404:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof404
+		}
+	st_case_404:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr484
+		case 108:
+			goto tr485
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr484:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st405
+	st405:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof405
+		}
+	st_case_405:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 100:
+			goto tr486
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr486:
+		lex.te = (lex.p) + 1
+
+		lex.act = 4
+		goto st406
+	st406:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof406
+		}
+	st_case_406:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st407
+		case 10:
+			goto tr489
+		case 13:
+			goto st407
+		case 32:
+			goto st407
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr487
+	tr489:
+
+		lex.line++
+		lex.lineStart = lex.p + 1
+		lex.linesSinceDocstring++
+
+		goto st407
+	st407:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof407
+		}
+	st_case_407:
+		switch lex.data[(lex.p)] {
+		case 9:
+			goto st407
+		case 10:
+			goto tr489
+		case 13:
+			goto st407
+		case 32:
+			goto st407
+		}
+		goto tr487
+	tr485:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st408
+	st408:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof408
+		}
+	st_case_408:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 97:
+			goto tr490
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr490:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st409
+	st409:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof409
+		}
+	st_case_409:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 116:
+			goto tr220
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr56:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st410
+	st410:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof410
+		}
+	st_case_410:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 104:
+			goto tr491
+		case 105:
 			goto tr492
 		}
 		switch {
@@ -14535,24 +14401,26 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
-	tr492:
+		goto tr67
+	tr491:
 		lex.te = (lex.p) + 1
 
-		lex.act = 41
-		goto st415
-	st415:
+		lex.act = 42
+		goto st411
+	st411:
 		if (lex.p)++; (lex.p) == (lex.pe) {
-			goto _test_eof415
+			goto _test_eof411
 		}
-	st_case_415:
+	st_case_411:
 		switch lex.data[(lex.p)] {
 		case 46:
 			goto st18
 		case 95:
 			goto tr27
-		case 108:
-			goto tr109
+		case 101:
+			goto tr129
+		case 105:
+			goto tr221
 		}
 		switch {
 		case lex.data[(lex.p)] < 65:
@@ -14566,7 +14434,162 @@ func (lex *lexer) Lex(out *yySymType) int {
 		default:
 			goto tr27
 		}
-		goto tr65
+		goto tr67
+	tr492:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st412
+	st412:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof412
+		}
+	st_case_412:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 116:
+			goto tr155
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr57:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st413
+	st413:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof413
+		}
+	st_case_413:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 111:
+			goto tr391
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr58:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st414
+	st414:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof414
+		}
+	st_case_414:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 105:
+			goto tr493
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr493:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st415
+	st415:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof415
+		}
+	st_case_415:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 101:
+			goto tr494
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
+	tr494:
+		lex.te = (lex.p) + 1
+
+		lex.act = 42
+		goto st416
+	st416:
+		if (lex.p)++; (lex.p) == (lex.pe) {
+			goto _test_eof416
+		}
+	st_case_416:
+		switch lex.data[(lex.p)] {
+		case 46:
+			goto st18
+		case 95:
+			goto tr27
+		case 108:
+			goto tr111
+		}
+		switch {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
+				goto tr27
+			}
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
+				goto tr27
+			}
+		default:
+			goto tr27
+		}
+		goto tr67
 	st_out:
 	_test_eof19:
 		lex.cs = 19
@@ -14637,20 +14660,20 @@ func (lex *lexer) Lex(out *yySymType) int {
 	_test_eof25:
 		lex.cs = 25
 		goto _test_eof
-	_test_eof17:
-		lex.cs = 17
-		goto _test_eof
 	_test_eof26:
 		lex.cs = 26
+		goto _test_eof
+	_test_eof17:
+		lex.cs = 17
 		goto _test_eof
 	_test_eof27:
 		lex.cs = 27
 		goto _test_eof
-	_test_eof18:
-		lex.cs = 18
-		goto _test_eof
 	_test_eof28:
 		lex.cs = 28
+		goto _test_eof
+	_test_eof18:
+		lex.cs = 18
 		goto _test_eof
 	_test_eof29:
 		lex.cs = 29
@@ -15813,6 +15836,9 @@ func (lex *lexer) Lex(out *yySymType) int {
 	_test_eof415:
 		lex.cs = 415
 		goto _test_eof
+	_test_eof416:
+		lex.cs = 416
+		goto _test_eof
 
 	_test_eof:
 		{
@@ -15820,809 +15846,811 @@ func (lex *lexer) Lex(out *yySymType) int {
 		if (lex.p) == eof {
 			switch lex.cs {
 			case 20:
-				goto tr58
-			case 21:
 				goto tr59
+			case 21:
+				goto tr60
 			case 22:
-				goto tr62
+				goto tr63
 			case 6:
 				goto tr7
 			case 7:
 				goto tr7
 			case 23:
-				goto tr62
-			case 24:
 				goto tr63
+			case 24:
+				goto tr64
 			case 15:
 				goto tr22
 			case 16:
 				goto tr22
 			case 25:
-				goto tr59
+				goto tr65
+			case 26:
+				goto tr60
 			case 17:
 				goto tr25
-			case 26:
-				goto tr59
 			case 27:
-				goto tr65
+				goto tr60
+			case 28:
+				goto tr67
 			case 18:
 				goto tr7
-			case 28:
-				goto tr65
 			case 29:
-				goto tr65
+				goto tr67
 			case 30:
-				goto tr65
+				goto tr67
 			case 31:
-				goto tr65
+				goto tr67
 			case 32:
-				goto tr71
+				goto tr67
 			case 33:
-				goto tr71
+				goto tr73
 			case 34:
-				goto tr65
+				goto tr73
 			case 35:
-				goto tr65
+				goto tr67
 			case 36:
-				goto tr65
+				goto tr67
 			case 37:
-				goto tr65
+				goto tr67
 			case 38:
-				goto tr65
+				goto tr67
 			case 39:
-				goto tr65
+				goto tr67
 			case 40:
-				goto tr65
+				goto tr67
 			case 41:
-				goto tr65
+				goto tr67
 			case 42:
-				goto tr65
+				goto tr67
 			case 43:
-				goto tr65
+				goto tr67
 			case 44:
-				goto tr65
+				goto tr67
 			case 45:
-				goto tr65
+				goto tr67
 			case 46:
-				goto tr65
+				goto tr67
 			case 47:
-				goto tr65
+				goto tr67
 			case 48:
-				goto tr65
+				goto tr67
 			case 49:
-				goto tr65
+				goto tr67
 			case 50:
-				goto tr65
+				goto tr67
 			case 51:
-				goto tr65
+				goto tr67
 			case 52:
-				goto tr65
+				goto tr67
 			case 53:
-				goto tr65
+				goto tr67
 			case 54:
-				goto tr65
+				goto tr67
 			case 55:
-				goto tr65
+				goto tr67
 			case 56:
-				goto tr65
+				goto tr67
 			case 57:
-				goto tr65
+				goto tr67
 			case 58:
-				goto tr65
+				goto tr67
 			case 59:
-				goto tr65
+				goto tr67
 			case 60:
-				goto tr65
+				goto tr67
 			case 61:
-				goto tr65
+				goto tr67
 			case 62:
-				goto tr65
+				goto tr67
 			case 63:
-				goto tr65
+				goto tr67
 			case 64:
-				goto tr65
+				goto tr67
 			case 65:
-				goto tr65
+				goto tr67
 			case 66:
-				goto tr65
+				goto tr67
 			case 67:
-				goto tr65
+				goto tr67
 			case 68:
-				goto tr65
+				goto tr67
 			case 69:
-				goto tr65
+				goto tr67
 			case 70:
-				goto tr65
+				goto tr67
 			case 71:
-				goto tr65
+				goto tr67
 			case 72:
-				goto tr65
+				goto tr67
 			case 73:
-				goto tr65
+				goto tr67
 			case 74:
-				goto tr65
+				goto tr67
 			case 75:
-				goto tr65
+				goto tr67
 			case 76:
-				goto tr65
+				goto tr67
 			case 77:
-				goto tr65
+				goto tr67
 			case 78:
-				goto tr65
+				goto tr67
 			case 79:
-				goto tr65
+				goto tr67
 			case 80:
-				goto tr65
+				goto tr67
 			case 81:
-				goto tr71
+				goto tr67
 			case 82:
-				goto tr65
+				goto tr73
 			case 83:
-				goto tr65
+				goto tr67
 			case 84:
-				goto tr65
+				goto tr67
 			case 85:
-				goto tr65
+				goto tr67
 			case 86:
-				goto tr65
+				goto tr67
 			case 87:
-				goto tr65
+				goto tr67
 			case 88:
-				goto tr65
+				goto tr67
 			case 89:
-				goto tr65
+				goto tr67
 			case 90:
-				goto tr65
+				goto tr67
 			case 91:
-				goto tr65
+				goto tr67
 			case 92:
-				goto tr132
+				goto tr67
 			case 93:
-				goto tr132
+				goto tr134
 			case 94:
-				goto tr65
+				goto tr134
 			case 95:
-				goto tr65
+				goto tr67
 			case 96:
-				goto tr137
+				goto tr67
 			case 97:
-				goto tr137
+				goto tr139
 			case 98:
-				goto tr65
+				goto tr139
 			case 99:
-				goto tr65
+				goto tr67
 			case 100:
-				goto tr65
+				goto tr67
 			case 101:
-				goto tr65
+				goto tr67
 			case 102:
-				goto tr65
+				goto tr67
 			case 103:
-				goto tr144
+				goto tr67
 			case 104:
-				goto tr144
+				goto tr146
 			case 105:
-				goto tr65
+				goto tr146
 			case 106:
-				goto tr65
+				goto tr67
 			case 107:
-				goto tr65
+				goto tr67
 			case 108:
-				goto tr65
+				goto tr67
 			case 109:
-				goto tr65
+				goto tr67
 			case 110:
-				goto tr65
+				goto tr67
 			case 111:
-				goto tr65
+				goto tr67
 			case 112:
-				goto tr65
+				goto tr67
 			case 113:
-				goto tr65
+				goto tr67
 			case 114:
-				goto tr65
+				goto tr67
 			case 115:
-				goto tr65
+				goto tr67
 			case 116:
-				goto tr160
+				goto tr67
 			case 117:
-				goto tr160
+				goto tr162
 			case 118:
-				goto tr65
+				goto tr162
 			case 119:
-				goto tr65
+				goto tr67
 			case 120:
-				goto tr65
+				goto tr67
 			case 121:
-				goto tr65
+				goto tr67
 			case 122:
-				goto tr65
+				goto tr67
 			case 123:
-				goto tr65
+				goto tr67
 			case 124:
-				goto tr65
+				goto tr67
 			case 125:
-				goto tr65
+				goto tr67
 			case 126:
-				goto tr65
+				goto tr67
 			case 127:
-				goto tr65
+				goto tr67
 			case 128:
-				goto tr65
+				goto tr67
 			case 129:
-				goto tr65
+				goto tr67
 			case 130:
-				goto tr174
+				goto tr67
 			case 131:
-				goto tr174
+				goto tr176
 			case 132:
-				goto tr65
+				goto tr176
 			case 133:
-				goto tr65
+				goto tr67
 			case 134:
-				goto tr65
+				goto tr67
 			case 135:
-				goto tr65
+				goto tr67
 			case 136:
-				goto tr65
+				goto tr67
 			case 137:
-				goto tr71
+				goto tr67
 			case 138:
-				goto tr65
+				goto tr73
 			case 139:
-				goto tr65
+				goto tr67
 			case 140:
-				goto tr71
+				goto tr67
 			case 141:
-				goto tr65
+				goto tr73
 			case 142:
-				goto tr71
+				goto tr67
 			case 143:
-				goto tr65
+				goto tr73
 			case 144:
-				goto tr65
+				goto tr67
 			case 145:
-				goto tr65
+				goto tr67
 			case 146:
-				goto tr192
+				goto tr67
 			case 147:
-				goto tr192
+				goto tr194
 			case 148:
-				goto tr65
+				goto tr194
 			case 149:
-				goto tr65
+				goto tr67
 			case 150:
-				goto tr65
+				goto tr67
 			case 151:
-				goto tr65
+				goto tr67
 			case 152:
-				goto tr65
+				goto tr67
 			case 153:
-				goto tr65
+				goto tr67
 			case 154:
-				goto tr65
+				goto tr67
 			case 155:
-				goto tr65
+				goto tr67
 			case 156:
-				goto tr65
+				goto tr67
 			case 157:
-				goto tr71
+				goto tr67
 			case 158:
-				goto tr65
+				goto tr73
 			case 159:
-				goto tr71
+				goto tr67
 			case 160:
-				goto tr65
+				goto tr73
 			case 161:
-				goto tr65
+				goto tr67
 			case 162:
-				goto tr65
+				goto tr67
 			case 163:
-				goto tr65
+				goto tr67
 			case 164:
-				goto tr71
+				goto tr67
 			case 165:
-				goto tr65
+				goto tr73
 			case 166:
-				goto tr65
+				goto tr67
 			case 167:
-				goto tr65
+				goto tr67
 			case 168:
-				goto tr65
+				goto tr67
 			case 169:
-				goto tr65
+				goto tr67
 			case 170:
-				goto tr65
+				goto tr67
 			case 171:
-				goto tr65
+				goto tr67
 			case 172:
-				goto tr65
+				goto tr67
 			case 173:
-				goto tr65
+				goto tr67
 			case 174:
-				goto tr221
+				goto tr67
 			case 175:
-				goto tr221
+				goto tr223
 			case 176:
-				goto tr65
+				goto tr223
 			case 177:
-				goto tr65
+				goto tr67
 			case 178:
-				goto tr65
+				goto tr67
 			case 179:
-				goto tr65
+				goto tr67
 			case 180:
-				goto tr71
+				goto tr67
 			case 181:
-				goto tr65
+				goto tr73
 			case 182:
-				goto tr65
+				goto tr67
 			case 183:
-				goto tr232
+				goto tr67
 			case 184:
-				goto tr232
+				goto tr234
 			case 185:
-				goto tr65
+				goto tr234
 			case 186:
-				goto tr65
+				goto tr67
 			case 187:
-				goto tr65
+				goto tr67
 			case 188:
-				goto tr65
+				goto tr67
 			case 189:
-				goto tr239
+				goto tr67
 			case 190:
-				goto tr239
+				goto tr241
 			case 191:
-				goto tr65
+				goto tr241
 			case 192:
-				goto tr65
+				goto tr67
 			case 193:
-				goto tr65
+				goto tr67
 			case 194:
-				goto tr65
+				goto tr67
 			case 195:
-				goto tr250
+				goto tr67
 			case 196:
-				goto tr250
+				goto tr252
 			case 197:
-				goto tr65
+				goto tr252
 			case 198:
-				goto tr65
+				goto tr67
 			case 199:
-				goto tr65
+				goto tr67
 			case 200:
-				goto tr65
+				goto tr67
 			case 201:
-				goto tr65
+				goto tr67
 			case 202:
-				goto tr65
+				goto tr67
 			case 203:
-				goto tr65
+				goto tr67
 			case 204:
-				goto tr65
+				goto tr67
 			case 205:
-				goto tr65
+				goto tr67
 			case 206:
-				goto tr65
+				goto tr67
 			case 207:
-				goto tr65
+				goto tr67
 			case 208:
-				goto tr65
+				goto tr67
 			case 209:
-				goto tr65
+				goto tr67
 			case 210:
-				goto tr65
+				goto tr67
 			case 211:
-				goto tr65
+				goto tr67
 			case 212:
-				goto tr65
+				goto tr67
 			case 213:
-				goto tr65
+				goto tr67
 			case 214:
-				goto tr65
+				goto tr67
 			case 215:
-				goto tr65
+				goto tr67
 			case 216:
-				goto tr65
+				goto tr67
 			case 217:
-				goto tr65
+				goto tr67
 			case 218:
-				goto tr65
+				goto tr67
 			case 219:
-				goto tr65
+				goto tr67
 			case 220:
-				goto tr276
+				goto tr67
 			case 221:
-				goto tr276
+				goto tr278
 			case 222:
-				goto tr65
+				goto tr278
 			case 223:
-				goto tr280
+				goto tr67
 			case 224:
-				goto tr280
+				goto tr282
 			case 225:
-				goto tr65
+				goto tr282
 			case 226:
-				goto tr284
+				goto tr67
 			case 227:
-				goto tr284
+				goto tr286
 			case 228:
-				goto tr287
+				goto tr286
 			case 229:
-				goto tr287
+				goto tr289
 			case 230:
-				goto tr65
+				goto tr289
 			case 231:
-				goto tr65
+				goto tr67
 			case 232:
-				goto tr65
+				goto tr67
 			case 233:
-				goto tr65
+				goto tr67
 			case 234:
-				goto tr65
+				goto tr67
 			case 235:
-				goto tr65
+				goto tr67
 			case 236:
-				goto tr65
+				goto tr67
 			case 237:
-				goto tr71
+				goto tr67
 			case 238:
-				goto tr65
+				goto tr73
 			case 239:
-				goto tr65
+				goto tr67
 			case 240:
-				goto tr65
+				goto tr67
 			case 241:
-				goto tr65
+				goto tr67
 			case 242:
-				goto tr304
+				goto tr67
 			case 243:
-				goto tr304
+				goto tr306
 			case 244:
-				goto tr65
+				goto tr306
 			case 245:
-				goto tr65
+				goto tr67
 			case 246:
-				goto tr65
+				goto tr67
 			case 247:
-				goto tr65
+				goto tr67
 			case 248:
-				goto tr65
+				goto tr67
 			case 249:
-				goto tr65
+				goto tr67
 			case 250:
-				goto tr65
+				goto tr67
 			case 251:
-				goto tr65
+				goto tr67
 			case 252:
-				goto tr65
+				goto tr67
 			case 253:
-				goto tr65
+				goto tr67
 			case 254:
-				goto tr65
+				goto tr67
 			case 255:
-				goto tr65
+				goto tr67
 			case 256:
-				goto tr65
+				goto tr67
 			case 257:
-				goto tr65
+				goto tr67
 			case 258:
-				goto tr65
+				goto tr67
 			case 259:
-				goto tr65
+				goto tr67
 			case 260:
-				goto tr65
+				goto tr67
 			case 261:
-				goto tr65
+				goto tr67
 			case 262:
-				goto tr65
+				goto tr67
 			case 263:
-				goto tr323
+				goto tr67
 			case 264:
-				goto tr323
+				goto tr325
 			case 265:
-				goto tr65
+				goto tr325
 			case 266:
-				goto tr65
+				goto tr67
 			case 267:
-				goto tr329
+				goto tr67
 			case 268:
-				goto tr329
+				goto tr331
 			case 269:
-				goto tr65
+				goto tr331
 			case 270:
-				goto tr65
+				goto tr67
 			case 271:
-				goto tr65
+				goto tr67
 			case 272:
-				goto tr65
+				goto tr67
 			case 273:
-				goto tr65
+				goto tr67
 			case 274:
-				goto tr65
+				goto tr67
 			case 275:
-				goto tr65
+				goto tr67
 			case 276:
-				goto tr65
+				goto tr67
 			case 277:
-				goto tr65
+				goto tr67
 			case 278:
-				goto tr65
+				goto tr67
 			case 279:
-				goto tr343
+				goto tr67
 			case 280:
-				goto tr343
+				goto tr345
 			case 281:
-				goto tr65
+				goto tr345
 			case 282:
-				goto tr65
+				goto tr67
 			case 283:
-				goto tr65
+				goto tr67
 			case 284:
-				goto tr65
+				goto tr67
 			case 285:
-				goto tr65
+				goto tr67
 			case 286:
-				goto tr65
+				goto tr67
 			case 287:
-				goto tr65
+				goto tr67
 			case 288:
-				goto tr65
+				goto tr67
 			case 289:
-				goto tr353
+				goto tr67
 			case 290:
-				goto tr353
+				goto tr355
 			case 291:
-				goto tr65
+				goto tr355
 			case 292:
-				goto tr65
+				goto tr67
 			case 293:
-				goto tr65
+				goto tr67
 			case 294:
-				goto tr65
+				goto tr67
 			case 295:
-				goto tr65
+				goto tr67
 			case 296:
-				goto tr65
+				goto tr67
 			case 297:
-				goto tr362
+				goto tr67
 			case 298:
-				goto tr362
+				goto tr364
 			case 299:
-				goto tr65
+				goto tr364
 			case 300:
-				goto tr65
+				goto tr67
 			case 301:
-				goto tr65
+				goto tr67
 			case 302:
-				goto tr65
+				goto tr67
 			case 303:
-				goto tr65
+				goto tr67
 			case 304:
-				goto tr65
+				goto tr67
 			case 305:
-				goto tr65
+				goto tr67
 			case 306:
-				goto tr65
+				goto tr67
 			case 307:
-				goto tr65
+				goto tr67
 			case 308:
-				goto tr65
+				goto tr67
 			case 309:
-				goto tr65
+				goto tr67
 			case 310:
-				goto tr65
+				goto tr67
 			case 311:
-				goto tr65
+				goto tr67
 			case 312:
-				goto tr65
+				goto tr67
 			case 313:
-				goto tr65
+				goto tr67
 			case 314:
-				goto tr65
+				goto tr67
 			case 315:
-				goto tr65
+				goto tr67
 			case 316:
-				goto tr65
+				goto tr67
 			case 317:
-				goto tr65
+				goto tr67
 			case 318:
-				goto tr65
+				goto tr67
 			case 319:
-				goto tr65
+				goto tr67
 			case 320:
-				goto tr65
+				goto tr67
 			case 321:
-				goto tr65
+				goto tr67
 			case 322:
-				goto tr65
+				goto tr67
 			case 323:
-				goto tr65
+				goto tr67
 			case 324:
-				goto tr65
+				goto tr67
 			case 325:
-				goto tr65
+				goto tr67
 			case 326:
-				goto tr65
+				goto tr67
 			case 327:
-				goto tr65
+				goto tr67
 			case 328:
-				goto tr395
+				goto tr67
 			case 329:
-				goto tr395
+				goto tr397
 			case 330:
-				goto tr65
+				goto tr397
 			case 331:
-				goto tr65
+				goto tr67
 			case 332:
-				goto tr65
+				goto tr67
 			case 333:
-				goto tr65
+				goto tr67
 			case 334:
-				goto tr65
+				goto tr67
 			case 335:
-				goto tr65
+				goto tr67
 			case 336:
-				goto tr65
+				goto tr67
 			case 337:
-				goto tr65
+				goto tr67
 			case 338:
-				goto tr65
+				goto tr67
 			case 339:
-				goto tr410
+				goto tr67
 			case 340:
-				goto tr410
+				goto tr412
 			case 341:
-				goto tr413
+				goto tr412
 			case 342:
-				goto tr413
+				goto tr415
 			case 343:
-				goto tr65
+				goto tr415
 			case 344:
-				goto tr65
+				goto tr67
 			case 345:
-				goto tr65
+				goto tr67
 			case 346:
-				goto tr65
+				goto tr67
 			case 347:
-				goto tr65
+				goto tr67
 			case 348:
-				goto tr65
+				goto tr67
 			case 349:
-				goto tr422
+				goto tr67
 			case 350:
-				goto tr422
+				goto tr424
 			case 351:
-				goto tr65
+				goto tr424
 			case 352:
-				goto tr65
+				goto tr67
 			case 353:
-				goto tr427
+				goto tr67
 			case 354:
-				goto tr427
+				goto tr429
 			case 355:
-				goto tr65
+				goto tr429
 			case 356:
-				goto tr65
+				goto tr67
 			case 357:
-				goto tr65
+				goto tr67
 			case 358:
-				goto tr65
+				goto tr67
 			case 359:
-				goto tr65
+				goto tr67
 			case 360:
-				goto tr65
+				goto tr67
 			case 361:
-				goto tr65
+				goto tr67
 			case 362:
-				goto tr65
+				goto tr67
 			case 363:
-				goto tr65
+				goto tr67
 			case 364:
-				goto tr65
+				goto tr67
 			case 365:
-				goto tr65
+				goto tr67
 			case 366:
-				goto tr65
+				goto tr67
 			case 367:
-				goto tr65
+				goto tr67
 			case 368:
-				goto tr71
+				goto tr67
 			case 369:
-				goto tr444
+				goto tr73
 			case 370:
-				goto tr444
+				goto tr446
 			case 371:
-				goto tr65
+				goto tr446
 			case 372:
-				goto tr65
+				goto tr67
 			case 373:
-				goto tr65
+				goto tr67
 			case 374:
-				goto tr65
+				goto tr67
 			case 375:
-				goto tr65
+				goto tr67
 			case 376:
-				goto tr65
+				goto tr67
 			case 377:
-				goto tr65
+				goto tr67
 			case 378:
-				goto tr454
+				goto tr67
 			case 379:
-				goto tr454
+				goto tr456
 			case 380:
-				goto tr65
+				goto tr456
 			case 381:
-				goto tr65
+				goto tr67
 			case 382:
-				goto tr65
+				goto tr67
 			case 383:
-				goto tr65
+				goto tr67
 			case 384:
-				goto tr65
+				goto tr67
 			case 385:
-				goto tr462
+				goto tr67
 			case 386:
-				goto tr462
+				goto tr464
 			case 387:
-				goto tr65
+				goto tr464
 			case 388:
-				goto tr65
+				goto tr67
 			case 389:
-				goto tr65
+				goto tr67
 			case 390:
-				goto tr65
+				goto tr67
 			case 391:
-				goto tr65
+				goto tr67
 			case 392:
-				goto tr473
+				goto tr67
 			case 393:
-				goto tr473
+				goto tr475
 			case 394:
-				goto tr65
+				goto tr475
 			case 395:
-				goto tr65
+				goto tr67
 			case 396:
-				goto tr65
+				goto tr67
 			case 397:
-				goto tr65
+				goto tr67
 			case 398:
-				goto tr65
+				goto tr67
 			case 399:
-				goto tr65
+				goto tr67
 			case 400:
-				goto tr65
+				goto tr67
 			case 401:
-				goto tr65
+				goto tr67
 			case 402:
-				goto tr65
+				goto tr67
 			case 403:
-				goto tr65
+				goto tr67
 			case 404:
-				goto tr65
+				goto tr67
 			case 405:
-				goto tr485
+				goto tr67
 			case 406:
-				goto tr485
+				goto tr487
 			case 407:
-				goto tr65
+				goto tr487
 			case 408:
-				goto tr65
+				goto tr67
 			case 409:
-				goto tr65
+				goto tr67
 			case 410:
-				goto tr65
+				goto tr67
 			case 411:
-				goto tr65
+				goto tr67
 			case 412:
-				goto tr65
+				goto tr67
 			case 413:
-				goto tr65
+				goto tr67
 			case 414:
-				goto tr65
+				goto tr67
 			case 415:
-				goto tr65
+				goto tr67
+			case 416:
+				goto tr67
 			}
 		}
 
@@ -16653,6 +16681,10 @@ func (lex *lexer) Pos() ast.Position {
 
 func (lex *lexer) RecordPosition(n ast.Node, pos ast.Position) {
 	lex.nodePositions[n] = pos
+}
+
+func (lex *lexer) Comment(s string) {
+	lex.comments[lex.line] = strings.TrimSpace(s)
 }
 
 func (lex *lexer) LastDocstring() string {

--- a/idl/internal/parser.go
+++ b/idl/internal/parser.go
@@ -29,10 +29,14 @@ func init() {
 // NodePositions maps (hashable) nodes to their document positions.
 type NodePositions map[ast.Node]ast.Position
 
+// Comments maps line numbers to comment strings.
+type Comments map[int]string
+
 // ParseResult holds the result of a successful Parse.
 type ParseResult struct {
 	Program       *ast.Program
 	NodePositions NodePositions
+	Comments      Comments
 }
 
 // Parse parses the given Thrift document.
@@ -43,6 +47,7 @@ func Parse(s []byte) (ParseResult, []ParseError) {
 		return ParseResult{
 			Program:       lex.program,
 			NodePositions: lex.nodePositions,
+			Comments:      lex.comments,
 		}, nil
 	}
 	return ParseResult{}, lex.errors


### PR DESCRIPTION
Line-wise comment strings are available through the `Comment()` function
on the `idl.Config` struct.

---

### Open questions

1. Should we strip the comment prefix (`#` and `//`) or store the entire comment string unaltered?
2. Is a line-wise accessor the right interface?
3. How should we handle multiline comments (`/* ... */`)?
  a. If we strip prefixes in (1), then should be attempt to strip any leading `*` characters on intermediate lines?
  b. Should a line-wise accessor return the full multiline comment string for all lines in its range?

---

I also played with a fancier, AST-like system based on a rich struct:

```go
type CommentStyle int

const (
	UnixStyle      CommentStyle = iota + 1
    CPPStyle
    MultiLineStyle
)

type Comment struct {
    Style CommentStyle
    Text  string
    Start ast.Position
    End   ast.Position
}
```

... but I started to feel like that was overdoing it.