### PR TITLE
Remove all usages of io/ioutil

### DIFF
--- a/cmd/thriftrw-list-deps/main_test.go
+++ b/cmd/thriftrw-list-deps/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestThriftrwListDeps(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmpDir)
@@ -29,7 +28,7 @@ include "./c.thrift"`,
 		path := filepath.Join(tmpDir, name)
 		err = os.MkdirAll(filepath.Dir(path), 0755)
 		require.NoError(t, err)
-		err = ioutil.WriteFile(path, []byte(content), 0644)
+		err = os.WriteFile(path, []byte(content), 0644)
 		require.NoError(t, err)
 	}
 

--- a/compile/options.go
+++ b/compile/options.go
@@ -21,7 +21,7 @@
 package compile
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -31,7 +31,7 @@ type Option func(*compiler)
 // FS is used by the compiler to interact with the filesystem.
 type FS interface {
 	// Read reads the file named by filename and returns the contents.
-	// See: https://golang.org/pkg/io/ioutil/#ReadFile
+	// See: https://golang.org/pkg/os/#ReadFile
 	Read(filename string) ([]byte, error)
 	// Abs returns an absolute representation of path.
 	// See: https://golang.org/pkg/path/filepath/#Abs
@@ -41,7 +41,7 @@ type FS interface {
 type realFS struct{}
 
 func (realFS) Read(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func (realFS) Abs(p string) (string, error) {

--- a/gen/embedidl_test.go
+++ b/gen/embedidl_test.go
@@ -23,7 +23,7 @@ package gen
 import (
 	"crypto/sha1"
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -39,7 +39,7 @@ func loadIDL(filename string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	rawIDL, err := ioutil.ReadAll(f)
+	rawIDL, err := io.ReadAll(f)
 	if err != nil {
 		return "", "", err
 	}

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -23,7 +23,6 @@ package gen
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -172,7 +171,7 @@ func Generate(m *compile.Module, o *Options) error {
 			return fmt.Errorf("could not create directory %q: %v", directory, err)
 		}
 
-		if err := ioutil.WriteFile(fullPath, contents, 0644); err != nil {
+		if err := os.WriteFile(fullPath, contents, 0644); err != nil {
 			return fmt.Errorf("failed to write %q: %v", fullPath, err)
 		}
 	}

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -51,7 +50,7 @@ func testdata(t *testing.T, paths ...string) string {
 }
 
 func TestGenerateWithRelativePaths(t *testing.T) {
-	outputDir, err := ioutil.TempDir("", "thriftrw-generate-test")
+	outputDir, err := os.MkdirTemp("", "thriftrw-generate-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(outputDir)
 
@@ -83,7 +82,7 @@ func TestGenerateWithRelativePaths(t *testing.T) {
 }
 
 func TestGenerateWithHyphenPaths(t *testing.T) {
-	outputDir, err := ioutil.TempDir("", "thriftrw-generate-test")
+	outputDir, err := os.MkdirTemp("", "thriftrw-generate-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(outputDir)
 
@@ -311,7 +310,7 @@ func TestGenerate(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
-			outputDir, err := ioutil.TempDir(os.TempDir(), "test-generate-recurse")
+			outputDir, err := os.MkdirTemp(os.TempDir(), "test-generate-recurse")
 			require.NoError(t, err)
 			defer os.RemoveAll(outputDir)
 

--- a/gen/golden_test.go
+++ b/gen/golden_test.go
@@ -22,7 +22,6 @@ package gen
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -57,7 +56,7 @@ func TestCodeIsUpToDate(t *testing.T) {
 	thriftFiles, err := filepath.Glob(thriftRoot + "/*.thrift")
 	require.NoError(t, err)
 
-	outputDir, err := ioutil.TempDir("", "thriftrw-golden-test")
+	outputDir, err := os.MkdirTemp("", "thriftrw-golden-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(outputDir)
 

--- a/gen/service_test.go
+++ b/gen/service_test.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -714,7 +714,7 @@ func TestArgsAndResultValidation(t *testing.T) {
 				})
 
 				t.Run("StreamEncode", func(t *testing.T) {
-					sw := binary.Default.Writer(ioutil.Discard)
+					sw := binary.Default.Writer(io.Discard)
 					defer sw.Close()
 
 					err := tt.serialize.Encode(sw)

--- a/gen/struct_test.go
+++ b/gen/struct_test.go
@@ -23,7 +23,7 @@ package gen
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 
@@ -1817,7 +1817,7 @@ func TestStructValidation(t *testing.T) {
 				})
 
 				t.Run("StreamEncode", func(t *testing.T) {
-					sw := binary.Default.Writer(ioutil.Discard)
+					sw := binary.Default.Writer(io.Discard)
 					defer sw.Close()
 
 					err := tt.serialize.Encode(sw)

--- a/internal/breaktest/repo.go
+++ b/internal/breaktest/repo.go
@@ -21,7 +21,6 @@
 package breaktest
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,7 +76,7 @@ func (w *writeThrift) writeThrifts(extraMsg string) error {
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(path, []byte(content), 0600); err != nil {
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 			return err
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,11 +32,11 @@ import (
 )
 
 func TestDeterminePackagePrefix(t *testing.T) {
-	gopath, err := ioutil.TempDir("", "thriftrw-main-test")
+	gopath, err := os.MkdirTemp("", "thriftrw-main-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(gopath)
 
-	gopath2, err := ioutil.TempDir("", "thriftrw-main-test")
+	gopath2, err := os.MkdirTemp("", "thriftrw-main-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(gopath2)
 

--- a/protocol/binary/stream_reader.go
+++ b/protocol/binary/stream_reader.go
@@ -23,7 +23,6 @@ package binary
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"math"
 	"sync"
 
@@ -128,7 +127,7 @@ func (sr *StreamReader) discardSeek(n int64) error {
 }
 
 func (sr *StreamReader) discardStream(n int64) error {
-	_, err := io.CopyN(ioutil.Discard, sr.reader, n)
+	_, err := io.CopyN(io.Discard, sr.reader, n)
 	if err == io.EOF {
 		// All EOFs are unexpected when streaming
 		err = io.ErrUnexpectedEOF


### PR DESCRIPTION
io/ioutil package was deprecated and is not supported since Go 1.19. This removes all ioutil pkg usages in thriftrw..