### PR TITLE
Update generated doc strings and make generate

### DIFF
--- a/gen/enum.go
+++ b/gen/enum.go
@@ -119,8 +119,8 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		// containing its name.
 		<- if .Spec.Items>
 		//
-		//   var <$v> <$enumName>
-		//   err := <$v>.UnmarshalText([]byte("<(index .Spec.Items 0).Name>"))
+		//	var <$v> <$enumName>
+		//	err := <$v>.UnmarshalText([]byte("<(index .Spec.Items 0).Name>"))
 		<- end>
 		func (<$v> *<$enumName>) UnmarshalText(<$value> []byte) error {
 			<- $s := newVar "s" ->
@@ -196,10 +196,10 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		<$sw := newVar "sw">
 		// Encode encodes <$enumName> directly to bytes.
 		//
-		//   sWriter := BinaryStreamer.Writer(writer)
+		//	sWriter := BinaryStreamer.Writer(writer)
 		//
-		//   var <$v> <$enumName>
-		//   return <$v>.Encode(sWriter)
+		//	var <$v> <$enumName>
+		//	return <$v>.Encode(sWriter)
 		func (<$v> <$enumName>) Encode(<$sw> <$stream>.Writer) error {
 			return <$sw>.WriteInt32(int32(<$v>))
 		}
@@ -217,16 +217,16 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		// FromWire deserializes <$enumName> from its Thrift-level
 		// representation.
 		//
-		//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-		//   if err != nil {
-		//     return <$enumName>(0), err
-		//   }
+		//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+		//	if err != nil {
+		//	    return <$enumName>(0), err
+		//	}
 		//
-		//   var <$v> <$enumName>
-		//   if err := <$v>.FromWire(x); err != nil {
-		//     return <$enumName>(0), err
-		//   }
-		//   return <$v>, nil
+		//	var <$v> <$enumName>
+		//	if err := <$v>.FromWire(x); err != nil {
+		//	    return <$enumName>(0), err
+		//	}
+		//	return <$v>, nil
 		func (<$v> *<$enumName>) FromWire(<$w> <$wire>.Value) error {
 			*<$v> = (<$enumName>)(<$w>.GetI32());
 			return nil
@@ -235,13 +235,13 @@ func enum(g Generator, spec *compile.EnumSpec) error {
 		<$sr := newVar "sr">
 		// Decode reads off the encoded <$enumName> directly off of the wire.
 		//
-		//   sReader := BinaryStreamer.Reader(reader)
+		//	sReader := BinaryStreamer.Reader(reader)
 		//
-		//   var <$v> <$enumName>
-		//   if err := <$v>.Decode(sReader); err != nil {
-		//     return <$enumName>(0), err
-		//   }
-		//   return <$v>, nil
+		//	var <$v> <$enumName>
+		//	if err := <$v>.Decode(sReader); err != nil {
+		//	    return <$enumName>(0), err
+		//	}
+		//	return <$v>, nil
 		func (<$v> *<$enumName>) Decode(<$sr> <$stream>.Reader) error {
 			<- $i := newVar "i" ->
 			<$i>, err := <$sr>.ReadInt32()

--- a/gen/field.go
+++ b/gen/field.go
@@ -300,14 +300,14 @@ func (f fieldGroupGenerator) ToWire(g Generator) error {
 		// An error is returned if the struct or any of its fields failed to
 		// validate.
 		//
-		//   x, err := <$v>.ToWire()
-		//   if err != nil {
-		//     return err
-		//   }
+		//	x, err := <$v>.ToWire()
+		//	if err != nil {
+		//		return err
+		//	}
 		//
-		//   if err := binaryProtocol.Encode(x, writer); err != nil {
-		//     return err
-		//   }
+		//	if err := binaryProtocol.Encode(x, writer); err != nil {
+		//		return err
+		//	}
 		func (<$v> *<.Name>) ToWire() (<$wire>.Value, error) {
 			<$fields := newVar "fields" ->
 			<- $i := newVar "i" ->
@@ -392,16 +392,16 @@ func (f fieldGroupGenerator) FromWire(g Generator) error {
 		// An error is returned if we were unable to build a <.Name> struct
 		// from the provided intermediate representation.
 		//
-		//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-		//   if err != nil {
-		//     return nil, err
-		//   }
+		//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+		//	if err != nil {
+		//		return nil, err
+		//	}
 		//
-		//   var <$v> <.Name>
-		//   if err := <$v>.FromWire(x); err != nil {
-		//     return nil, err
-		//   }
-		//   return &<$v>, nil
+		//	var <$v> <.Name>
+		//	if err := <$v>.FromWire(x); err != nil {
+		//		return nil, err
+		//	}
+		//	return &<$v>, nil
 		func (<$v> *<.Name>) FromWire(<$w> <$wire>.Value) error {
 			<if len .Fields> var err error <end>
 			<$f := newVar "field">

--- a/gen/internal/tests/collision/collision.go
+++ b/gen/internal/tests/collision/collision.go
@@ -36,14 +36,14 @@ type AccessorConflict struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *AccessorConflict) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -87,16 +87,16 @@ func (v *AccessorConflict) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a AccessorConflict struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v AccessorConflict
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v AccessorConflict
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *AccessorConflict) FromWire(w wire.Value) error {
 	var err error
 
@@ -393,14 +393,14 @@ type AccessorNoConflict struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *AccessorNoConflict) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -436,16 +436,16 @@ func (v *AccessorNoConflict) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a AccessorNoConflict struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v AccessorNoConflict
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v AccessorNoConflict
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *AccessorNoConflict) FromWire(w wire.Value) error {
 	var err error
 
@@ -728,8 +728,8 @@ func MyEnum_Values() []MyEnum {
 // UnmarshalText tries to decode MyEnum from a byte slice
 // containing its name.
 //
-//   var v MyEnum
-//   err := v.UnmarshalText([]byte("X"))
+//	var v MyEnum
+//	err := v.UnmarshalText([]byte("X"))
 func (v *MyEnum) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "X":
@@ -807,10 +807,10 @@ func (v MyEnum) Ptr() *MyEnum {
 
 // Encode encodes MyEnum directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v MyEnum
-//   return v.Encode(sWriter)
+//	var v MyEnum
+//	return v.Encode(sWriter)
 func (v MyEnum) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -827,16 +827,16 @@ func (v MyEnum) ToWire() (wire.Value, error) {
 // FromWire deserializes MyEnum from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return MyEnum(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return MyEnum(0), err
+//	}
 //
-//   var v MyEnum
-//   if err := v.FromWire(x); err != nil {
-//     return MyEnum(0), err
-//   }
-//   return v, nil
+//	var v MyEnum
+//	if err := v.FromWire(x); err != nil {
+//	    return MyEnum(0), err
+//	}
+//	return v, nil
 func (v *MyEnum) FromWire(w wire.Value) error {
 	*v = (MyEnum)(w.GetI32())
 	return nil
@@ -844,13 +844,13 @@ func (v *MyEnum) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded MyEnum directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v MyEnum
-//   if err := v.Decode(sReader); err != nil {
-//     return MyEnum(0), err
-//   }
-//   return v, nil
+//	var v MyEnum
+//	if err := v.Decode(sReader); err != nil {
+//	    return MyEnum(0), err
+//	}
+//	return v, nil
 func (v *MyEnum) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -1042,14 +1042,14 @@ func (_Map_String_String_MapItemList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -1158,16 +1158,16 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 // An error is returned if we were unable to build a PrimitiveContainers struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v PrimitiveContainers
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v PrimitiveContainers
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	var err error
 
@@ -1673,14 +1673,14 @@ type StructCollision struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *StructCollision) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1713,16 +1713,16 @@ func (v *StructCollision) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a StructCollision struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v StructCollision
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v StructCollision
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *StructCollision) FromWire(w wire.Value) error {
 	var err error
 
@@ -1934,14 +1934,14 @@ type UnionCollision struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *UnionCollision) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1981,16 +1981,16 @@ func (v *UnionCollision) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a UnionCollision struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v UnionCollision
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v UnionCollision
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *UnionCollision) FromWire(w wire.Value) error {
 	var err error
 
@@ -2256,14 +2256,14 @@ func Default_WithDefault() *WithDefault {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *WithDefault) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -2304,16 +2304,16 @@ func _StructCollision_Read(w wire.Value) (*StructCollision2, error) {
 // An error is returned if we were unable to build a WithDefault struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v WithDefault
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v WithDefault
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *WithDefault) FromWire(w wire.Value) error {
 	var err error
 
@@ -2563,8 +2563,8 @@ func MyEnum2_Values() []MyEnum2 {
 // UnmarshalText tries to decode MyEnum2 from a byte slice
 // containing its name.
 //
-//   var v MyEnum2
-//   err := v.UnmarshalText([]byte("X"))
+//	var v MyEnum2
+//	err := v.UnmarshalText([]byte("X"))
 func (v *MyEnum2) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "X":
@@ -2628,10 +2628,10 @@ func (v MyEnum2) Ptr() *MyEnum2 {
 
 // Encode encodes MyEnum2 directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v MyEnum2
-//   return v.Encode(sWriter)
+//	var v MyEnum2
+//	return v.Encode(sWriter)
 func (v MyEnum2) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -2648,16 +2648,16 @@ func (v MyEnum2) ToWire() (wire.Value, error) {
 // FromWire deserializes MyEnum2 from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return MyEnum2(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return MyEnum2(0), err
+//	}
 //
-//   var v MyEnum2
-//   if err := v.FromWire(x); err != nil {
-//     return MyEnum2(0), err
-//   }
-//   return v, nil
+//	var v MyEnum2
+//	if err := v.FromWire(x); err != nil {
+//	    return MyEnum2(0), err
+//	}
+//	return v, nil
 func (v *MyEnum2) FromWire(w wire.Value) error {
 	*v = (MyEnum2)(w.GetI32())
 	return nil
@@ -2665,13 +2665,13 @@ func (v *MyEnum2) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded MyEnum2 directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v MyEnum2
-//   if err := v.Decode(sReader); err != nil {
-//     return MyEnum2(0), err
-//   }
-//   return v, nil
+//	var v MyEnum2
+//	if err := v.Decode(sReader); err != nil {
+//	    return MyEnum2(0), err
+//	}
+//	return v, nil
 func (v *MyEnum2) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -2767,14 +2767,14 @@ type StructCollision2 struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *StructCollision2) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2807,16 +2807,16 @@ func (v *StructCollision2) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a StructCollision2 struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v StructCollision2
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v StructCollision2
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *StructCollision2) FromWire(w wire.Value) error {
 	var err error
 
@@ -3028,14 +3028,14 @@ type UnionCollision2 struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *UnionCollision2) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -3075,16 +3075,16 @@ func (v *UnionCollision2) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a UnionCollision2 struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v UnionCollision2
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v UnionCollision2
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *UnionCollision2) FromWire(w wire.Value) error {
 	var err error
 

--- a/gen/internal/tests/containers/containers.go
+++ b/gen/internal/tests/containers/containers.go
@@ -618,14 +618,14 @@ func (_Map_Set_I32_mapType_List_Double_MapItemList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ContainersOfContainers) ToWire() (wire.Value, error) {
 	var (
 		fields [9]wire.Field
@@ -1134,16 +1134,16 @@ func _Map_Set_I32_mapType_List_Double_Read(m wire.MapItemList) ([]struct {
 // An error is returned if we were unable to build a ContainersOfContainers struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ContainersOfContainers
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ContainersOfContainers
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ContainersOfContainers) FromWire(w wire.Value) error {
 	var err error
 
@@ -3471,14 +3471,14 @@ func (_Map_EnumWithDuplicateValues_I32_MapItemList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *EnumContainers) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -3605,16 +3605,16 @@ func _Map_EnumWithDuplicateValues_I32_Read(m wire.MapItemList) (map[enums.EnumWi
 // An error is returned if we were unable to build a EnumContainers struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v EnumContainers
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v EnumContainers
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *EnumContainers) FromWire(w wire.Value) error {
 	var err error
 
@@ -4203,14 +4203,14 @@ func (_List_RecordType_1_ValueList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ListOfConflictingEnums) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -4291,16 +4291,16 @@ func _List_RecordType_1_Read(l wire.ValueList) ([]enums.RecordType, error) {
 // An error is returned if we were unable to build a ListOfConflictingEnums struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ListOfConflictingEnums
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ListOfConflictingEnums
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ListOfConflictingEnums) FromWire(w wire.Value) error {
 	var err error
 
@@ -4737,14 +4737,14 @@ func (_List_UUID_1_ValueList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ListOfConflictingUUIDs) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -4825,16 +4825,16 @@ func _List_UUID_1_Read(l wire.ValueList) ([]uuid_conflict.UUID, error) {
 // An error is returned if we were unable to build a ListOfConflictingUUIDs struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ListOfConflictingUUIDs
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ListOfConflictingUUIDs
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ListOfConflictingUUIDs) FromWire(w wire.Value) error {
 	var err error
 
@@ -5218,14 +5218,14 @@ type ListOfOptionalPrimitives struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ListOfOptionalPrimitives) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -5253,16 +5253,16 @@ func (v *ListOfOptionalPrimitives) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a ListOfOptionalPrimitives struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ListOfOptionalPrimitives
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ListOfOptionalPrimitives
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ListOfOptionalPrimitives) FromWire(w wire.Value) error {
 	var err error
 
@@ -5424,14 +5424,14 @@ type ListOfRequiredPrimitives struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ListOfRequiredPrimitives) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -5457,16 +5457,16 @@ func (v *ListOfRequiredPrimitives) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a ListOfRequiredPrimitives struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ListOfRequiredPrimitives
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ListOfRequiredPrimitives
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ListOfRequiredPrimitives) FromWire(w wire.Value) error {
 	var err error
 
@@ -5718,14 +5718,14 @@ func (_Map_String_Binary_MapItemList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *MapOfBinaryAndString) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -5826,16 +5826,16 @@ func _Map_String_Binary_Read(m wire.MapItemList) (map[string][]byte, error) {
 // An error is returned if we were unable to build a MapOfBinaryAndString struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v MapOfBinaryAndString
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v MapOfBinaryAndString
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *MapOfBinaryAndString) FromWire(w wire.Value) error {
 	var err error
 
@@ -6444,14 +6444,14 @@ func (_Map_String_Bool_MapItemList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *PrimitiveContainers) ToWire() (wire.Value, error) {
 	var (
 		fields [6]wire.Field
@@ -6630,16 +6630,16 @@ func _Map_String_Bool_Read(m wire.MapItemList) (map[string]bool, error) {
 // An error is returned if we were unable to build a PrimitiveContainers struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v PrimitiveContainers
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v PrimitiveContainers
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *PrimitiveContainers) FromWire(w wire.Value) error {
 	var err error
 
@@ -7515,14 +7515,14 @@ func (_Map_I64_Double_MapItemList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *PrimitiveContainersRequired) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -7594,16 +7594,16 @@ func _Map_I64_Double_Read(m wire.MapItemList) (map[int64]float64, error) {
 // An error is returned if we were unable to build a PrimitiveContainersRequired struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v PrimitiveContainersRequired
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v PrimitiveContainersRequired
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *PrimitiveContainersRequired) FromWire(w wire.Value) error {
 	var err error
 

--- a/gen/internal/tests/enum-text-marshal-strict/enum-text-marshal-strict.go
+++ b/gen/internal/tests/enum-text-marshal-strict/enum-text-marshal-strict.go
@@ -37,8 +37,8 @@ func EnumMarshalStrict_Values() []EnumMarshalStrict {
 // UnmarshalText tries to decode EnumMarshalStrict from a byte slice
 // containing its name.
 //
-//   var v EnumMarshalStrict
-//   err := v.UnmarshalText([]byte("Foo"))
+//	var v EnumMarshalStrict
+//	err := v.UnmarshalText([]byte("Foo"))
 func (v *EnumMarshalStrict) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "Foo":
@@ -109,10 +109,10 @@ func (v EnumMarshalStrict) Ptr() *EnumMarshalStrict {
 
 // Encode encodes EnumMarshalStrict directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v EnumMarshalStrict
-//   return v.Encode(sWriter)
+//	var v EnumMarshalStrict
+//	return v.Encode(sWriter)
 func (v EnumMarshalStrict) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -129,16 +129,16 @@ func (v EnumMarshalStrict) ToWire() (wire.Value, error) {
 // FromWire deserializes EnumMarshalStrict from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return EnumMarshalStrict(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return EnumMarshalStrict(0), err
+//	}
 //
-//   var v EnumMarshalStrict
-//   if err := v.FromWire(x); err != nil {
-//     return EnumMarshalStrict(0), err
-//   }
-//   return v, nil
+//	var v EnumMarshalStrict
+//	if err := v.FromWire(x); err != nil {
+//	    return EnumMarshalStrict(0), err
+//	}
+//	return v, nil
 func (v *EnumMarshalStrict) FromWire(w wire.Value) error {
 	*v = (EnumMarshalStrict)(w.GetI32())
 	return nil
@@ -146,13 +146,13 @@ func (v *EnumMarshalStrict) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded EnumMarshalStrict directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v EnumMarshalStrict
-//   if err := v.Decode(sReader); err != nil {
-//     return EnumMarshalStrict(0), err
-//   }
-//   return v, nil
+//	var v EnumMarshalStrict
+//	if err := v.Decode(sReader); err != nil {
+//	    return EnumMarshalStrict(0), err
+//	}
+//	return v, nil
 func (v *EnumMarshalStrict) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {

--- a/gen/internal/tests/enum_conflict/enum_conflict.go
+++ b/gen/internal/tests/enum_conflict/enum_conflict.go
@@ -40,8 +40,8 @@ func RecordType_Values() []RecordType {
 // UnmarshalText tries to decode RecordType from a byte slice
 // containing its name.
 //
-//   var v RecordType
-//   err := v.UnmarshalText([]byte("Name"))
+//	var v RecordType
+//	err := v.UnmarshalText([]byte("Name"))
 func (v *RecordType) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "Name":
@@ -98,10 +98,10 @@ func (v RecordType) Ptr() *RecordType {
 
 // Encode encodes RecordType directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v RecordType
-//   return v.Encode(sWriter)
+//	var v RecordType
+//	return v.Encode(sWriter)
 func (v RecordType) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -118,16 +118,16 @@ func (v RecordType) ToWire() (wire.Value, error) {
 // FromWire deserializes RecordType from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return RecordType(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return RecordType(0), err
+//	}
 //
-//   var v RecordType
-//   if err := v.FromWire(x); err != nil {
-//     return RecordType(0), err
-//   }
-//   return v, nil
+//	var v RecordType
+//	if err := v.FromWire(x); err != nil {
+//	    return RecordType(0), err
+//	}
+//	return v, nil
 func (v *RecordType) FromWire(w wire.Value) error {
 	*v = (RecordType)(w.GetI32())
 	return nil
@@ -135,13 +135,13 @@ func (v *RecordType) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded RecordType directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v RecordType
-//   if err := v.Decode(sReader); err != nil {
-//     return RecordType(0), err
-//   }
-//   return v, nil
+//	var v RecordType
+//	if err := v.Decode(sReader); err != nil {
+//	    return RecordType(0), err
+//	}
+//	return v, nil
 func (v *RecordType) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -250,14 +250,14 @@ func Default_Records() *Records {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Records) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -313,16 +313,16 @@ func _RecordType_1_Read(w wire.Value) (enums.RecordType, error) {
 // An error is returned if we were unable to build a Records struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Records
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Records
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Records) FromWire(w wire.Value) error {
 	var err error
 

--- a/gen/internal/tests/enums/enums.go
+++ b/gen/internal/tests/enums/enums.go
@@ -64,10 +64,10 @@ func (v EmptyEnum) Ptr() *EmptyEnum {
 
 // Encode encodes EmptyEnum directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v EmptyEnum
-//   return v.Encode(sWriter)
+//	var v EmptyEnum
+//	return v.Encode(sWriter)
 func (v EmptyEnum) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -84,16 +84,16 @@ func (v EmptyEnum) ToWire() (wire.Value, error) {
 // FromWire deserializes EmptyEnum from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return EmptyEnum(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return EmptyEnum(0), err
+//	}
 //
-//   var v EmptyEnum
-//   if err := v.FromWire(x); err != nil {
-//     return EmptyEnum(0), err
-//   }
-//   return v, nil
+//	var v EmptyEnum
+//	if err := v.FromWire(x); err != nil {
+//	    return EmptyEnum(0), err
+//	}
+//	return v, nil
 func (v *EmptyEnum) FromWire(w wire.Value) error {
 	*v = (EmptyEnum)(w.GetI32())
 	return nil
@@ -101,13 +101,13 @@ func (v *EmptyEnum) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded EmptyEnum directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v EmptyEnum
-//   if err := v.Decode(sReader); err != nil {
-//     return EmptyEnum(0), err
-//   }
-//   return v, nil
+//	var v EmptyEnum
+//	if err := v.Decode(sReader); err != nil {
+//	    return EmptyEnum(0), err
+//	}
+//	return v, nil
 func (v *EmptyEnum) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -195,8 +195,8 @@ func EnumDefault_Values() []EnumDefault {
 // UnmarshalText tries to decode EnumDefault from a byte slice
 // containing its name.
 //
-//   var v EnumDefault
-//   err := v.UnmarshalText([]byte("Foo"))
+//	var v EnumDefault
+//	err := v.UnmarshalText([]byte("Foo"))
 func (v *EnumDefault) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "Foo":
@@ -260,10 +260,10 @@ func (v EnumDefault) Ptr() *EnumDefault {
 
 // Encode encodes EnumDefault directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v EnumDefault
-//   return v.Encode(sWriter)
+//	var v EnumDefault
+//	return v.Encode(sWriter)
 func (v EnumDefault) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -280,16 +280,16 @@ func (v EnumDefault) ToWire() (wire.Value, error) {
 // FromWire deserializes EnumDefault from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return EnumDefault(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return EnumDefault(0), err
+//	}
 //
-//   var v EnumDefault
-//   if err := v.FromWire(x); err != nil {
-//     return EnumDefault(0), err
-//   }
-//   return v, nil
+//	var v EnumDefault
+//	if err := v.FromWire(x); err != nil {
+//	    return EnumDefault(0), err
+//	}
+//	return v, nil
 func (v *EnumDefault) FromWire(w wire.Value) error {
 	*v = (EnumDefault)(w.GetI32())
 	return nil
@@ -297,13 +297,13 @@ func (v *EnumDefault) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded EnumDefault directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v EnumDefault
-//   if err := v.Decode(sReader); err != nil {
-//     return EnumDefault(0), err
-//   }
-//   return v, nil
+//	var v EnumDefault
+//	if err := v.Decode(sReader); err != nil {
+//	    return EnumDefault(0), err
+//	}
+//	return v, nil
 func (v *EnumDefault) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -419,8 +419,8 @@ func EnumWithDuplicateName_Values() []EnumWithDuplicateName {
 // UnmarshalText tries to decode EnumWithDuplicateName from a byte slice
 // containing its name.
 //
-//   var v EnumWithDuplicateName
-//   err := v.UnmarshalText([]byte("A"))
+//	var v EnumWithDuplicateName
+//	err := v.UnmarshalText([]byte("A"))
 func (v *EnumWithDuplicateName) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "A":
@@ -526,10 +526,10 @@ func (v EnumWithDuplicateName) Ptr() *EnumWithDuplicateName {
 
 // Encode encodes EnumWithDuplicateName directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v EnumWithDuplicateName
-//   return v.Encode(sWriter)
+//	var v EnumWithDuplicateName
+//	return v.Encode(sWriter)
 func (v EnumWithDuplicateName) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -546,16 +546,16 @@ func (v EnumWithDuplicateName) ToWire() (wire.Value, error) {
 // FromWire deserializes EnumWithDuplicateName from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return EnumWithDuplicateName(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return EnumWithDuplicateName(0), err
+//	}
 //
-//   var v EnumWithDuplicateName
-//   if err := v.FromWire(x); err != nil {
-//     return EnumWithDuplicateName(0), err
-//   }
-//   return v, nil
+//	var v EnumWithDuplicateName
+//	if err := v.FromWire(x); err != nil {
+//	    return EnumWithDuplicateName(0), err
+//	}
+//	return v, nil
 func (v *EnumWithDuplicateName) FromWire(w wire.Value) error {
 	*v = (EnumWithDuplicateName)(w.GetI32())
 	return nil
@@ -563,13 +563,13 @@ func (v *EnumWithDuplicateName) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded EnumWithDuplicateName directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v EnumWithDuplicateName
-//   if err := v.Decode(sReader); err != nil {
-//     return EnumWithDuplicateName(0), err
-//   }
-//   return v, nil
+//	var v EnumWithDuplicateName
+//	if err := v.Decode(sReader); err != nil {
+//	    return EnumWithDuplicateName(0), err
+//	}
+//	return v, nil
 func (v *EnumWithDuplicateName) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -697,8 +697,8 @@ func EnumWithDuplicateValues_Values() []EnumWithDuplicateValues {
 // UnmarshalText tries to decode EnumWithDuplicateValues from a byte slice
 // containing its name.
 //
-//   var v EnumWithDuplicateValues
-//   err := v.UnmarshalText([]byte("P"))
+//	var v EnumWithDuplicateValues
+//	err := v.UnmarshalText([]byte("P"))
 func (v *EnumWithDuplicateValues) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "P":
@@ -758,10 +758,10 @@ func (v EnumWithDuplicateValues) Ptr() *EnumWithDuplicateValues {
 
 // Encode encodes EnumWithDuplicateValues directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v EnumWithDuplicateValues
-//   return v.Encode(sWriter)
+//	var v EnumWithDuplicateValues
+//	return v.Encode(sWriter)
 func (v EnumWithDuplicateValues) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -778,16 +778,16 @@ func (v EnumWithDuplicateValues) ToWire() (wire.Value, error) {
 // FromWire deserializes EnumWithDuplicateValues from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return EnumWithDuplicateValues(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return EnumWithDuplicateValues(0), err
+//	}
 //
-//   var v EnumWithDuplicateValues
-//   if err := v.FromWire(x); err != nil {
-//     return EnumWithDuplicateValues(0), err
-//   }
-//   return v, nil
+//	var v EnumWithDuplicateValues
+//	if err := v.FromWire(x); err != nil {
+//	    return EnumWithDuplicateValues(0), err
+//	}
+//	return v, nil
 func (v *EnumWithDuplicateValues) FromWire(w wire.Value) error {
 	*v = (EnumWithDuplicateValues)(w.GetI32())
 	return nil
@@ -795,13 +795,13 @@ func (v *EnumWithDuplicateValues) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded EnumWithDuplicateValues directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v EnumWithDuplicateValues
-//   if err := v.Decode(sReader); err != nil {
-//     return EnumWithDuplicateValues(0), err
-//   }
-//   return v, nil
+//	var v EnumWithDuplicateValues
+//	if err := v.Decode(sReader); err != nil {
+//	    return EnumWithDuplicateValues(0), err
+//	}
+//	return v, nil
 func (v *EnumWithDuplicateValues) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -901,8 +901,8 @@ func EnumWithHexValues_Values() []EnumWithHexValues {
 // UnmarshalText tries to decode EnumWithHexValues from a byte slice
 // containing its name.
 //
-//   var v EnumWithHexValues
-//   err := v.UnmarshalText([]byte("X"))
+//	var v EnumWithHexValues
+//	err := v.UnmarshalText([]byte("X"))
 func (v *EnumWithHexValues) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "X":
@@ -966,10 +966,10 @@ func (v EnumWithHexValues) Ptr() *EnumWithHexValues {
 
 // Encode encodes EnumWithHexValues directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v EnumWithHexValues
-//   return v.Encode(sWriter)
+//	var v EnumWithHexValues
+//	return v.Encode(sWriter)
 func (v EnumWithHexValues) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -986,16 +986,16 @@ func (v EnumWithHexValues) ToWire() (wire.Value, error) {
 // FromWire deserializes EnumWithHexValues from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return EnumWithHexValues(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return EnumWithHexValues(0), err
+//	}
 //
-//   var v EnumWithHexValues
-//   if err := v.FromWire(x); err != nil {
-//     return EnumWithHexValues(0), err
-//   }
-//   return v, nil
+//	var v EnumWithHexValues
+//	if err := v.FromWire(x); err != nil {
+//	    return EnumWithHexValues(0), err
+//	}
+//	return v, nil
 func (v *EnumWithHexValues) FromWire(w wire.Value) error {
 	*v = (EnumWithHexValues)(w.GetI32())
 	return nil
@@ -1003,13 +1003,13 @@ func (v *EnumWithHexValues) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded EnumWithHexValues directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v EnumWithHexValues
-//   if err := v.Decode(sReader); err != nil {
-//     return EnumWithHexValues(0), err
-//   }
-//   return v, nil
+//	var v EnumWithHexValues
+//	if err := v.Decode(sReader); err != nil {
+//	    return EnumWithHexValues(0), err
+//	}
+//	return v, nil
 func (v *EnumWithHexValues) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -1119,8 +1119,8 @@ func EnumWithLabel_Values() []EnumWithLabel {
 // UnmarshalText tries to decode EnumWithLabel from a byte slice
 // containing its name.
 //
-//   var v EnumWithLabel
-//   err := v.UnmarshalText([]byte("USERNAME"))
+//	var v EnumWithLabel
+//	err := v.UnmarshalText([]byte("USERNAME"))
 func (v *EnumWithLabel) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "surname":
@@ -1205,10 +1205,10 @@ func (v EnumWithLabel) Ptr() *EnumWithLabel {
 
 // Encode encodes EnumWithLabel directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v EnumWithLabel
-//   return v.Encode(sWriter)
+//	var v EnumWithLabel
+//	return v.Encode(sWriter)
 func (v EnumWithLabel) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -1225,16 +1225,16 @@ func (v EnumWithLabel) ToWire() (wire.Value, error) {
 // FromWire deserializes EnumWithLabel from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return EnumWithLabel(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return EnumWithLabel(0), err
+//	}
 //
-//   var v EnumWithLabel
-//   if err := v.FromWire(x); err != nil {
-//     return EnumWithLabel(0), err
-//   }
-//   return v, nil
+//	var v EnumWithLabel
+//	if err := v.FromWire(x); err != nil {
+//	    return EnumWithLabel(0), err
+//	}
+//	return v, nil
 func (v *EnumWithLabel) FromWire(w wire.Value) error {
 	*v = (EnumWithLabel)(w.GetI32())
 	return nil
@@ -1242,13 +1242,13 @@ func (v *EnumWithLabel) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded EnumWithLabel directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v EnumWithLabel
-//   if err := v.Decode(sReader); err != nil {
-//     return EnumWithLabel(0), err
-//   }
-//   return v, nil
+//	var v EnumWithLabel
+//	if err := v.Decode(sReader); err != nil {
+//	    return EnumWithLabel(0), err
+//	}
+//	return v, nil
 func (v *EnumWithLabel) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -1364,8 +1364,8 @@ func EnumWithValues_Values() []EnumWithValues {
 // UnmarshalText tries to decode EnumWithValues from a byte slice
 // containing its name.
 //
-//   var v EnumWithValues
-//   err := v.UnmarshalText([]byte("X"))
+//	var v EnumWithValues
+//	err := v.UnmarshalText([]byte("X"))
 func (v *EnumWithValues) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "X":
@@ -1429,10 +1429,10 @@ func (v EnumWithValues) Ptr() *EnumWithValues {
 
 // Encode encodes EnumWithValues directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v EnumWithValues
-//   return v.Encode(sWriter)
+//	var v EnumWithValues
+//	return v.Encode(sWriter)
 func (v EnumWithValues) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -1449,16 +1449,16 @@ func (v EnumWithValues) ToWire() (wire.Value, error) {
 // FromWire deserializes EnumWithValues from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return EnumWithValues(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return EnumWithValues(0), err
+//	}
 //
-//   var v EnumWithValues
-//   if err := v.FromWire(x); err != nil {
-//     return EnumWithValues(0), err
-//   }
-//   return v, nil
+//	var v EnumWithValues
+//	if err := v.FromWire(x); err != nil {
+//	    return EnumWithValues(0), err
+//	}
+//	return v, nil
 func (v *EnumWithValues) FromWire(w wire.Value) error {
 	*v = (EnumWithValues)(w.GetI32())
 	return nil
@@ -1466,13 +1466,13 @@ func (v *EnumWithValues) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded EnumWithValues directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v EnumWithValues
-//   if err := v.Decode(sReader); err != nil {
-//     return EnumWithValues(0), err
-//   }
-//   return v, nil
+//	var v EnumWithValues
+//	if err := v.Decode(sReader); err != nil {
+//	    return EnumWithValues(0), err
+//	}
+//	return v, nil
 func (v *EnumWithValues) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -1584,8 +1584,8 @@ func RecordType_Values() []RecordType {
 // UnmarshalText tries to decode RecordType from a byte slice
 // containing its name.
 //
-//   var v RecordType
-//   err := v.UnmarshalText([]byte("NAME"))
+//	var v RecordType
+//	err := v.UnmarshalText([]byte("NAME"))
 func (v *RecordType) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "NAME":
@@ -1649,10 +1649,10 @@ func (v RecordType) Ptr() *RecordType {
 
 // Encode encodes RecordType directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v RecordType
-//   return v.Encode(sWriter)
+//	var v RecordType
+//	return v.Encode(sWriter)
 func (v RecordType) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -1669,16 +1669,16 @@ func (v RecordType) ToWire() (wire.Value, error) {
 // FromWire deserializes RecordType from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return RecordType(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return RecordType(0), err
+//	}
 //
-//   var v RecordType
-//   if err := v.FromWire(x); err != nil {
-//     return RecordType(0), err
-//   }
-//   return v, nil
+//	var v RecordType
+//	if err := v.FromWire(x); err != nil {
+//	    return RecordType(0), err
+//	}
+//	return v, nil
 func (v *RecordType) FromWire(w wire.Value) error {
 	*v = (RecordType)(w.GetI32())
 	return nil
@@ -1686,13 +1686,13 @@ func (v *RecordType) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded RecordType directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v RecordType
-//   if err := v.Decode(sReader); err != nil {
-//     return RecordType(0), err
-//   }
-//   return v, nil
+//	var v RecordType
+//	if err := v.Decode(sReader); err != nil {
+//	    return RecordType(0), err
+//	}
+//	return v, nil
 func (v *RecordType) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -1794,8 +1794,8 @@ func RecordTypeValues_Values() []RecordTypeValues {
 // UnmarshalText tries to decode RecordTypeValues from a byte slice
 // containing its name.
 //
-//   var v RecordTypeValues
-//   err := v.UnmarshalText([]byte("FOO"))
+//	var v RecordTypeValues
+//	err := v.UnmarshalText([]byte("FOO"))
 func (v *RecordTypeValues) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "FOO":
@@ -1852,10 +1852,10 @@ func (v RecordTypeValues) Ptr() *RecordTypeValues {
 
 // Encode encodes RecordTypeValues directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v RecordTypeValues
-//   return v.Encode(sWriter)
+//	var v RecordTypeValues
+//	return v.Encode(sWriter)
 func (v RecordTypeValues) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -1872,16 +1872,16 @@ func (v RecordTypeValues) ToWire() (wire.Value, error) {
 // FromWire deserializes RecordTypeValues from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return RecordTypeValues(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return RecordTypeValues(0), err
+//	}
 //
-//   var v RecordTypeValues
-//   if err := v.FromWire(x); err != nil {
-//     return RecordTypeValues(0), err
-//   }
-//   return v, nil
+//	var v RecordTypeValues
+//	if err := v.FromWire(x); err != nil {
+//	    return RecordTypeValues(0), err
+//	}
+//	return v, nil
 func (v *RecordTypeValues) FromWire(w wire.Value) error {
 	*v = (RecordTypeValues)(w.GetI32())
 	return nil
@@ -1889,13 +1889,13 @@ func (v *RecordTypeValues) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded RecordTypeValues directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v RecordTypeValues
-//   if err := v.Decode(sReader); err != nil {
-//     return RecordTypeValues(0), err
-//   }
-//   return v, nil
+//	var v RecordTypeValues
+//	if err := v.Decode(sReader); err != nil {
+//	    return RecordTypeValues(0), err
+//	}
+//	return v, nil
 func (v *RecordTypeValues) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -1986,14 +1986,14 @@ type StructWithOptionalEnum struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *StructWithOptionalEnum) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -2027,16 +2027,16 @@ func _EnumDefault_Read(w wire.Value) (EnumDefault, error) {
 // An error is returned if we were unable to build a StructWithOptionalEnum struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v StructWithOptionalEnum
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v StructWithOptionalEnum
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *StructWithOptionalEnum) FromWire(w wire.Value) error {
 	var err error
 
@@ -2227,8 +2227,8 @@ func LowerCaseEnum_Values() []LowerCaseEnum {
 // UnmarshalText tries to decode LowerCaseEnum from a byte slice
 // containing its name.
 //
-//   var v LowerCaseEnum
-//   err := v.UnmarshalText([]byte("containing"))
+//	var v LowerCaseEnum
+//	err := v.UnmarshalText([]byte("containing"))
 func (v *LowerCaseEnum) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "containing":
@@ -2292,10 +2292,10 @@ func (v LowerCaseEnum) Ptr() *LowerCaseEnum {
 
 // Encode encodes LowerCaseEnum directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v LowerCaseEnum
-//   return v.Encode(sWriter)
+//	var v LowerCaseEnum
+//	return v.Encode(sWriter)
 func (v LowerCaseEnum) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -2312,16 +2312,16 @@ func (v LowerCaseEnum) ToWire() (wire.Value, error) {
 // FromWire deserializes LowerCaseEnum from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return LowerCaseEnum(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return LowerCaseEnum(0), err
+//	}
 //
-//   var v LowerCaseEnum
-//   if err := v.FromWire(x); err != nil {
-//     return LowerCaseEnum(0), err
-//   }
-//   return v, nil
+//	var v LowerCaseEnum
+//	if err := v.FromWire(x); err != nil {
+//	    return LowerCaseEnum(0), err
+//	}
+//	return v, nil
 func (v *LowerCaseEnum) FromWire(w wire.Value) error {
 	*v = (LowerCaseEnum)(w.GetI32())
 	return nil
@@ -2329,13 +2329,13 @@ func (v *LowerCaseEnum) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded LowerCaseEnum directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v LowerCaseEnum
-//   if err := v.Decode(sReader); err != nil {
-//     return LowerCaseEnum(0), err
-//   }
-//   return v, nil
+//	var v LowerCaseEnum
+//	if err := v.Decode(sReader); err != nil {
+//	    return LowerCaseEnum(0), err
+//	}
+//	return v, nil
 func (v *LowerCaseEnum) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {

--- a/gen/internal/tests/exceptions/exceptions.go
+++ b/gen/internal/tests/exceptions/exceptions.go
@@ -27,14 +27,14 @@ type DoesNotExistException struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *DoesNotExistException) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -68,16 +68,16 @@ func (v *DoesNotExistException) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a DoesNotExistException struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v DoesNotExistException
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v DoesNotExistException
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *DoesNotExistException) FromWire(w wire.Value) error {
 	var err error
 
@@ -316,14 +316,14 @@ type DoesNotExistException2 struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *DoesNotExistException2) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -357,16 +357,16 @@ func (v *DoesNotExistException2) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a DoesNotExistException2 struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v DoesNotExistException2
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v DoesNotExistException2
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *DoesNotExistException2) FromWire(w wire.Value) error {
 	var err error
 
@@ -592,14 +592,14 @@ type EmptyException struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *EmptyException) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -616,16 +616,16 @@ func (v *EmptyException) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a EmptyException struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v EmptyException
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v EmptyException
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *EmptyException) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {

--- a/gen/internal/tests/hyphenated-file/hyphenated-file.go
+++ b/gen/internal/tests/hyphenated-file/hyphenated-file.go
@@ -26,14 +26,14 @@ type DocumentStruct struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *DocumentStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -68,16 +68,16 @@ func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
 // An error is returned if we were unable to build a DocumentStruct struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v DocumentStruct
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v DocumentStruct
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *DocumentStruct) FromWire(w wire.Value) error {
 	var err error
 

--- a/gen/internal/tests/hyphenated_file/hyphenated_file.go
+++ b/gen/internal/tests/hyphenated_file/hyphenated_file.go
@@ -26,14 +26,14 @@ type DocumentStructure struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *DocumentStructure) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -68,16 +68,16 @@ func _Second_Read(w wire.Value) (*non_hyphenated.Second, error) {
 // An error is returned if we were unable to build a DocumentStructure struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v DocumentStructure
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v DocumentStructure
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *DocumentStructure) FromWire(w wire.Value) error {
 	var err error
 

--- a/gen/internal/tests/non_hyphenated/non_hyphenated.go
+++ b/gen/internal/tests/non_hyphenated/non_hyphenated.go
@@ -22,14 +22,14 @@ type First struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *First) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -46,16 +46,16 @@ func (v *First) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a First struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v First
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v First
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *First) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -164,14 +164,14 @@ type Second struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Second) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -188,16 +188,16 @@ func (v *Second) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a Second struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Second
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Second
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Second) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {

--- a/gen/internal/tests/nozap/nozap.go
+++ b/gen/internal/tests/nozap/nozap.go
@@ -36,8 +36,8 @@ func EnumDefault_Values() []EnumDefault {
 // UnmarshalText tries to decode EnumDefault from a byte slice
 // containing its name.
 //
-//   var v EnumDefault
-//   err := v.UnmarshalText([]byte("Foo"))
+//	var v EnumDefault
+//	err := v.UnmarshalText([]byte("Foo"))
 func (v *EnumDefault) UnmarshalText(value []byte) error {
 	switch s := string(value); s {
 	case "Foo":
@@ -84,10 +84,10 @@ func (v EnumDefault) Ptr() *EnumDefault {
 
 // Encode encodes EnumDefault directly to bytes.
 //
-//   sWriter := BinaryStreamer.Writer(writer)
+//	sWriter := BinaryStreamer.Writer(writer)
 //
-//   var v EnumDefault
-//   return v.Encode(sWriter)
+//	var v EnumDefault
+//	return v.Encode(sWriter)
 func (v EnumDefault) Encode(sw stream.Writer) error {
 	return sw.WriteInt32(int32(v))
 }
@@ -104,16 +104,16 @@ func (v EnumDefault) ToWire() (wire.Value, error) {
 // FromWire deserializes EnumDefault from its Thrift-level
 // representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TI32)
-//   if err != nil {
-//     return EnumDefault(0), err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TI32)
+//	if err != nil {
+//	    return EnumDefault(0), err
+//	}
 //
-//   var v EnumDefault
-//   if err := v.FromWire(x); err != nil {
-//     return EnumDefault(0), err
-//   }
-//   return v, nil
+//	var v EnumDefault
+//	if err := v.FromWire(x); err != nil {
+//	    return EnumDefault(0), err
+//	}
+//	return v, nil
 func (v *EnumDefault) FromWire(w wire.Value) error {
 	*v = (EnumDefault)(w.GetI32())
 	return nil
@@ -121,13 +121,13 @@ func (v *EnumDefault) FromWire(w wire.Value) error {
 
 // Decode reads off the encoded EnumDefault directly off of the wire.
 //
-//   sReader := BinaryStreamer.Reader(reader)
+//	sReader := BinaryStreamer.Reader(reader)
 //
-//   var v EnumDefault
-//   if err := v.Decode(sReader); err != nil {
-//     return EnumDefault(0), err
-//   }
-//   return v, nil
+//	var v EnumDefault
+//	if err := v.Decode(sReader); err != nil {
+//	    return EnumDefault(0), err
+//	}
+//	return v, nil
 func (v *EnumDefault) Decode(sr stream.Reader) error {
 	i, err := sr.ReadInt32()
 	if err != nil {
@@ -319,14 +319,14 @@ func (_Map_I64_Double_MapItemList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *PrimitiveRequiredStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [11]wire.Field
@@ -493,16 +493,16 @@ func _Map_I64_Double_Read(m wire.MapItemList) (map[int64]float64, error) {
 // An error is returned if we were unable to build a PrimitiveRequiredStruct struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v PrimitiveRequiredStruct
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v PrimitiveRequiredStruct
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	var err error
 

--- a/gen/internal/tests/services/services.go
+++ b/gen/internal/tests/services/services.go
@@ -30,14 +30,14 @@ type ConflictingNamesSetValueArgs struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ConflictingNamesSetValueArgs) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -72,16 +72,16 @@ func (v *ConflictingNamesSetValueArgs) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a ConflictingNamesSetValueArgs struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ConflictingNamesSetValueArgs
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ConflictingNamesSetValueArgs
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ConflictingNamesSetValueArgs) FromWire(w wire.Value) error {
 	var err error
 
@@ -300,14 +300,14 @@ type InternalError struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *InternalError) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -335,16 +335,16 @@ func (v *InternalError) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a InternalError struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v InternalError
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v InternalError
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *InternalError) FromWire(w wire.Value) error {
 	var err error
 
@@ -595,14 +595,14 @@ type Cache_Clear_Args struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Cache_Clear_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -619,16 +619,16 @@ func (v *Cache_Clear_Args) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a Cache_Clear_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Cache_Clear_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Cache_Clear_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Cache_Clear_Args) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -772,14 +772,14 @@ type Cache_ClearAfter_Args struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Cache_ClearAfter_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -807,16 +807,16 @@ func (v *Cache_ClearAfter_Args) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a Cache_ClearAfter_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Cache_ClearAfter_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Cache_ClearAfter_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Cache_ClearAfter_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -1032,14 +1032,14 @@ type ConflictingNames_SetValue_Args struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ConflictingNames_SetValue_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -1073,16 +1073,16 @@ func _ConflictingNamesSetValueArgs_Read(w wire.Value) (*ConflictingNamesSetValue
 // An error is returned if we were unable to build a ConflictingNames_SetValue_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ConflictingNames_SetValue_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ConflictingNames_SetValue_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ConflictingNames_SetValue_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -1342,14 +1342,14 @@ type ConflictingNames_SetValue_Result struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ConflictingNames_SetValue_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -1366,16 +1366,16 @@ func (v *ConflictingNames_SetValue_Result) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a ConflictingNames_SetValue_Result struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ConflictingNames_SetValue_Result
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ConflictingNames_SetValue_Result
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ConflictingNames_SetValue_Result) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -1503,14 +1503,14 @@ type KeyValue_DeleteValue_Args struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_DeleteValue_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -1544,16 +1544,16 @@ func _Key_Read(w wire.Value) (Key, error) {
 // An error is returned if we were unable to build a KeyValue_DeleteValue_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_DeleteValue_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_DeleteValue_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_DeleteValue_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -1855,14 +1855,14 @@ type KeyValue_DeleteValue_Result struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_DeleteValue_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1914,16 +1914,16 @@ func _InternalError_Read(w wire.Value) (*InternalError, error) {
 // An error is returned if we were unable to build a KeyValue_DeleteValue_Result struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_DeleteValue_Result
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_DeleteValue_Result
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_DeleteValue_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -2226,14 +2226,14 @@ func (_List_Key_ValueList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_GetManyValues_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -2279,16 +2279,16 @@ func _List_Key_Read(l wire.ValueList) ([]Key, error) {
 // An error is returned if we were unable to build a KeyValue_GetManyValues_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_GetManyValues_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_GetManyValues_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_GetManyValues_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -2670,14 +2670,14 @@ func (_List_ArbitraryValue_ValueList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_GetManyValues_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2741,16 +2741,16 @@ func _List_ArbitraryValue_Read(l wire.ValueList) ([]*unions.ArbitraryValue, erro
 // An error is returned if we were unable to build a KeyValue_GetManyValues_Result struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_GetManyValues_Result
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_GetManyValues_Result
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_GetManyValues_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -3098,14 +3098,14 @@ type KeyValue_GetValue_Args struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_GetValue_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -3133,16 +3133,16 @@ func (v *KeyValue_GetValue_Args) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a KeyValue_GetValue_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_GetValue_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_GetValue_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_GetValue_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -3425,14 +3425,14 @@ type KeyValue_GetValue_Result struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_GetValue_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -3472,16 +3472,16 @@ func (v *KeyValue_GetValue_Result) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a KeyValue_GetValue_Result struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_GetValue_Result
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_GetValue_Result
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_GetValue_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -3747,14 +3747,14 @@ type KeyValue_SetValue_Args struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_SetValue_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -3790,16 +3790,16 @@ func (v *KeyValue_SetValue_Args) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a KeyValue_SetValue_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_SetValue_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_SetValue_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_SetValue_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -4111,14 +4111,14 @@ type KeyValue_SetValue_Result struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_SetValue_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -4135,16 +4135,16 @@ func (v *KeyValue_SetValue_Result) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a KeyValue_SetValue_Result struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_SetValue_Result
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_SetValue_Result
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_SetValue_Result) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -4277,14 +4277,14 @@ type KeyValue_SetValueV2_Args struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_SetValueV2_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -4319,16 +4319,16 @@ func (v *KeyValue_SetValueV2_Args) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a KeyValue_SetValueV2_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_SetValueV2_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_SetValueV2_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_SetValueV2_Args) FromWire(w wire.Value) error {
 	var err error
 
@@ -4642,14 +4642,14 @@ type KeyValue_SetValueV2_Result struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_SetValueV2_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -4666,16 +4666,16 @@ func (v *KeyValue_SetValueV2_Result) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a KeyValue_SetValueV2_Result struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_SetValueV2_Result
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_SetValueV2_Result
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_SetValueV2_Result) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -4802,14 +4802,14 @@ type KeyValue_Size_Args struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_Size_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -4826,16 +4826,16 @@ func (v *KeyValue_Size_Args) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a KeyValue_Size_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_Size_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_Size_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_Size_Args) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -5041,14 +5041,14 @@ type KeyValue_Size_Result struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *KeyValue_Size_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -5080,16 +5080,16 @@ func (v *KeyValue_Size_Result) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a KeyValue_Size_Result struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v KeyValue_Size_Result
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v KeyValue_Size_Result
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *KeyValue_Size_Result) FromWire(w wire.Value) error {
 	var err error
 
@@ -5297,14 +5297,14 @@ type NonStandardServiceName_NonStandardFunctionName_Args struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -5321,16 +5321,16 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Args) ToWire() (wire.Val
 // An error is returned if we were unable to build a NonStandardServiceName_NonStandardFunctionName_Args struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v NonStandardServiceName_NonStandardFunctionName_Args
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v NonStandardServiceName_NonStandardFunctionName_Args
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *NonStandardServiceName_NonStandardFunctionName_Args) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -5526,14 +5526,14 @@ type NonStandardServiceName_NonStandardFunctionName_Result struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -5550,16 +5550,16 @@ func (v *NonStandardServiceName_NonStandardFunctionName_Result) ToWire() (wire.V
 // An error is returned if we were unable to build a NonStandardServiceName_NonStandardFunctionName_Result struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v NonStandardServiceName_NonStandardFunctionName_Result
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v NonStandardServiceName_NonStandardFunctionName_Result
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *NonStandardServiceName_NonStandardFunctionName_Result) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {

--- a/gen/internal/tests/set_to_slice/set_to_slice.go
+++ b/gen/internal/tests/set_to_slice/set_to_slice.go
@@ -228,14 +228,14 @@ func (_Set_Set_String_sliceType_sliceType_ValueList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Bar) ToWire() (wire.Value, error) {
 	var (
 		fields [10]wire.Field
@@ -441,16 +441,16 @@ func _StringListList_Read(w wire.Value) (StringListList, error) {
 // An error is returned if we were unable to build a Bar struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Bar
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Bar
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Bar) FromWire(w wire.Value) error {
 	var err error
 
@@ -1468,14 +1468,14 @@ type Foo struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Foo) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -1501,16 +1501,16 @@ func (v *Foo) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a Foo struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Foo
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Foo
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Foo) FromWire(w wire.Value) error {
 	var err error
 

--- a/gen/internal/tests/structs/structs.go
+++ b/gen/internal/tests/structs/structs.go
@@ -29,14 +29,14 @@ type ContactInfo struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ContactInfo) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -62,16 +62,16 @@ func (v *ContactInfo) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a ContactInfo struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ContactInfo
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ContactInfo
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ContactInfo) FromWire(w wire.Value) error {
 	var err error
 
@@ -344,14 +344,14 @@ func (_List_Double_ValueList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *DefaultsStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [12]wire.Field
@@ -594,16 +594,16 @@ func _Edge_Read(w wire.Value) (*Edge, error) {
 // An error is returned if we were unable to build a DefaultsStruct struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v DefaultsStruct
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v DefaultsStruct
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *DefaultsStruct) FromWire(w wire.Value) error {
 	var err error
 
@@ -1799,14 +1799,14 @@ type Edge struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Edge) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -1850,16 +1850,16 @@ func _Point_Read(w wire.Value) (*Point, error) {
 // An error is returned if we were unable to build a Edge struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Edge
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Edge
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Edge) FromWire(w wire.Value) error {
 	var err error
 
@@ -2091,14 +2091,14 @@ type EmptyStruct struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *EmptyStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -2115,16 +2115,16 @@ func (v *EmptyStruct) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a EmptyStruct struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v EmptyStruct
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v EmptyStruct
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *EmptyStruct) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {
@@ -2235,14 +2235,14 @@ type Frame struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Frame) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2286,16 +2286,16 @@ func _Size_Read(w wire.Value) (*Size, error) {
 // An error is returned if we were unable to build a Frame struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Frame
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Frame
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Frame) FromWire(w wire.Value) error {
 	var err error
 
@@ -2533,14 +2533,14 @@ type GoTags struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *GoTags) ToWire() (wire.Value, error) {
 	var (
 		fields [6]wire.Field
@@ -2603,16 +2603,16 @@ func (v *GoTags) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a GoTags struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v GoTags
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v GoTags
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *GoTags) FromWire(w wire.Value) error {
 	var err error
 
@@ -3078,14 +3078,14 @@ func (_List_Edge_ValueList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Graph) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -3129,16 +3129,16 @@ func _List_Edge_Read(l wire.ValueList) ([]*Edge, error) {
 // An error is returned if we were unable to build a Graph struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Graph
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Graph
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Graph) FromWire(w wire.Value) error {
 	var err error
 
@@ -3429,14 +3429,14 @@ type Node struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Node) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -3476,16 +3476,16 @@ func _List_Read(w wire.Value) (*List, error) {
 // An error is returned if we were unable to build a Node struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Node
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Node
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Node) FromWire(w wire.Value) error {
 	var err error
 
@@ -3746,14 +3746,14 @@ func (_Map_String_String_MapItemList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *NotOmitEmpty) ToWire() (wire.Value, error) {
 	var (
 		fields [8]wire.Field
@@ -3865,16 +3865,16 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 // An error is returned if we were unable to build a NotOmitEmpty struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v NotOmitEmpty
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v NotOmitEmpty
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *NotOmitEmpty) FromWire(w wire.Value) error {
 	var err error
 
@@ -4501,14 +4501,14 @@ type Omit struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Omit) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -4541,16 +4541,16 @@ func (v *Omit) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a Omit struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Omit
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Omit
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Omit) FromWire(w wire.Value) error {
 	var err error
 
@@ -4761,14 +4761,14 @@ type PersonalInfo struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *PersonalInfo) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -4796,16 +4796,16 @@ func (v *PersonalInfo) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a PersonalInfo struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v PersonalInfo
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v PersonalInfo
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *PersonalInfo) FromWire(w wire.Value) error {
 	var err error
 
@@ -4973,14 +4973,14 @@ type Point struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Point) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -5013,16 +5013,16 @@ func (v *Point) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a Point struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Point
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Point
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Point) FromWire(w wire.Value) error {
 	var err error
 
@@ -5243,14 +5243,14 @@ type PrimitiveOptionalStruct struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *PrimitiveOptionalStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [8]wire.Field
@@ -5334,16 +5334,16 @@ func (v *PrimitiveOptionalStruct) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a PrimitiveOptionalStruct struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v PrimitiveOptionalStruct
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v PrimitiveOptionalStruct
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *PrimitiveOptionalStruct) FromWire(w wire.Value) error {
 	var err error
 
@@ -5940,14 +5940,14 @@ type PrimitiveRequiredStruct struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *PrimitiveRequiredStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [8]wire.Field
@@ -6024,16 +6024,16 @@ func (v *PrimitiveRequiredStruct) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a PrimitiveRequiredStruct struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v PrimitiveRequiredStruct
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v PrimitiveRequiredStruct
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *PrimitiveRequiredStruct) FromWire(w wire.Value) error {
 	var err error
 
@@ -6547,14 +6547,14 @@ type Rename struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Rename) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -6587,16 +6587,16 @@ func (v *Rename) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a Rename struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Rename
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Rename
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Rename) FromWire(w wire.Value) error {
 	var err error
 
@@ -6811,14 +6811,14 @@ type Size struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Size) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -6851,16 +6851,16 @@ func (v *Size) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a Size struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Size
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Size
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Size) FromWire(w wire.Value) error {
 	var err error
 
@@ -7074,14 +7074,14 @@ type StructLabels struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *StructLabels) ToWire() (wire.Value, error) {
 	var (
 		fields [4]wire.Field
@@ -7133,16 +7133,16 @@ func (v *StructLabels) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a StructLabels struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v StructLabels
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v StructLabels
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *StructLabels) FromWire(w wire.Value) error {
 	var err error
 
@@ -7475,14 +7475,14 @@ type User struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *User) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -7536,16 +7536,16 @@ func _PersonalInfo_Read(w wire.Value) (*PersonalInfo, error) {
 // An error is returned if we were unable to build a User struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v User
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v User
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *User) FromWire(w wire.Value) error {
 	var err error
 
@@ -8042,14 +8042,14 @@ type ZapOptOutStruct struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ZapOptOutStruct) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -8082,16 +8082,16 @@ func (v *ZapOptOutStruct) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a ZapOptOutStruct struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ZapOptOutStruct
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ZapOptOutStruct
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ZapOptOutStruct) FromWire(w wire.Value) error {
 	var err error
 

--- a/gen/internal/tests/typedefs/typedefs.go
+++ b/gen/internal/tests/typedefs/typedefs.go
@@ -224,14 +224,14 @@ func Default_DefaultPrimitiveTypedef() *DefaultPrimitiveTypedef {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *DefaultPrimitiveTypedef) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -269,16 +269,16 @@ func _State_Read(w wire.Value) (State, error) {
 // An error is returned if we were unable to build a DefaultPrimitiveTypedef struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v DefaultPrimitiveTypedef
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v DefaultPrimitiveTypedef
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *DefaultPrimitiveTypedef) FromWire(w wire.Value) error {
 	var err error
 
@@ -783,14 +783,14 @@ type Event struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Event) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -839,16 +839,16 @@ func _Timestamp_Read(w wire.Value) (Timestamp, error) {
 // An error is returned if we were unable to build a Event struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Event
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Event
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Event) FromWire(w wire.Value) error {
 	var err error
 
@@ -2300,14 +2300,14 @@ type Transition struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Transition) ToWire() (wire.Value, error) {
 	var (
 		fields [3]wire.Field
@@ -2354,16 +2354,16 @@ func _EventGroup_Read(w wire.Value) (EventGroup, error) {
 // An error is returned if we were unable to build a Transition struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Transition
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Transition
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Transition) FromWire(w wire.Value) error {
 	var err error
 
@@ -2631,14 +2631,14 @@ type TransitiveTypedefField struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *TransitiveTypedefField) ToWire() (wire.Value, error) {
 	var (
 		fields [1]wire.Field
@@ -2673,16 +2673,16 @@ func _MyUUID_Read(w wire.Value) (*MyUUID, error) {
 // An error is returned if we were unable to build a TransitiveTypedefField struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v TransitiveTypedefField
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v TransitiveTypedefField
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *TransitiveTypedefField) FromWire(w wire.Value) error {
 	var err error
 
@@ -2903,14 +2903,14 @@ type I128 struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *I128) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -2943,16 +2943,16 @@ func (v *I128) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a I128 struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v I128
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v I128
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *I128) FromWire(w wire.Value) error {
 	var err error
 

--- a/gen/internal/tests/unions/unions.go
+++ b/gen/internal/tests/unions/unions.go
@@ -106,14 +106,14 @@ func (_Map_String_ArbitraryValue_MapItemList) Close() {}
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *ArbitraryValue) ToWire() (wire.Value, error) {
 	var (
 		fields [5]wire.Field
@@ -229,16 +229,16 @@ func _Map_String_ArbitraryValue_Read(m wire.MapItemList) (map[string]*ArbitraryV
 // An error is returned if we were unable to build a ArbitraryValue struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v ArbitraryValue
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v ArbitraryValue
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *ArbitraryValue) FromWire(w wire.Value) error {
 	var err error
 
@@ -885,14 +885,14 @@ type Document struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *Document) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -938,16 +938,16 @@ func _PDF_Read(w wire.Value) (typedefs.PDF, error) {
 // An error is returned if we were unable to build a Document struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v Document
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v Document
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *Document) FromWire(w wire.Value) error {
 	var err error
 
@@ -1203,14 +1203,14 @@ type EmptyUnion struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *EmptyUnion) ToWire() (wire.Value, error) {
 	var (
 		fields [0]wire.Field
@@ -1227,16 +1227,16 @@ func (v *EmptyUnion) ToWire() (wire.Value, error) {
 // An error is returned if we were unable to build a EmptyUnion struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v EmptyUnion
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v EmptyUnion
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *EmptyUnion) FromWire(w wire.Value) error {
 
 	for _, field := range w.GetStruct().Fields {

--- a/gen/internal/tests/uuid_conflict/uuid_conflict.go
+++ b/gen/internal/tests/uuid_conflict/uuid_conflict.go
@@ -75,14 +75,14 @@ type UUIDConflict struct {
 // An error is returned if the struct or any of its fields failed to
 // validate.
 //
-//   x, err := v.ToWire()
-//   if err != nil {
-//     return err
-//   }
+//	x, err := v.ToWire()
+//	if err != nil {
+//		return err
+//	}
 //
-//   if err := binaryProtocol.Encode(x, writer); err != nil {
-//     return err
-//   }
+//	if err := binaryProtocol.Encode(x, writer); err != nil {
+//		return err
+//	}
 func (v *UUIDConflict) ToWire() (wire.Value, error) {
 	var (
 		fields [2]wire.Field
@@ -129,16 +129,16 @@ func _UUID_1_Read(w wire.Value) (*typedefs.UUID, error) {
 // An error is returned if we were unable to build a UUIDConflict struct
 // from the provided intermediate representation.
 //
-//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
-//   if err != nil {
-//     return nil, err
-//   }
+//	x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//	if err != nil {
+//		return nil, err
+//	}
 //
-//   var v UUIDConflict
-//   if err := v.FromWire(x); err != nil {
-//     return nil, err
-//   }
-//   return &v, nil
+//	var v UUIDConflict
+//	if err := v.FromWire(x); err != nil {
+//		return nil, err
+//	}
+//	return &v, nil
 func (v *UUIDConflict) FromWire(w wire.Value) error {
 	var err error
 

--- a/internal/envelope/exception/exception.go
+++ b/internal/envelope/exception/exception.go
@@ -216,12 +216,12 @@ func (v ExceptionType) ToWire() (wire.Value, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TI32)
 //	if err != nil {
-//	  return ExceptionType(0), err
+//	    return ExceptionType(0), err
 //	}
 //
 //	var v ExceptionType
 //	if err := v.FromWire(x); err != nil {
-//	  return ExceptionType(0), err
+//	    return ExceptionType(0), err
 //	}
 //	return v, nil
 func (v *ExceptionType) FromWire(w wire.Value) error {
@@ -235,7 +235,7 @@ func (v *ExceptionType) FromWire(w wire.Value) error {
 //
 //	var v ExceptionType
 //	if err := v.Decode(sReader); err != nil {
-//	  return ExceptionType(0), err
+//	    return ExceptionType(0), err
 //	}
 //	return v, nil
 func (v *ExceptionType) Decode(sr stream.Reader) error {
@@ -367,11 +367,11 @@ type TApplicationException struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *TApplicationException) ToWire() (wire.Value, error) {
 	var (
@@ -416,12 +416,12 @@ func _ExceptionType_Read(w wire.Value) (ExceptionType, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v TApplicationException
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *TApplicationException) FromWire(w wire.Value) error {

--- a/plugin/api/api.go
+++ b/plugin/api/api.go
@@ -122,11 +122,11 @@ func (_Map_String_String_MapItemList) Close() {}
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *Argument) ToWire() (wire.Value, error) {
 	var (
@@ -206,12 +206,12 @@ func _Map_String_String_Read(m wire.MapItemList) (map[string]string, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v Argument
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *Argument) FromWire(w wire.Value) error {
@@ -664,12 +664,12 @@ func (v Feature) ToWire() (wire.Value, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TI32)
 //	if err != nil {
-//	  return Feature(0), err
+//	    return Feature(0), err
 //	}
 //
 //	var v Feature
 //	if err := v.FromWire(x); err != nil {
-//	  return Feature(0), err
+//	    return Feature(0), err
 //	}
 //	return v, nil
 func (v *Feature) FromWire(w wire.Value) error {
@@ -683,7 +683,7 @@ func (v *Feature) FromWire(w wire.Value) error {
 //
 //	var v Feature
 //	if err := v.Decode(sReader); err != nil {
-//	  return Feature(0), err
+//	    return Feature(0), err
 //	}
 //	return v, nil
 func (v *Feature) Decode(sr stream.Reader) error {
@@ -834,11 +834,11 @@ func (_List_Argument_ValueList) Close() {}
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *Function) ToWire() (wire.Value, error) {
 	var (
@@ -937,12 +937,12 @@ func _List_Argument_Read(l wire.ValueList) ([]*Argument, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v Function
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *Function) FromWire(w wire.Value) error {
@@ -1672,11 +1672,11 @@ func (_List_ModuleID_ValueList) Close() {}
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *GenerateServiceRequest) ToWire() (wire.Value, error) {
 	var (
@@ -1861,12 +1861,12 @@ func _List_ModuleID_Read(l wire.ValueList) ([]ModuleID, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v GenerateServiceRequest
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *GenerateServiceRequest) FromWire(w wire.Value) error {
@@ -2732,11 +2732,11 @@ func (_Map_String_Binary_MapItemList) Close() {}
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *GenerateServiceResponse) ToWire() (wire.Value, error) {
 	var (
@@ -2795,12 +2795,12 @@ func _Map_String_Binary_Read(m wire.MapItemList) (map[string][]byte, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v GenerateServiceResponse
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *GenerateServiceResponse) FromWire(w wire.Value) error {
@@ -3061,11 +3061,11 @@ type HandshakeRequest struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *HandshakeRequest) ToWire() (wire.Value, error) {
 	var (
@@ -3085,12 +3085,12 @@ func (v *HandshakeRequest) ToWire() (wire.Value, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v HandshakeRequest
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *HandshakeRequest) FromWire(w wire.Value) error {
@@ -3244,11 +3244,11 @@ func (_List_Feature_ValueList) Close() {}
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *HandshakeResponse) ToWire() (wire.Value, error) {
 	var (
@@ -3323,12 +3323,12 @@ func _List_Feature_Read(l wire.ValueList) ([]Feature, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v HandshakeResponse
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *HandshakeResponse) FromWire(w wire.Value) error {
@@ -3754,11 +3754,11 @@ type Module struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *Module) ToWire() (wire.Value, error) {
 	var (
@@ -3801,12 +3801,12 @@ func (v *Module) ToWire() (wire.Value, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v Module
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *Module) FromWire(w wire.Value) error {
@@ -4173,11 +4173,11 @@ func (_List_Function_ValueList) Close() {}
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *Service) ToWire() (wire.Value, error) {
 	var (
@@ -4267,12 +4267,12 @@ func _List_Function_Read(l wire.ValueList) ([]*Function, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v Service
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *Service) FromWire(w wire.Value) error {
@@ -4991,12 +4991,12 @@ func (v SimpleType) ToWire() (wire.Value, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TI32)
 //	if err != nil {
-//	  return SimpleType(0), err
+//	    return SimpleType(0), err
 //	}
 //
 //	var v SimpleType
 //	if err := v.FromWire(x); err != nil {
-//	  return SimpleType(0), err
+//	    return SimpleType(0), err
 //	}
 //	return v, nil
 func (v *SimpleType) FromWire(w wire.Value) error {
@@ -5010,7 +5010,7 @@ func (v *SimpleType) FromWire(w wire.Value) error {
 //
 //	var v SimpleType
 //	if err := v.Decode(sReader); err != nil {
-//	  return SimpleType(0), err
+//	    return SimpleType(0), err
 //	}
 //	return v, nil
 func (v *SimpleType) Decode(sr stream.Reader) error {
@@ -5150,11 +5150,11 @@ type Type struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *Type) ToWire() (wire.Value, error) {
 	var (
@@ -5247,12 +5247,12 @@ func _TypeReference_Read(w wire.Value) (*TypeReference, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v Type
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *Type) FromWire(w wire.Value) error {
@@ -5777,11 +5777,11 @@ type TypePair struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *TypePair) ToWire() (wire.Value, error) {
 	var (
@@ -5822,12 +5822,12 @@ func (v *TypePair) ToWire() (wire.Value, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v TypePair
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *TypePair) FromWire(w wire.Value) error {
@@ -6080,11 +6080,11 @@ type TypeReference struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *TypeReference) ToWire() (wire.Value, error) {
 	var (
@@ -6128,12 +6128,12 @@ func (v *TypeReference) ToWire() (wire.Value, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v TypeReference
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *TypeReference) FromWire(w wire.Value) error {
@@ -6412,11 +6412,11 @@ type Plugin_Goodbye_Args struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *Plugin_Goodbye_Args) ToWire() (wire.Value, error) {
 	var (
@@ -6436,12 +6436,12 @@ func (v *Plugin_Goodbye_Args) ToWire() (wire.Value, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v Plugin_Goodbye_Args
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *Plugin_Goodbye_Args) FromWire(w wire.Value) error {
@@ -6641,11 +6641,11 @@ type Plugin_Goodbye_Result struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *Plugin_Goodbye_Result) ToWire() (wire.Value, error) {
 	var (
@@ -6665,12 +6665,12 @@ func (v *Plugin_Goodbye_Result) ToWire() (wire.Value, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v Plugin_Goodbye_Result
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *Plugin_Goodbye_Result) FromWire(w wire.Value) error {
@@ -6802,11 +6802,11 @@ type Plugin_Handshake_Args struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *Plugin_Handshake_Args) ToWire() (wire.Value, error) {
 	var (
@@ -6843,12 +6843,12 @@ func _HandshakeRequest_Read(w wire.Value) (*HandshakeRequest, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v Plugin_Handshake_Args
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *Plugin_Handshake_Args) FromWire(w wire.Value) error {
@@ -7122,11 +7122,11 @@ type Plugin_Handshake_Result struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *Plugin_Handshake_Result) ToWire() (wire.Value, error) {
 	var (
@@ -7167,12 +7167,12 @@ func _HandshakeResponse_Read(w wire.Value) (*HandshakeResponse, error) {
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v Plugin_Handshake_Result
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *Plugin_Handshake_Result) FromWire(w wire.Value) error {
@@ -7387,11 +7387,11 @@ type ServiceGenerator_Generate_Args struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *ServiceGenerator_Generate_Args) ToWire() (wire.Value, error) {
 	var (
@@ -7428,12 +7428,12 @@ func _GenerateServiceRequest_Read(w wire.Value) (*GenerateServiceRequest, error)
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v ServiceGenerator_Generate_Args
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *ServiceGenerator_Generate_Args) FromWire(w wire.Value) error {
@@ -7707,11 +7707,11 @@ type ServiceGenerator_Generate_Result struct {
 //
 //	x, err := v.ToWire()
 //	if err != nil {
-//	  return err
+//		return err
 //	}
 //
 //	if err := binaryProtocol.Encode(x, writer); err != nil {
-//	  return err
+//		return err
 //	}
 func (v *ServiceGenerator_Generate_Result) ToWire() (wire.Value, error) {
 	var (
@@ -7752,12 +7752,12 @@ func _GenerateServiceResponse_Read(w wire.Value) (*GenerateServiceResponse, erro
 //
 //	x, err := binaryProtocol.Decode(reader, wire.TStruct)
 //	if err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //
 //	var v ServiceGenerator_Generate_Result
 //	if err := v.FromWire(x); err != nil {
-//	  return nil, err
+//		return nil, err
 //	}
 //	return &v, nil
 func (v *ServiceGenerator_Generate_Result) FromWire(w wire.Value) error {


### PR DESCRIPTION
 Update generated doc strings and make generate

These changes are the result of:
- Re-tabbing the doc string generation logic of gen/enum.go and gen/field.go
- running 'GO111MODULE=on make generate' on dev.

These steps are performed to update generated code, make the generated
code compliant with gofmt, and resolve release issues ahead of time.