### PR TITLE
Add support for changed types in thriftbreak

### DIFF
--- a/internal/compare/compare.go
+++ b/internal/compare/compare.go
@@ -99,6 +99,21 @@ func (p *Pass) requiredField(fromField, toField *compile.FieldSpec, to *compile.
 	}
 }
 
+func (p *Pass) changedTypes(fromField, toField *compile.FieldSpec, to *compile.StructSpec, file string) {
+	if fromField.Type == nil || toField.Type == nil {
+		return
+	}
+
+	if fromField.Type.ThriftName() != toField.Type.ThriftName() {
+		p.Report(Diagnostic{
+			FilePath: file,
+			Message: fmt.Sprintf(
+				"changing type field %q in %q to %q",
+				toField.Type.ThriftName(), to.ThriftName(), fromField.Type.ThriftName()),
+		})
+	}
+}
+
 // StructSpecs compares two structs defined in a Thrift file.
 func (p *Pass) structSpecs(from, to *compile.StructSpec, file string) {
 	fields := make(map[int16]*compile.FieldSpec, len(from.Fields))
@@ -109,6 +124,7 @@ func (p *Pass) structSpecs(from, to *compile.StructSpec, file string) {
 	for _, toField := range to.Fields {
 		if fromField, ok := fields[toField.ID]; ok {
 			p.requiredField(fromField, toField, to, file)
+			p.changedTypes(fromField, toField, to, file)
 		} else if toField.Required {
 			p.Report(Diagnostic{
 				FilePath: file,

--- a/internal/compare/compare.go
+++ b/internal/compare/compare.go
@@ -108,8 +108,9 @@ func (p *Pass) changedTypes(fromField, toField *compile.FieldSpec, to *compile.S
 		p.Report(Diagnostic{
 			FilePath: file,
 			Message: fmt.Sprintf(
-				"changing type field %q in %q to %q",
-				toField.Type.ThriftName(), to.ThriftName(), fromField.Type.ThriftName()),
+				"changing type of field %q in struct %q from %q to %q",
+				toField.ThriftName(), to.ThriftName(), fromField.Type.ThriftName(),
+				toField.Type.ThriftName()),
 		})
 	}
 }

--- a/internal/compare/compare_test.go
+++ b/internal/compare/compare_test.go
@@ -124,7 +124,7 @@ func TestErrorRequiredCase(t *testing.T) {
 					},
 				},
 			},
-			wantError: `foo.thrift:changing type field "bool" in "structA" to "binary"`,
+			wantError: `foo.thrift:changing type of field "fieldA" in struct "structA" from "binary" to "bool"`,
 		},
 	}
 

--- a/internal/compare/compare_test.go
+++ b/internal/compare/compare_test.go
@@ -101,6 +101,31 @@ func TestErrorRequiredCase(t *testing.T) {
 			wantError: `foo.thrift:changing an optional field "fieldA" in "structA" to required` +
 				"\n" + `foo.thrift:changing an optional field "fieldB" in "structA" to required`,
 		},
+		{
+			desc: "found a type changed",
+			fromStruct: &compile.StructSpec{
+				Fields: compile.FieldGroup{
+					&compile.FieldSpec{
+						Name: "fieldA",
+						Type: &compile.BinarySpec{},
+					},
+				},
+			},
+			toStruct: &compile.StructSpec{
+				Name: "structA",
+				Fields: compile.FieldGroup{
+					&compile.FieldSpec{
+						Name: "fieldA",
+						Type: &compile.BoolSpec{},
+					},
+					&compile.FieldSpec{
+						Name: "fieldB",
+						Type: &compile.BinarySpec{},
+					},
+				},
+			},
+			wantError: `foo.thrift:changing type field "bool" in "structA" to "binary"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/compare/compare_test.go
+++ b/internal/compare/compare_test.go
@@ -104,6 +104,7 @@ func TestErrorRequiredCase(t *testing.T) {
 		{
 			desc: "found a type changed",
 			fromStruct: &compile.StructSpec{
+				Name: "structA",
 				Fields: compile.FieldGroup{
 					&compile.FieldSpec{
 						Name: "fieldA",


### PR DESCRIPTION
Changing field types is a breaking change, this could be prevented by raising an error in thriftbreak.

Example:
```
// some.thrift
struct MyStruct {
    1: optional bool status
}

changed to

// some.thrift
struct MyStruct {
    1: optional string status
}
```
is a breaking change because status went from being a bool to a string.
