### PR TITLE
ci: Test only against go1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19.x", "1.20.x"]
+        go: ["1.20.x"]
         include:
         - go: 1.20.x
           latest: true


### PR DESCRIPTION
If a change to ThriftRW utilizes an API only available in the latest version of Go, the CI validation for the previous version will fail. We should stick to using only the latest Go version for CI validation.