### PR TITLE
Remove usage of deprecated APIs in reflect

### DIFF
--- a/wire/unsafe.go
+++ b/wire/unsafe.go
@@ -21,7 +21,6 @@
 package wire
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -29,19 +28,12 @@ import (
 // new memory for it with the assumption that the resulting byte slice will not
 // be mutated.
 func unsafeStringToBytes(s string) []byte {
-	p := unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data)
-
-	var b []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Data = uintptr(p)
-	hdr.Cap = len(s)
-	hdr.Len = len(s)
-	return b
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 // unsafeBytesToString converts a byte slice into a string without allocating
 // new memory with the assumption that the source byte slice will not be mutated
 // after this.
 func unsafeBytesToString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }


### PR DESCRIPTION
reflect.StringHeader and reflect.SliceHeader have been deprecated:
- https://pkg.go.dev/reflect#StringHeader
- https://pkg.go.dev/reflect#SliceHeader

change this to use unsafe.String and unsafe.Slice instead.

Note that this doesn't change the performance: 

dev branch:
```
goos: darwin
goarch: arm64
pkg: go.uber.org/thriftrw/gen
cpu: Apple M1 Max
BenchmarkRoundTrip/PrimitiveOptionalStruct/Encode-10  	 1582638	       761.0 ns/op
BenchmarkRoundTrip/PrimitiveOptionalStruct/Streaming_Encode-10         	 2801079	       445.3 ns/op
BenchmarkRoundTrip/PrimitiveOptionalStruct/Decode-10                   	  998443	      1194 ns/op
BenchmarkRoundTrip/PrimitiveOptionalStruct/Streaming_Decode-10         	 1934899	       619.9 ns/op
BenchmarkRoundTrip/Graph/Encode-10                                     	  705380	      1697 ns/op
BenchmarkRoundTrip/Graph/Streaming_Encode-10                           	 1827822	       651.7 ns/op
BenchmarkRoundTrip/Graph/Decode-10                                     	  409455	      2903 ns/op
BenchmarkRoundTrip/Graph/Streaming_Decode-10                           	 1000000	      1054 ns/op
BenchmarkRoundTrip/ContainersOfContainers/Encode-10                    	   92904	     12809 ns/op
BenchmarkRoundTrip/ContainersOfContainers/Streaming_Encode-10          	  149362	      8000 ns/op
BenchmarkRoundTrip/ContainersOfContainers/Decode-10                    	   33994	     35248 ns/op
BenchmarkRoundTrip/ContainersOfContainers/Streaming_Decode-10          	   62726	     19254 ns/op
```

this branch:
```
goos: darwin
goarch: arm64
pkg: go.uber.org/thriftrw/gen
cpu: Apple M1 Max
BenchmarkRoundTrip/PrimitiveOptionalStruct/Encode-10  	 1586850	       760.7 ns/op
BenchmarkRoundTrip/PrimitiveOptionalStruct/Streaming_Encode-10         	 2825220	       431.9 ns/op
BenchmarkRoundTrip/PrimitiveOptionalStruct/Decode-10                   	  969396	      1186 ns/op
BenchmarkRoundTrip/PrimitiveOptionalStruct/Streaming_Decode-10         	 1929952	       622.3 ns/op
BenchmarkRoundTrip/Graph/Encode-10                                     	  720025	      1703 ns/op
BenchmarkRoundTrip/Graph/Streaming_Encode-10                           	 1872415	       638.6 ns/op
BenchmarkRoundTrip/Graph/Decode-10                                     	  408147	      2880 ns/op
BenchmarkRoundTrip/Graph/Streaming_Decode-10                           	 1000000	      1089 ns/op
BenchmarkRoundTrip/ContainersOfContainers/Encode-10                    	   92539	     12774 ns/op
BenchmarkRoundTrip/ContainersOfContainers/Streaming_Encode-10          	  149848	      7972 ns/op
BenchmarkRoundTrip/ContainersOfContainers/Decode-10                    	   35406	     33498 ns/op
BenchmarkRoundTrip/ContainersOfContainers/Streaming_Decode-10          	   65391	     18379 ns/op
PASS
```