### PR TITLE
Add new TemplateOption AddTemplate

### DIFF
--- a/plugin/template.go
+++ b/plugin/template.go
@@ -228,7 +228,7 @@ func (g *goFileGenerator) Generate(filename, tmpl string, data interface{}) ([]b
 	for idx, additionalT := range g.additionalTmpls {
 		t, err = t.New("template_" + strconv.Itoa(idx)).Parse(additionalT)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse addiontal template %d for file %q: %v", idx, filename, err)
+			return nil, fmt.Errorf("failed to parse additional template %d for file %q: %w", idx, filename, err)
 		}
 	}
 

--- a/plugin/template.go
+++ b/plugin/template.go
@@ -80,7 +80,7 @@ func GoFileImportPath(path string) TemplateOption {
 //	GoFileFromTemplate(
 //		filename,
 //		mytemplate,
-//		AddTemplate("<define "block">Reusable block<.><end>"),
+//		AddTemplate("example", "<define "example">Reusable block<.><end>"),
 //	)
 //
 // If specified, you can reference any defined block in the additional template

--- a/plugin/template_test.go
+++ b/plugin/template_test.go
@@ -269,7 +269,7 @@ func TestGoFileFromTemplate(t *testing.T) {
 				<template "test">
 			`,
 			options: []TemplateOption{
-				AddTemplate(unlines(
+				AddTemplate("test", unlines(
 					`<define "test">`,
 					`func myFun() string {`,
 					`	return "hello world"`,
@@ -283,6 +283,23 @@ func TestGoFileFromTemplate(t *testing.T) {
 				`	return "hello world"`,
 				`}`,
 			),
+		},
+		{
+			desc: "use define error",
+			template: `
+				package hello
+
+				<template "test">
+			`,
+			options: []TemplateOption{
+				AddTemplate("test", unlines(
+					`<define "test">`,
+					`<range>`,
+					`	return "hello world"`,
+					`}`,
+					`<end>`)),
+			},
+			wantError: `failed to parse additional template test for file test.go: template: test:2: missing value for range`,
 		},
 	}
 

--- a/plugin/template_test.go
+++ b/plugin/template_test.go
@@ -261,6 +261,29 @@ func TestGoFileFromTemplate(t *testing.T) {
 				`var x foo_bar.Foo1 = foo_bar2.Foo2`,
 			),
 		},
+		{
+			desc: "use define block",
+			template: `
+				package hello
+
+				<template "test">
+			`,
+			options: []TemplateOption{
+				AddTemplate(unlines(
+					`<define "test">`,
+					`func myFun() string {`,
+					`	return "hello world"`,
+					`}`,
+					`<end>`)),
+			},
+			wantBody: unlines(
+				`package hello`,
+				``,
+				`func myFun() string {`,
+				`	return "hello world"`,
+				`}`,
+			),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This enables consumers to split their template across multiple files and reference define blocks from other files.