### PR TITLE
CI: Upgrade codecov action & use token

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,4 +45,6 @@ jobs:
       run: make cover
 
     - name: Upload coverage to codecov.io
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Currently, codecov actions on PRs stall for a very long time.

This PR upgrades to the latest codecov action
and usages the token when uploading.
This will fix the stalling issue.