### PR TITLE
Fix remaining lint errors

### DIFF
--- a/cmd/thriftbreak/main_test.go
+++ b/cmd/thriftbreak/main_test.go
@@ -23,7 +23,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -90,7 +89,7 @@ func TestThriftBreakIntegration(t *testing.T) {
 			tmpDir := t.TempDir()
 			breaktest.CreateRepoAndCommit(t, tmpDir, from, to, remove)
 
-			f, err := ioutil.TempFile(tmpDir, "stdout")
+			f, err := os.CreateTemp(tmpDir, "stdout")
 			require.NoError(t, err, "create temporary file")
 			defer func(oldStdout *os.File) {
 				assert.NoError(t, f.Close())
@@ -103,7 +102,7 @@ func TestThriftBreakIntegration(t *testing.T) {
 			require.Error(t, err, "expected an error with Thrift backwards incompatible changes")
 			assert.EqualError(t, err, "found 5 issues")
 
-			stderr, err := ioutil.ReadFile(f.Name())
+			stderr, err := os.ReadFile(f.Name())
 			require.NoError(t, err)
 
 			out := string(stderr)

--- a/gen/string.go
+++ b/gen/string.go
@@ -27,6 +27,8 @@ import (
 	"unicode/utf8"
 
 	"go.uber.org/thriftrw/compile"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // isAllCaps checks if a string contains all capital letters only. Non-letters
@@ -63,7 +65,7 @@ func pascalCase(allowAllCaps bool, words ...string) string {
 		if isAllCaps(chunk) && !allowAllCaps {
 			// A single ALLCAPS word does not count as SCREAMING_SNAKE_CASE.
 			// There must be at least one underscore.
-			words[i] = strings.Title(strings.ToLower(chunk))
+			words[i] = cases.Title(language.English).String(strings.ToLower(chunk))
 			continue
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	go.uber.org/multierr v1.1.0
 	go.uber.org/zap v1.9.1
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+	golang.org/x/text v0.7.0
 	golang.org/x/tools v0.4.1-0.20221208213631-3f74d914ae6d
 	honnef.co/go/tools v0.4.3
 )


### PR DESCRIPTION
After rebasing #574 on top of #577 and running GO111MODULE=on make lint I still see some errors.

cmd/thriftbreak/main_test.go:26:2: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)
gen/string.go:66:15: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.  (SA1019)

After this change:

$ git log --oneline
a054ce6 (HEAD -> optimise_read_string) Fix remaining lint errors 
2c1d285 build tags
8a1aa7d address review comments
f26170a inline
41dacbd remove bench reports
4ad4d9c optimise write string
fb22d6e optimise readstring()
6268dfe (origin/dev, origin/HEAD) Remove all usages of io/ioutil (#577)

$ GO111MODULE=on make lint
Checking gofmt
Checking govet
Checking golint
Checking staticcheck
$ echo $?
0

I've cherry-picked the contents of the HEAD commit displayed above into a separate branch for a PR to dev.