### PR TITLE
CI: Use Go 1.22.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.20.x", "1.21.x"]
+        go: ["1.21.x", "1.22.x"]
         include:
-        - go: 1.21.x
+        - go: 1.22.x
           latest: true
 
     steps:


### PR DESCRIPTION
This PR switches CI to use Go 1.22.

I chose to leave go.mod as-is to avoid requiring users to upgrade beyond 1.20.