### PR TITLE
Module to Thrift File Generator

### DIFF
--- a/compile/compiler.go
+++ b/compile/compiler.go
@@ -145,6 +145,7 @@ func (c compiler) load(p string) (*Module, error) {
 		Constants:  make(map[string]*Constant),
 		Types:      make(map[string]TypeSpec),
 		Services:   make(map[string]*ServiceSpec),
+		Namespaces: make(map[string]string),
 	}
 
 	m.Raw = s
@@ -174,6 +175,10 @@ func (c compiler) gather(m *Module, prog *ast.Program) error {
 
 	// Process all included modules first.
 	for _, h := range prog.Headers {
+		if ns, ok := h.(*ast.Namespace); ok {
+			m.Namespaces[ns.Scope] = ns.Name
+			continue
+		}
 		header, ok := h.(*ast.Include)
 		if !ok {
 			continue

--- a/compile/generate.go
+++ b/compile/generate.go
@@ -1,0 +1,758 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package compile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"go.uber.org/thriftrw/ast"
+)
+
+// GenerateThriftFile writes the Thrift IDL representation of this Module to the
+// given path. The content is reconstructed entirely from the Module's compiled
+// structured fields (namespaces, includes, constants, types, services) and does
+// not rely on the raw IDL input.
+//
+// GenerateThriftFile is, in effect, the inverse of Compile: compiling the
+// generated file yields a Module structurally equivalent to the receiver.
+func (m *Module) GenerateThriftFile(path string) error {
+	if m == nil {
+		return fmt.Errorf("nil module")
+	}
+
+	content, err := m.thriftIDL()
+	if err != nil {
+		return fmt.Errorf("generate thrift content for %q: %w", path, err)
+	}
+
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create directory for %q: %w", path, err)
+		}
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write thrift file %q: %w", path, err)
+	}
+
+	return nil
+}
+
+// thriftIDL builds the Thrift IDL representation of the Module as a string.
+// Sections are emitted in the order: namespaces, includes, constants, types,
+// services.
+func (m *Module) thriftIDL() (string, error) {
+	var builder strings.Builder
+
+	writeNamespaces(&builder, m)
+
+	if err := writeIncludes(&builder, m); err != nil {
+		return "", err
+	}
+
+	if err := writeConstants(&builder, m); err != nil {
+		return "", err
+	}
+
+	if err := writeTypes(&builder, m); err != nil {
+		return "", err
+	}
+
+	if err := writeServices(&builder, m); err != nil {
+		return "", err
+	}
+
+	return builder.String(), nil
+}
+
+// sortedKeys returns the keys of m sorted lexicographically. It is used to give
+// the generated output a deterministic ordering for map-backed declarations.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// writeNamespaces writes the namespace declarations stored on the module.
+// Namespaces are emitted in sorted scope order for deterministic output.
+func writeNamespaces(builder *strings.Builder, module *Module) {
+	if len(module.Namespaces) == 0 {
+		return
+	}
+
+	for _, scope := range sortedKeys(module.Namespaces) {
+		builder.WriteString(fmt.Sprintf("namespace %s %s\n", scope, module.Namespaces[scope]))
+	}
+	builder.WriteString("\n")
+}
+
+// writeIncludes writes the include statements for the module, reconstructing
+// each include path relative to the directory of the current thrift file.
+func writeIncludes(builder *strings.Builder, module *Module) error {
+	if len(module.Includes) == 0 {
+		return nil
+	}
+
+	moduleDir := filepath.Dir(module.ThriftPath)
+
+	for _, name := range sortedKeys(module.Includes) {
+		includedModule, ok := module.Includes[name]
+		if !ok || includedModule == nil || includedModule.Module == nil {
+			return fmt.Errorf("included module %q is nil in thrift file: %s", name, module.ThriftPath)
+		}
+
+		relPath, err := filepath.Rel(moduleDir, includedModule.Module.ThriftPath)
+		if err != nil {
+			return fmt.Errorf("error while computing relative include path for %q in thrift file %s: %w", name, module.ThriftPath, err)
+		}
+
+		builder.WriteString(fmt.Sprintf("include \"%s\"\n", relPath))
+	}
+	builder.WriteString("\n")
+
+	return nil
+}
+
+// writeConstants writes constant definitions to the builder using the compiled
+// constant values, in sorted name order for deterministic output.
+func writeConstants(builder *strings.Builder, module *Module) error {
+	if len(module.Constants) == 0 {
+		return nil
+	}
+
+	for _, name := range sortedKeys(module.Constants) {
+		constant, ok := module.Constants[name]
+		if !ok || constant == nil {
+			continue
+		}
+
+		writeDocumentation(builder, constant.Doc)
+
+		typeStr, err := getType(constant.Type, module)
+		if err != nil {
+			return fmt.Errorf("error while getting type for constant %s in thrift file %s: %w", name, module.ThriftPath, err)
+		}
+
+		valueStr, err := constantValueToString(constant.Value, module, 0)
+		if err != nil {
+			return fmt.Errorf("error while getting value for constant %s in thrift file %s: %w", name, module.ThriftPath, err)
+		}
+
+		builder.WriteString(fmt.Sprintf("const %s %s = %s\n", typeStr, name, valueStr))
+	}
+
+	builder.WriteString("\n")
+	return nil
+}
+
+// constantValueToString serializes a compiled ConstantValue back into its
+// Thrift literal representation. indent is the current indentation depth (in
+// levels of two spaces) used for multi-line container literals.
+func constantValueToString(value ConstantValue, module *Module, indent int) (string, error) {
+	switch v := value.(type) {
+	case ConstantBool:
+		if bool(v) {
+			return "true", nil
+		}
+		return "false", nil
+	case ConstantInt:
+		return strconv.FormatInt(int64(v), 10), nil
+	case ConstantString:
+		return fmt.Sprintf("\"%s\"", escapeString(string(v))), nil
+	case ConstantDouble:
+		return strconv.FormatFloat(float64(v), 'g', -1, 64), nil
+	case ConstantList:
+		return constantSliceToString([]ConstantValue(v), module, indent)
+	case ConstantSet:
+		return constantSliceToString([]ConstantValue(v), module, indent)
+	case ConstantMap:
+		return constantMapToString(v, module, indent)
+	case *ConstantStruct:
+		return constantStructToString(v, module, indent)
+	case ConstReference:
+		if v.Target == nil {
+			return "", fmt.Errorf("constant reference has nil target in thrift file: %s", module.ThriftPath)
+		}
+		return getQualifiedTypeName(v.Target.Name, v.Target.File, module)
+	case EnumItemReference:
+		if v.Enum == nil || v.Item == nil {
+			return "", fmt.Errorf("enum item reference is incomplete in thrift file: %s", module.ThriftPath)
+		}
+		enumName, err := getQualifiedTypeName(v.Enum.Name, v.Enum.File, module)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s.%s", enumName, v.Item.Name), nil
+	}
+
+	return "", fmt.Errorf("unknown constant value type %T in thrift file: %s", value, module.ThriftPath)
+}
+
+// constantSliceToString renders a list or set constant literal.
+func constantSliceToString(items []ConstantValue, module *Module, indent int) (string, error) {
+	if len(items) == 0 {
+		return "[]", nil
+	}
+
+	itemIndent := strings.Repeat("  ", indent+1)
+	closeIndent := strings.Repeat("  ", indent)
+
+	var builder strings.Builder
+	builder.WriteString("[\n")
+	for _, item := range items {
+		itemStr, err := constantValueToString(item, module, indent+1)
+		if err != nil {
+			return "", err
+		}
+		builder.WriteString(itemIndent + itemStr + ",\n")
+	}
+	builder.WriteString(closeIndent + "]")
+
+	return builder.String(), nil
+}
+
+// constantMapToString renders a map constant literal.
+func constantMapToString(items ConstantMap, module *Module, indent int) (string, error) {
+	if len(items) == 0 {
+		return "{}", nil
+	}
+
+	itemIndent := strings.Repeat("  ", indent+1)
+	closeIndent := strings.Repeat("  ", indent)
+
+	var builder strings.Builder
+	builder.WriteString("{\n")
+	for _, pair := range items {
+		keyStr, err := constantValueToString(pair.Key, module, indent+1)
+		if err != nil {
+			return "", err
+		}
+		valueStr, err := constantValueToString(pair.Value, module, indent+1)
+		if err != nil {
+			return "", err
+		}
+		builder.WriteString(itemIndent + keyStr + ": " + valueStr + ",\n")
+	}
+	builder.WriteString(closeIndent + "}")
+
+	return builder.String(), nil
+}
+
+// constantStructToString renders a struct constant literal (a map with string keys).
+func constantStructToString(structValue *ConstantStruct, module *Module, indent int) (string, error) {
+	if structValue == nil || len(structValue.Fields) == 0 {
+		return "{}", nil
+	}
+
+	itemIndent := strings.Repeat("  ", indent+1)
+	closeIndent := strings.Repeat("  ", indent)
+
+	var builder strings.Builder
+	builder.WriteString("{\n")
+	for _, fieldName := range sortedKeys(structValue.Fields) {
+		valueStr, err := constantValueToString(structValue.Fields[fieldName], module, indent+1)
+		if err != nil {
+			return "", err
+		}
+		builder.WriteString(fmt.Sprintf("%s\"%s\": %s,\n", itemIndent, fieldName, valueStr))
+	}
+	builder.WriteString(closeIndent + "}")
+
+	return builder.String(), nil
+}
+
+// writeTypes writes the typedef, enum, struct, union, and exception definitions.
+func writeTypes(builder *strings.Builder, module *Module) error {
+	if len(module.Types) == 0 {
+		return nil
+	}
+
+	// Sort types with enums first, exceptions last and other typeSpecs in between.
+	for _, name := range sortTypesByKind(module) {
+		typeSpec := module.Types[name]
+
+		switch t := typeSpec.(type) {
+		case *TypedefSpec:
+			if err := writeTypedef(builder, t, module); err != nil {
+				return fmt.Errorf("error while writing typedef: %w", err)
+			}
+		case *EnumSpec:
+			if err := writeEnum(builder, t); err != nil {
+				return fmt.Errorf("error while writing enum: %w", err)
+			}
+		case *StructSpec:
+			// StructSpec includes structs, unions, and exceptions.
+			if err := writeStruct(builder, t, module); err != nil {
+				return fmt.Errorf("error while writing struct: %w", err)
+			}
+		}
+		builder.WriteString("\n")
+	}
+
+	return nil
+}
+
+// writeDocumentation writes a documentation comment block, if doc is non-empty.
+func writeDocumentation(builder *strings.Builder, doc string) {
+	if doc == "" {
+		return
+	}
+
+	lines := strings.Split(strings.TrimSpace(doc), "\n")
+	builder.WriteString("/**")
+	builder.WriteString("\n")
+	for _, line := range lines {
+		builder.WriteString("* " + line + "\n")
+	}
+	builder.WriteString("*/")
+	builder.WriteString("\n")
+}
+
+// sortTypesByKind returns the names of the module's types ordered so that the
+// generated output declares them in a stable, dependency-friendly order:
+//
+//  1. Enums
+//  2. Typedefs
+//  3. Structs
+//  4. Unions
+//  5. Exceptions
+//
+// Within each kind, names are sorted alphabetically.
+func sortTypesByKind(module *Module) []string {
+	typeNames := make([]string, 0, len(module.Types))
+	for name := range module.Types {
+		typeNames = append(typeNames, name)
+	}
+
+	sort.Slice(typeNames, func(i, j int) bool {
+		priorityI := getTypePriority(module.Types[typeNames[i]])
+		priorityJ := getTypePriority(module.Types[typeNames[j]])
+
+		if priorityI != priorityJ {
+			return priorityI < priorityJ
+		}
+		return typeNames[i] < typeNames[j]
+	})
+
+	return typeNames
+}
+
+// getTypePriority returns the sorting priority for a type. Lower numbers come
+// first in the sorted output.
+func getTypePriority(typeSpec TypeSpec) int {
+	switch t := typeSpec.(type) {
+	case *EnumSpec:
+		return 1
+	case *TypedefSpec:
+		return 2
+	case *StructSpec:
+		switch t.Type {
+		case ast.StructType:
+			return 3
+		case ast.UnionType:
+			return 4
+		case ast.ExceptionType:
+			return 6
+		}
+	}
+	// Unreachable for the current set of type specs; kept to accommodate any
+	// new TypeSpec added in the future.
+	return 5
+}
+
+// writeTypedef writes a typedef definition.
+func writeTypedef(builder *strings.Builder, typedef *TypedefSpec, module *Module) error {
+	if typedef == nil {
+		return fmt.Errorf("typedef spec is nil")
+	}
+
+	writeDocumentation(builder, typedef.Doc)
+
+	targetType, err := getType(typedef.Target, module)
+	if err != nil {
+		return fmt.Errorf("error while getting type name for typedef: %w", err)
+	}
+	builder.WriteString(fmt.Sprintf("typedef %s %s", targetType, typedef.Name))
+
+	if annotations := getAnnotations(typedef.Annotations); annotations != "" {
+		builder.WriteString(" " + annotations)
+	}
+
+	builder.WriteString("\n")
+	return nil
+}
+
+// getType returns the Thrift type name of the given typeSpec. References to
+// named types defined in included modules are qualified with the include alias.
+func getType(typeSpec TypeSpec, module *Module) (string, error) {
+	if typeSpec == nil {
+		return "", fmt.Errorf("typeSpec is nil")
+	}
+
+	switch t := typeSpec.(type) {
+	case *BoolSpec:
+		return "bool", nil
+	case *I8Spec:
+		return "i8", nil
+	case *I16Spec:
+		return "i16", nil
+	case *I32Spec:
+		return "i32", nil
+	case *I64Spec:
+		return "i64", nil
+	case *DoubleSpec:
+		return "double", nil
+	case *StringSpec:
+		return "string", nil
+	case *BinarySpec:
+		return "binary", nil
+	case *ListSpec:
+		typeName, err := getType(t.ValueSpec, module)
+		if err != nil {
+			return "", fmt.Errorf("error while getting type string for list %s : %w", t.ValueSpec.ThriftName(), err)
+		}
+		return fmt.Sprintf("list<%s>", typeName), nil
+
+	case *SetSpec:
+		typeName, err := getType(t.ValueSpec, module)
+		if err != nil {
+			return "", fmt.Errorf("error while getting type string for set %s : %w", t.ValueSpec.ThriftName(), err)
+		}
+		return fmt.Sprintf("set<%s>", typeName), nil
+
+	case *MapSpec:
+		keyType, err := getType(t.KeySpec, module)
+		if err != nil {
+			return "", fmt.Errorf("error while getting type string for map key %s : %w", t.KeySpec.ThriftName(), err)
+		}
+		valueType, err := getType(t.ValueSpec, module)
+		if err != nil {
+			return "", fmt.Errorf("error while getting type string for map value %s : %w", t.ValueSpec.ThriftName(), err)
+		}
+		return fmt.Sprintf("map<%s, %s>", keyType, valueType), nil
+
+	case *TypedefSpec:
+		return getQualifiedTypeName(t.Name, t.File, module)
+
+	case *EnumSpec:
+		return getQualifiedTypeName(t.Name, t.File, module)
+
+	case *StructSpec:
+		return getQualifiedTypeName(t.Name, t.File, module)
+	}
+
+	return "", fmt.Errorf("unknown type: %T in thrift file: %s", typeSpec, module.ThriftPath)
+}
+
+// getAnnotations converts annotations to their Thrift string representation,
+// e.g. (go.name = "Foo", deprecated). Annotations are sorted by name.
+func getAnnotations(annotations Annotations) string {
+	if len(annotations) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(annotations))
+	for _, name := range sortedKeys(annotations) {
+		value := annotations[name]
+		if value != "" {
+			parts = append(parts, fmt.Sprintf("%s = \"%s\"", name, escapeString(value)))
+		} else {
+			parts = append(parts, name)
+		}
+	}
+
+	return fmt.Sprintf("(%s)", strings.Join(parts, ", "))
+}
+
+// getQualifiedTypeName returns the qualified name for a type, prefixing it with
+// the include alias if the type is defined in an included module.
+func getQualifiedTypeName(typeName, typeFilePath string, module *Module) (string, error) {
+	// If the type's file is the same as the current module's file, it's local.
+	if typeFilePath == module.ThriftPath {
+		return typeName, nil
+	}
+
+	// Check if this type comes from an included module.
+	for _, includedModule := range module.Includes {
+		if includedModule != nil && includedModule.Module != nil && typeFilePath == includedModule.Module.ThriftPath {
+			return fmt.Sprintf("%s.%s", includedModule.Name, typeName), nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to resolve qualified type name for type: %s from file: %s", typeName, typeFilePath)
+}
+
+// escapeString escapes special characters in a Thrift string literal.
+func escapeString(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	s = strings.ReplaceAll(s, "\r", "\\r")
+	s = strings.ReplaceAll(s, "\t", "\\t")
+	return s
+}
+
+// writeEnum writes an enum definition.
+func writeEnum(builder *strings.Builder, enum *EnumSpec) error {
+	if enum == nil {
+		return fmt.Errorf("enum spec is nil")
+	}
+
+	writeDocumentation(builder, enum.Doc)
+
+	builder.WriteString(fmt.Sprintf("enum %s {\n", enum.Name))
+
+	for i, item := range enum.Items {
+		writeDocumentation(builder, item.Doc)
+
+		builder.WriteString(fmt.Sprintf("  %s = %d", item.Name, item.Value))
+
+		if annotations := getAnnotations(item.Annotations); annotations != "" {
+			builder.WriteString(" " + annotations)
+		}
+
+		if i < len(enum.Items)-1 {
+			builder.WriteString(",")
+		}
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString("}")
+
+	if annotations := getAnnotations(enum.Annotations); annotations != "" {
+		builder.WriteString(" " + annotations)
+	}
+
+	builder.WriteString("\n")
+	return nil
+}
+
+// writeStruct writes a struct, union, or exception definition.
+func writeStruct(builder *strings.Builder, structSpec *StructSpec, module *Module) error {
+	if structSpec == nil {
+		return fmt.Errorf("struct spec is nil")
+	}
+
+	writeDocumentation(builder, structSpec.Doc)
+
+	var keyword string
+	switch structSpec.Type {
+	case ast.StructType:
+		keyword = "struct"
+	case ast.UnionType:
+		keyword = "union"
+	case ast.ExceptionType:
+		keyword = "exception"
+	default:
+		return fmt.Errorf("unknown structSpec type %s in thrift file: %s", structSpec.Name, module.ThriftPath)
+	}
+
+	builder.WriteString(fmt.Sprintf("%s %s {\n", keyword, structSpec.Name))
+
+	for _, field := range structSpec.Fields {
+		writeDocumentation(builder, field.Doc)
+
+		builder.WriteString(fmt.Sprintf("  %d: ", field.ID))
+
+		// Requiredness. Unions never carry a requiredness keyword.
+		if field.Required {
+			builder.WriteString("required ")
+		} else if keyword != "union" {
+			builder.WriteString("optional ")
+		}
+
+		fieldType, err := getType(field.Type, module)
+		if err != nil {
+			return fmt.Errorf("error while getting type string for field %s : %w in thrift file: %s", field.Name, err, module.ThriftPath)
+		}
+		builder.WriteString(fieldType + " ")
+
+		// Annotations carried by the field's (scalar) type spec.
+		if isScalarField(field) {
+			if typeSpecAnnotations := getAnnotations(field.Type.ThriftAnnotations()); typeSpecAnnotations != "" {
+				builder.WriteString(typeSpecAnnotations + " ")
+			}
+		}
+
+		builder.WriteString(field.Name)
+
+		if field.Default != nil {
+			defaultValue, err := constantValueToString(field.Default, module, 0)
+			if err != nil {
+				return fmt.Errorf("error while getting default value for field %s in thrift file: %s : %w", field.Name, module.ThriftPath, err)
+			}
+			builder.WriteString(" = " + defaultValue)
+		}
+
+		if annotations := getAnnotations(field.Annotations); annotations != "" {
+			builder.WriteString(" " + annotations)
+		}
+
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString("}")
+
+	if annotations := getAnnotations(structSpec.Annotations); annotations != "" {
+		builder.WriteString(" " + annotations)
+	}
+
+	builder.WriteString("\n")
+	return nil
+}
+
+// isScalarField reports whether the field's type is a primitive Thrift type.
+func isScalarField(field *FieldSpec) bool {
+	switch field.Type.(type) {
+	case *BoolSpec, *I8Spec, *I16Spec, *I32Spec, *I64Spec, *DoubleSpec, *StringSpec, *BinarySpec:
+		return true
+	}
+	return false
+}
+
+// writeServices writes service definitions, including their functions,
+// arguments, return types, exceptions, and inheritance.
+func writeServices(builder *strings.Builder, module *Module) error {
+	if len(module.Services) == 0 {
+		return nil
+	}
+
+	for _, serviceName := range sortedKeys(module.Services) {
+		service := module.Services[serviceName]
+
+		builder.WriteString(fmt.Sprintf("service %s", serviceName))
+
+		if service.Parent != nil {
+			parentName, err := getOriginalServiceParentName(module, serviceName, service.Parent)
+			if err != nil {
+				return fmt.Errorf("error while getting parent service name for service %s in thrift file: %s : %w", serviceName, module.ThriftPath, err)
+			}
+			builder.WriteString(fmt.Sprintf(" extends %s", parentName))
+		}
+
+		builder.WriteString(" {\n")
+
+		for _, fname := range sortedKeys(service.Functions) {
+			function := service.Functions[fname]
+
+			if function.OneWay {
+				builder.WriteString("  oneway ")
+			} else {
+				builder.WriteString("  ")
+			}
+
+			if function.ResultSpec != nil && function.ResultSpec.ReturnType != nil {
+				returnType, err := getType(function.ResultSpec.ReturnType, module)
+				if err != nil {
+					return fmt.Errorf("error while getting return type %s : %w in thrift file: %s", function.ResultSpec.ReturnType.ThriftName(), err, module.ThriftPath)
+				}
+				builder.WriteString(returnType + " ")
+			} else {
+				builder.WriteString("void ")
+			}
+
+			builder.WriteString(fname + "(")
+
+			for i, arg := range FieldGroup(function.ArgsSpec) {
+				if i > 0 {
+					builder.WriteString(", ")
+				}
+
+				fieldType, err := getType(arg.Type, module)
+				if err != nil {
+					return fmt.Errorf("error while getting data type for function argument %s for function %s in thrift file: %s : %w", arg.Name, function.Name, module.ThriftPath, err)
+				}
+				if arg.Required {
+					builder.WriteString(fmt.Sprintf("%d: required %s %s", arg.ID, fieldType, arg.Name))
+				} else {
+					builder.WriteString(fmt.Sprintf("%d: %s %s", arg.ID, fieldType, arg.Name))
+				}
+			}
+
+			builder.WriteString(")")
+
+			if function.ResultSpec != nil && len(function.ResultSpec.Exceptions) > 0 {
+				builder.WriteString(" throws (")
+				for i, exc := range function.ResultSpec.Exceptions {
+					if i > 0 {
+						builder.WriteString(", ")
+					}
+
+					fieldType, err := getType(exc.Type, module)
+					if err != nil {
+						return fmt.Errorf("error while getting data type for exception %s in thrift file: %s : %w", exc.Name, module.ThriftPath, err)
+					}
+					if exc.Required {
+						builder.WriteString(fmt.Sprintf("%d: required %s %s", exc.ID, fieldType, exc.Name))
+					} else {
+						builder.WriteString(fmt.Sprintf("%d: %s %s", exc.ID, fieldType, exc.Name))
+					}
+				}
+				builder.WriteString(")")
+			}
+
+			if annotations := getAnnotations(function.Annotations); annotations != "" {
+				builder.WriteString(" " + annotations)
+			}
+
+			builder.WriteString("\n")
+		}
+
+		builder.WriteString("}")
+
+		if annotations := getAnnotations(service.Annotations); annotations != "" {
+			builder.WriteString(" " + annotations)
+		}
+
+		builder.WriteString("\n\n")
+	}
+
+	return nil
+}
+
+// getOriginalServiceParentName resolves the name of a service's parent,
+// qualifying it with the include alias when the parent is defined in an
+// included module.
+func getOriginalServiceParentName(module *Module, serviceName string, parent *ServiceSpec) (string, error) {
+	if parent == nil {
+		return "", fmt.Errorf("parent service spec is nil")
+	}
+
+	if parent.File == module.ThriftPath {
+		return parent.Name, nil
+	}
+
+	for includeName, include := range module.Includes {
+		if include != nil && include.Module != nil && parent.File == include.Module.ThriftPath {
+			return fmt.Sprintf("%s.%s", includeName, parent.Name), nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find original service parent name for %s", serviceName)
+}

--- a/compile/generate.go
+++ b/compile/generate.go
@@ -43,7 +43,7 @@ func (m *Module) GenerateThriftFile(path string) error {
 		return fmt.Errorf("nil module")
 	}
 
-	content, err := m.thriftIDL()
+	content, err := m.thriftIDL(path)
 	if err != nil {
 		return fmt.Errorf("generate thrift content for %q: %w", path, err)
 	}
@@ -64,12 +64,16 @@ func (m *Module) GenerateThriftFile(path string) error {
 // thriftIDL builds the Thrift IDL representation of the Module as a string.
 // Sections are emitted in the order: namespaces, includes, constants, types,
 // services.
-func (m *Module) thriftIDL() (string, error) {
+//
+// outputPath is the path the generated IDL will be written to; it is used to
+// compute include paths relative to the output file's directory so that the
+// generated file recompiles correctly from wherever the caller writes it.
+func (m *Module) thriftIDL(outputPath string) (string, error) {
 	var builder strings.Builder
 
 	writeNamespaces(&builder, m)
 
-	if err := writeIncludes(&builder, m); err != nil {
+	if err := writeIncludes(&builder, m, outputPath); err != nil {
 		return "", err
 	}
 
@@ -113,13 +117,23 @@ func writeNamespaces(builder *strings.Builder, module *Module) {
 }
 
 // writeIncludes writes the include statements for the module, reconstructing
-// each include path relative to the directory of the current thrift file.
-func writeIncludes(builder *strings.Builder, module *Module) error {
+// each include path relative to the directory of outputPath (the path the
+// generated IDL will be written to). Using the output directory — rather than
+// the source module's directory — ensures the emitted include resolves
+// correctly when the generated file is recompiled from a directory different
+// from where the source module was originally read.
+func writeIncludes(builder *strings.Builder, module *Module, outputPath string) error {
 	if len(module.Includes) == 0 {
 		return nil
 	}
 
-	moduleDir := filepath.Dir(module.ThriftPath)
+	// Normalize to absolute paths so filepath.Rel produces a consistent result
+	// regardless of whether outputPath and each ThriftPath were originally
+	// supplied as relative or absolute paths.
+	absOutputDir, err := filepath.Abs(filepath.Dir(outputPath))
+	if err != nil {
+		return fmt.Errorf("error while resolving absolute output directory for %q: %w", outputPath, err)
+	}
 
 	for _, name := range sortedKeys(module.Includes) {
 		includedModule, ok := module.Includes[name]
@@ -127,9 +141,14 @@ func writeIncludes(builder *strings.Builder, module *Module) error {
 			return fmt.Errorf("included module %q is nil in thrift file: %s", name, module.ThriftPath)
 		}
 
-		relPath, err := filepath.Rel(moduleDir, includedModule.Module.ThriftPath)
+		absIncluded, err := filepath.Abs(includedModule.Module.ThriftPath)
 		if err != nil {
-			return fmt.Errorf("error while computing relative include path for %q in thrift file %s: %w", name, module.ThriftPath, err)
+			return fmt.Errorf("error while resolving absolute path for included module %q: %w", name, err)
+		}
+
+		relPath, err := filepath.Rel(absOutputDir, absIncluded)
+		if err != nil {
+			return fmt.Errorf("error while computing include path for %q relative to output %q: %w", name, outputPath, err)
 		}
 
 		builder.WriteString(fmt.Sprintf("include \"%s\"\n", relPath))

--- a/compile/generate.go
+++ b/compile/generate.go
@@ -156,7 +156,7 @@ func writeIncludes(builder *strings.Builder, module *Module, outputPath string) 
 			return fmt.Errorf("error while computing include path for %q relative to output %q: %w", name, outputPath, err)
 		}
 
-		builder.WriteString(fmt.Sprintf("include \"%s\"\n", relPath))
+		builder.WriteString(fmt.Sprintf("include \"%s\"\n", filepath.ToSlash(relPath)))
 	}
 	builder.WriteString("\n")
 
@@ -208,7 +208,7 @@ func constantValueToString(value ConstantValue, module *Module, indent int) (str
 	case ConstantInt:
 		return strconv.FormatInt(int64(v), 10), nil
 	case ConstantString:
-		return fmt.Sprintf("\"%s\"", escapeString(string(v))), nil
+		return strconv.Quote(string(v)), nil
 	case ConstantDouble:
 		return strconv.FormatFloat(float64(v), 'g', -1, 64), nil
 	case ConstantList:
@@ -521,7 +521,7 @@ func getAnnotations(annotations Annotations) string {
 	for _, name := range sortedKeys(annotations) {
 		value := annotations[name]
 		if value != "" {
-			parts = append(parts, fmt.Sprintf("%s = \"%s\"", name, escapeString(value)))
+			parts = append(parts, fmt.Sprintf("%s = %s", name, strconv.Quote(value)))
 		} else {
 			parts = append(parts, name)
 		}
@@ -546,16 +546,6 @@ func getQualifiedTypeName(typeName, typeFilePath string, module *Module) (string
 	}
 
 	return "", fmt.Errorf("unable to resolve qualified type name for type: %s from file: %s", typeName, typeFilePath)
-}
-
-// escapeString escapes special characters in a Thrift string literal.
-func escapeString(s string) string {
-	s = strings.ReplaceAll(s, "\\", "\\\\")
-	s = strings.ReplaceAll(s, "\"", "\\\"")
-	s = strings.ReplaceAll(s, "\n", "\\n")
-	s = strings.ReplaceAll(s, "\r", "\\r")
-	s = strings.ReplaceAll(s, "\t", "\\t")
-	return s
 }
 
 // writeEnum writes an enum definition.

--- a/compile/generate.go
+++ b/compile/generate.go
@@ -31,6 +31,11 @@ import (
 	"go.uber.org/thriftrw/ast"
 )
 
+var (
+	filepathAbs = filepath.Abs
+	filepathRel = filepath.Rel
+)
+
 // GenerateThriftFile writes the Thrift IDL representation of this Module to the
 // given path. The content is reconstructed entirely from the Module's compiled
 // structured fields (namespaces, includes, constants, types, services) and does
@@ -130,7 +135,7 @@ func writeIncludes(builder *strings.Builder, module *Module, outputPath string) 
 	// Normalize to absolute paths so filepath.Rel produces a consistent result
 	// regardless of whether outputPath and each ThriftPath were originally
 	// supplied as relative or absolute paths.
-	absOutputDir, err := filepath.Abs(filepath.Dir(outputPath))
+	absOutputDir, err := filepathAbs(filepath.Dir(outputPath))
 	if err != nil {
 		return fmt.Errorf("error while resolving absolute output directory for %q: %w", outputPath, err)
 	}
@@ -141,12 +146,12 @@ func writeIncludes(builder *strings.Builder, module *Module, outputPath string) 
 			return fmt.Errorf("included module %q is nil in thrift file: %s", name, module.ThriftPath)
 		}
 
-		absIncluded, err := filepath.Abs(includedModule.Module.ThriftPath)
+		absIncluded, err := filepathAbs(includedModule.Module.ThriftPath)
 		if err != nil {
 			return fmt.Errorf("error while resolving absolute path for included module %q: %w", name, err)
 		}
 
-		relPath, err := filepath.Rel(absOutputDir, absIncluded)
+		relPath, err := filepathRel(absOutputDir, absIncluded)
 		if err != nil {
 			return fmt.Errorf("error while computing include path for %q relative to output %q: %w", name, outputPath, err)
 		}
@@ -173,7 +178,7 @@ func writeConstants(builder *strings.Builder, module *Module) error {
 
 		writeDocumentation(builder, constant.Doc)
 
-		typeStr, err := getType(constant.Type, module)
+		typeStr, err := getAnnotatedType(constant.Type, module)
 		if err != nil {
 			return fmt.Errorf("error while getting type for constant %s in thrift file %s: %w", name, module.ThriftPath, err)
 		}
@@ -339,17 +344,23 @@ func writeTypes(builder *strings.Builder, module *Module) error {
 
 // writeDocumentation writes a documentation comment block, if doc is non-empty.
 func writeDocumentation(builder *strings.Builder, doc string) {
+	writeIndentedDocumentation(builder, doc, "")
+}
+
+// writeIndentedDocumentation writes a documentation comment block prefixed with
+// indent on each line, if doc is non-empty.
+func writeIndentedDocumentation(builder *strings.Builder, doc, indent string) {
 	if doc == "" {
 		return
 	}
 
 	lines := strings.Split(strings.TrimSpace(doc), "\n")
-	builder.WriteString("/**")
+	builder.WriteString(indent + "/**")
 	builder.WriteString("\n")
 	for _, line := range lines {
-		builder.WriteString("* " + line + "\n")
+		builder.WriteString(indent + "* " + line + "\n")
 	}
-	builder.WriteString("*/")
+	builder.WriteString(indent + "*/")
 	builder.WriteString("\n")
 }
 
@@ -413,11 +424,11 @@ func writeTypedef(builder *strings.Builder, typedef *TypedefSpec, module *Module
 
 	writeDocumentation(builder, typedef.Doc)
 
-	targetType, err := getType(typedef.Target, module)
+	targetType, err := getAnnotatedType(typedef.Target, module)
 	if err != nil {
 		return fmt.Errorf("error while getting type name for typedef: %w", err)
 	}
-	builder.WriteString(fmt.Sprintf("typedef %s %s", targetType, typedef.Name))
+	builder.WriteString("typedef " + targetType + " " + typedef.Name)
 
 	if annotations := getAnnotations(typedef.Annotations); annotations != "" {
 		builder.WriteString(" " + annotations)
@@ -427,54 +438,55 @@ func writeTypedef(builder *strings.Builder, typedef *TypedefSpec, module *Module
 	return nil
 }
 
-// getType returns the Thrift type name of the given typeSpec. References to
+// getAnnotatedType returns the Thrift type string for the given typeSpec,
+// including annotations on the type and any nested components. References to
 // named types defined in included modules are qualified with the include alias.
-func getType(typeSpec TypeSpec, module *Module) (string, error) {
+func getAnnotatedType(typeSpec TypeSpec, module *Module) (string, error) {
 	if typeSpec == nil {
 		return "", fmt.Errorf("typeSpec is nil")
 	}
 
 	switch t := typeSpec.(type) {
 	case *BoolSpec:
-		return "bool", nil
+		return appendTypeAnnotations(t.ThriftName(), t.Annotations), nil
 	case *I8Spec:
-		return "i8", nil
+		return appendTypeAnnotations(t.ThriftName(), t.Annotations), nil
 	case *I16Spec:
-		return "i16", nil
+		return appendTypeAnnotations(t.ThriftName(), t.Annotations), nil
 	case *I32Spec:
-		return "i32", nil
+		return appendTypeAnnotations(t.ThriftName(), t.Annotations), nil
 	case *I64Spec:
-		return "i64", nil
+		return appendTypeAnnotations(t.ThriftName(), t.Annotations), nil
 	case *DoubleSpec:
-		return "double", nil
+		return appendTypeAnnotations(t.ThriftName(), t.Annotations), nil
 	case *StringSpec:
-		return "string", nil
+		return appendTypeAnnotations(t.ThriftName(), t.Annotations), nil
 	case *BinarySpec:
-		return "binary", nil
+		return appendTypeAnnotations(t.ThriftName(), t.Annotations), nil
 	case *ListSpec:
-		typeName, err := getType(t.ValueSpec, module)
+		valueType, err := getAnnotatedType(t.ValueSpec, module)
 		if err != nil {
 			return "", fmt.Errorf("error while getting type string for list %s : %w", t.ValueSpec.ThriftName(), err)
 		}
-		return fmt.Sprintf("list<%s>", typeName), nil
+		return appendTypeAnnotations(fmt.Sprintf("list<%s>", valueType), t.Annotations), nil
 
 	case *SetSpec:
-		typeName, err := getType(t.ValueSpec, module)
+		valueType, err := getAnnotatedType(t.ValueSpec, module)
 		if err != nil {
 			return "", fmt.Errorf("error while getting type string for set %s : %w", t.ValueSpec.ThriftName(), err)
 		}
-		return fmt.Sprintf("set<%s>", typeName), nil
+		return appendTypeAnnotations(fmt.Sprintf("set<%s>", valueType), t.Annotations), nil
 
 	case *MapSpec:
-		keyType, err := getType(t.KeySpec, module)
+		keyType, err := getAnnotatedType(t.KeySpec, module)
 		if err != nil {
 			return "", fmt.Errorf("error while getting type string for map key %s : %w", t.KeySpec.ThriftName(), err)
 		}
-		valueType, err := getType(t.ValueSpec, module)
+		valueType, err := getAnnotatedType(t.ValueSpec, module)
 		if err != nil {
 			return "", fmt.Errorf("error while getting type string for map value %s : %w", t.ValueSpec.ThriftName(), err)
 		}
-		return fmt.Sprintf("map<%s, %s>", keyType, valueType), nil
+		return appendTypeAnnotations(fmt.Sprintf("map<%s, %s>", keyType, valueType), t.Annotations), nil
 
 	case *TypedefSpec:
 		return getQualifiedTypeName(t.Name, t.File, module)
@@ -487,6 +499,15 @@ func getType(typeSpec TypeSpec, module *Module) (string, error) {
 	}
 
 	return "", fmt.Errorf("unknown type: %T in thrift file: %s", typeSpec, module.ThriftPath)
+}
+
+// appendTypeAnnotations appends Thrift type annotations to a type string when
+// present, e.g. "string" + (go.name = "x") -> `string (go.name = "x")`.
+func appendTypeAnnotations(typeStr string, annotations Annotations) string {
+	if typeAnnotations := getAnnotations(annotations); typeAnnotations != "" {
+		return typeStr + " " + typeAnnotations
+	}
+	return typeStr
 }
 
 // getAnnotations converts annotations to their Thrift string representation,
@@ -606,31 +627,14 @@ func writeStruct(builder *strings.Builder, structSpec *StructSpec, module *Modul
 			builder.WriteString("optional ")
 		}
 
-		fieldType, err := getType(field.Type, module)
+		fieldType, err := getAnnotatedType(field.Type, module)
 		if err != nil {
 			return fmt.Errorf("error while getting type string for field %s : %w in thrift file: %s", field.Name, err, module.ThriftPath)
 		}
 		builder.WriteString(fieldType + " ")
 
-		// Annotations carried by the field's (scalar) type spec.
-		if isScalarField(field) {
-			if typeSpecAnnotations := getAnnotations(field.Type.ThriftAnnotations()); typeSpecAnnotations != "" {
-				builder.WriteString(typeSpecAnnotations + " ")
-			}
-		}
-
-		builder.WriteString(field.Name)
-
-		if field.Default != nil {
-			defaultValue, err := constantValueToString(field.Default, module, 0)
-			if err != nil {
-				return fmt.Errorf("error while getting default value for field %s in thrift file: %s : %w", field.Name, module.ThriftPath, err)
-			}
-			builder.WriteString(" = " + defaultValue)
-		}
-
-		if annotations := getAnnotations(field.Annotations); annotations != "" {
-			builder.WriteString(" " + annotations)
+		if err := writeFieldNameDefaultAndAnnotations(builder, field, module); err != nil {
+			return fmt.Errorf("error while writing field %s in thrift file: %s : %w", field.Name, module.ThriftPath, err)
 		}
 
 		builder.WriteString("\n")
@@ -646,13 +650,86 @@ func writeStruct(builder *strings.Builder, structSpec *StructSpec, module *Modul
 	return nil
 }
 
-// isScalarField reports whether the field's type is a primitive Thrift type.
-func isScalarField(field *FieldSpec) bool {
-	switch field.Type.(type) {
-	case *BoolSpec, *I8Spec, *I16Spec, *I32Spec, *I64Spec, *DoubleSpec, *StringSpec, *BinarySpec:
-		return true
+// writeFieldNameDefaultAndAnnotations writes a field's name, optional default
+// value, and field-level annotations.
+func writeFieldNameDefaultAndAnnotations(builder *strings.Builder, field *FieldSpec, module *Module) error {
+	builder.WriteString(field.Name)
+
+	if field.Default != nil {
+		defaultValue, err := constantValueToString(field.Default, module, 0)
+		if err != nil {
+			return err
+		}
+		builder.WriteString(" = " + defaultValue)
 	}
-	return false
+
+	if annotations := getAnnotations(field.Annotations); annotations != "" {
+		builder.WriteString(" " + annotations)
+	}
+
+	return nil
+}
+
+// writeFunctionFields writes function parameters or throws-clause exception
+// fields. When any field has a docstring, fields are emitted one per line;
+// otherwise they are comma-separated inline.
+func writeFunctionFields(builder *strings.Builder, fields FieldGroup, module *Module, functionName, fieldKind string) error {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	multiline := false
+	for _, field := range fields {
+		if field.Doc != "" {
+			multiline = true
+			break
+		}
+	}
+
+	paramIndent := "    "
+	for i, field := range fields {
+		if i > 0 {
+			if multiline {
+				builder.WriteString(",\n")
+			} else {
+				builder.WriteString(", ")
+			}
+		} else if multiline {
+			builder.WriteString("\n")
+		}
+
+		if multiline {
+			writeIndentedDocumentation(builder, field.Doc, paramIndent)
+			builder.WriteString(paramIndent)
+		}
+
+		builder.WriteString(fmt.Sprintf("%d: ", field.ID))
+		if field.Required {
+			builder.WriteString("required ")
+		}
+
+		fieldType, err := getAnnotatedType(field.Type, module)
+		if err != nil {
+			return fmt.Errorf(
+				"error while getting data type for function %s %s in thrift file: %s : %w",
+				fieldKind, field.Name, module.ThriftPath, err,
+			)
+		}
+		builder.WriteString(fieldType + " ")
+
+		if err := writeFieldNameDefaultAndAnnotations(builder, field, module); err != nil {
+			return fmt.Errorf(
+				"error while writing function %s %s for function %s in thrift file: %s : %w",
+				fieldKind, field.Name, functionName, module.ThriftPath, err,
+			)
+		}
+	}
+
+	if multiline {
+		builder.WriteString("\n  ")
+	}
+
+	return nil
 }
 
 // writeServices writes service definitions, including their functions,
@@ -687,7 +764,7 @@ func writeServices(builder *strings.Builder, module *Module) error {
 			}
 
 			if function.ResultSpec != nil && function.ResultSpec.ReturnType != nil {
-				returnType, err := getType(function.ResultSpec.ReturnType, module)
+				returnType, err := getAnnotatedType(function.ResultSpec.ReturnType, module)
 				if err != nil {
 					return fmt.Errorf("error while getting return type %s : %w in thrift file: %s", function.ResultSpec.ReturnType.ThriftName(), err, module.ThriftPath)
 				}
@@ -698,40 +775,16 @@ func writeServices(builder *strings.Builder, module *Module) error {
 
 			builder.WriteString(fname + "(")
 
-			for i, arg := range FieldGroup(function.ArgsSpec) {
-				if i > 0 {
-					builder.WriteString(", ")
-				}
-
-				fieldType, err := getType(arg.Type, module)
-				if err != nil {
-					return fmt.Errorf("error while getting data type for function argument %s for function %s in thrift file: %s : %w", arg.Name, function.Name, module.ThriftPath, err)
-				}
-				if arg.Required {
-					builder.WriteString(fmt.Sprintf("%d: required %s %s", arg.ID, fieldType, arg.Name))
-				} else {
-					builder.WriteString(fmt.Sprintf("%d: %s %s", arg.ID, fieldType, arg.Name))
-				}
+			if err := writeFunctionFields(builder, FieldGroup(function.ArgsSpec), module, function.Name, "argument"); err != nil {
+				return err
 			}
 
 			builder.WriteString(")")
 
 			if function.ResultSpec != nil && len(function.ResultSpec.Exceptions) > 0 {
 				builder.WriteString(" throws (")
-				for i, exc := range function.ResultSpec.Exceptions {
-					if i > 0 {
-						builder.WriteString(", ")
-					}
-
-					fieldType, err := getType(exc.Type, module)
-					if err != nil {
-						return fmt.Errorf("error while getting data type for exception %s in thrift file: %s : %w", exc.Name, module.ThriftPath, err)
-					}
-					if exc.Required {
-						builder.WriteString(fmt.Sprintf("%d: required %s %s", exc.ID, fieldType, exc.Name))
-					} else {
-						builder.WriteString(fmt.Sprintf("%d: %s %s", exc.ID, fieldType, exc.Name))
-					}
+				if err := writeFunctionFields(builder, function.ResultSpec.Exceptions, module, function.Name, "exception"); err != nil {
+					return err
 				}
 				builder.WriteString(")")
 			}

--- a/compile/generate_test.go
+++ b/compile/generate_test.go
@@ -194,15 +194,49 @@ func TestGenerateThriftFile_NilModule(t *testing.T) {
 	assert.Error(t, m.GenerateThriftFile(filepath.Join(t.TempDir(), "out.thrift")))
 }
 
+// TestGenerateThriftFile_IncludeRelativeToOutputDir verifies that when the
+// generated file is written to a directory different from the source module's
+// directory, the emitted include statement is computed relative to the output
+// file's location so the generated file recompiles correctly.
+func TestGenerateThriftFile_IncludeRelativeToOutputDir(t *testing.T) {
+	srcDir, mainPath := writeGenerateTestFiles(t)
+
+	original, err := Compile(mainPath)
+	require.NoError(t, err, "compiling source thrift")
+
+	// Write the generated file to a sibling directory. The included.thrift
+	// file remains only in srcDir, so the emitted include must traverse
+	// upwards (e.g. "../src/included.thrift") for recompilation to succeed.
+	outDir := filepath.Join(filepath.Dir(srcDir), "out")
+	require.NoError(t, os.MkdirAll(outDir, 0o755))
+	outPath := filepath.Join(outDir, "out_main.thrift")
+
+	require.NoError(t, original.GenerateThriftFile(outPath), "generating thrift file")
+
+	generated, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	expectedRel, err := filepath.Rel(outDir, filepath.Join(srcDir, "included.thrift"))
+	require.NoError(t, err)
+	assert.Contains(t, string(generated), `include "`+expectedRel+`"`,
+		"include should be relative to the output file's directory")
+
+	// The generated file must recompile: this proves the include actually
+	// resolves from the output directory, not just that the string looks right.
+	recompiled, err := Compile(outPath)
+	require.NoError(t, err, "recompiling generated thrift from a different directory")
+	assert.Equal(t, len(original.Includes), len(recompiled.Includes), "include count preserved")
+}
+
 func TestModuleThriftIDL_Deterministic(t *testing.T) {
 	_, mainPath := writeGenerateTestFiles(t)
 
 	m, err := Compile(mainPath)
 	require.NoError(t, err)
 
-	first, err := m.thriftIDL()
+	first, err := m.thriftIDL(mainPath)
 	require.NoError(t, err)
-	second, err := m.thriftIDL()
+	second, err := m.thriftIDL(mainPath)
 	require.NoError(t, err)
 
 	assert.Equal(t, first, second, "generated output should be deterministic across runs")

--- a/compile/generate_test.go
+++ b/compile/generate_test.go
@@ -21,13 +21,17 @@
 package compile
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/thriftrw/ast"
+	"go.uber.org/thriftrw/wire"
 )
 
 const generateTestIncludedThrift = `
@@ -189,6 +193,177 @@ func TestGenerateThriftFile_RoundTrip(t *testing.T) {
 	})
 }
 
+func TestGenerateThriftFile_Annotations(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.thrift")
+	thrift := `
+namespace go main
+
+typedef set<string> (go.type = "slice") StringList
+typedef i64 (js.type = "Long") Timestamp (unit = "ms")
+
+service API {
+  oneway void notify(1: string msg = "hello" (go.name = "Message"))
+}
+`
+	require.NoError(t, os.WriteFile(mainPath, []byte(thrift), 0o644))
+
+	original, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "out.thrift")
+	require.NoError(t, original.GenerateThriftFile(outPath))
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	generated := string(content)
+
+	assert.Contains(t, generated, `typedef set<string> (go.type = "slice") StringList`)
+	assert.Contains(t, generated, `typedef i64 (js.type = "Long") Timestamp (unit = "ms")`)
+	assert.Contains(t, generated, `oneway void notify(1: string msg = "hello" (go.name = "Message"))`)
+
+	recompiled, err := Compile(outPath)
+	require.NoError(t, err, "recompiling generated thrift with annotations")
+
+	stringList, ok := recompiled.Types["StringList"].(*TypedefSpec)
+	require.True(t, ok)
+	assert.Equal(t, Annotations{"go.type": "slice"}, stringList.Target.ThriftAnnotations())
+
+	timestamp, ok := recompiled.Types["Timestamp"].(*TypedefSpec)
+	require.True(t, ok)
+	assert.Equal(t, Annotations{"js.type": "Long"}, timestamp.Target.ThriftAnnotations())
+	assert.Equal(t, Annotations{"unit": "ms"}, timestamp.Annotations)
+
+	notifyArg := recompiled.Services["API"].Functions["notify"].ArgsSpec[0]
+	assert.Equal(t, Annotations{"go.name": "Message"}, notifyArg.Annotations)
+	require.NotNil(t, notifyArg.Default)
+}
+
+func TestGenerateThriftFile_AnnotatedTypes(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.thrift")
+	thrift := `
+namespace go main
+
+const list<string (go.name = "x")> ListConst = ["a"]
+const list<i32> (deprecated) DeprecatedList = [1]
+
+struct ContainerField {
+  1: optional list<i32 (obfuscate)> (c = "d") items
+  2: optional map<string, string (a = "b")> (m = "n") mapping
+}
+
+typedef list<string (inner = "v")> (outer = "w") NestedTypedef
+
+exception E {
+  1: required string message
+}
+
+service S {
+  list<string (foo = "bar")> search(
+    /** query id */
+    1: i32 q
+  )
+  void get() throws (1: E err (http.status = "404"))
+}
+`
+	require.NoError(t, os.WriteFile(mainPath, []byte(thrift), 0o644))
+
+	original, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "out.thrift")
+	require.NoError(t, original.GenerateThriftFile(outPath))
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	generated := string(content)
+
+	assert.Contains(t, generated, `const list<string (go.name = "x")> ListConst`)
+	assert.Contains(t, generated, `const list<i32> (deprecated) DeprecatedList`)
+	assert.Contains(t, generated, `1: optional list<i32 (obfuscate)> (c = "d") items`)
+	assert.Contains(t, generated, `2: optional map<string, string (a = "b")> (m = "n") mapping`)
+	assert.Contains(t, generated, `typedef list<string (inner = "v")> (outer = "w") NestedTypedef`)
+	assert.Contains(t, generated, `list<string (foo = "bar")> search(`)
+	assert.Contains(t, generated, `query id`)
+	assert.Contains(t, generated, `throws (1: E err (http.status = "404"))`)
+
+	recompiled, err := Compile(outPath)
+	require.NoError(t, err, "recompiling generated thrift with annotated types")
+
+	listConst := recompiled.Constants["ListConst"].Type.(*ListSpec)
+	assert.Equal(t, Annotations{"go.name": "x"}, listConst.ValueSpec.ThriftAnnotations())
+
+	deprecatedList := recompiled.Constants["DeprecatedList"].Type.(*ListSpec)
+	assert.Equal(t, Annotations{"deprecated": ""}, deprecatedList.ThriftAnnotations())
+
+	itemsField := recompiled.Types["ContainerField"].(*StructSpec).Fields[0]
+	listField := itemsField.Type.(*ListSpec)
+	assert.Equal(t, Annotations{"obfuscate": ""}, listField.ValueSpec.ThriftAnnotations())
+	assert.Equal(t, Annotations{"c": "d"}, listField.ThriftAnnotations())
+
+	searchArg := recompiled.Services["S"].Functions["search"].ArgsSpec[0]
+	assert.Equal(t, "query id", searchArg.Doc)
+
+	throwsExc := recompiled.Services["S"].Functions["get"].ResultSpec.Exceptions[0]
+	assert.Equal(t, Annotations{"http.status": "404"}, throwsExc.Annotations)
+}
+
+func TestGenerateThriftFile_PrimitiveTypeNames(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.thrift")
+	thrift := `
+namespace go main
+
+typedef byte ByteAlias
+typedef i64 Timestamp
+
+struct Primitives {
+  1: required bool flag
+  2: required byte raw
+  3: required i16 small
+  4: required i32 count
+  5: required i64 big
+  6: required double ratio
+  7: required string name
+  8: required binary data
+  9: required byte (go.name = "Tagged") tagged
+}
+
+service S {
+  byte echo(1: byte input)
+}
+`
+	require.NoError(t, os.WriteFile(mainPath, []byte(thrift), 0o644))
+
+	original, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "out.thrift")
+	require.NoError(t, original.GenerateThriftFile(outPath))
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	generated := string(content)
+
+	// I8Spec.ThriftName() is "byte"; generation must not hardcode "i8".
+	assert.Contains(t, generated, "typedef byte ByteAlias")
+	assert.Contains(t, generated, "2: required byte raw")
+	assert.Contains(t, generated, "8: required binary data")
+	assert.Contains(t, generated, "9: required byte (go.name = \"Tagged\") tagged")
+	assert.Contains(t, generated, "byte echo(1: byte input)")
+	assert.NotContains(t, generated, " i8 ")
+
+	recompiled, err := Compile(outPath)
+	require.NoError(t, err, "recompiling generated thrift with primitive type names")
+
+	byteField := recompiled.Types["Primitives"].(*StructSpec).Fields[1]
+	assert.IsType(t, &I8Spec{}, byteField.Type)
+
+	echoArg := recompiled.Services["S"].Functions["echo"].ArgsSpec[0]
+	assert.IsType(t, &I8Spec{}, echoArg.Type)
+}
+
 func TestGenerateThriftFile_NilModule(t *testing.T) {
 	var m *Module
 	assert.Error(t, m.GenerateThriftFile(filepath.Join(t.TempDir(), "out.thrift")))
@@ -240,4 +415,882 @@ func TestModuleThriftIDL_Deterministic(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, first, second, "generated output should be deterministic across runs")
+}
+
+// unknownGenerateType is a TypeSpec outside the set handled by getAnnotatedType.
+type unknownGenerateType struct{ nativeThriftType }
+
+func (unknownGenerateType) ThriftName() string                            { return "unknown" }
+func (unknownGenerateType) ThriftAnnotations() Annotations                { return nil }
+func (unknownGenerateType) Link(Scope) (TypeSpec, error)                  { return nil, nil }
+func (unknownGenerateType) TypeCode() wire.Type                           { return wire.TI32 }
+func (unknownGenerateType) ForEachTypeReference(func(TypeSpec) error) error { return nil }
+
+type fakeConstantValue struct{}
+
+func (fakeConstantValue) Link(Scope, TypeSpec) (ConstantValue, error) { return nil, nil }
+
+func TestGenerateThriftFile_ConstantValues(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.thrift")
+	thrift := `
+namespace go main
+
+const i32 Seed = 7
+const i32 Ref = Seed
+const bool Flag = false
+const double Ratio = 1.5
+const set<i32> Values = [1, 2]
+const list<i32> EmptyList = []
+const map<string, i32> EmptyMap = {}
+
+struct Payload {
+  1: required bool ok
+  2: required string msg
+}
+const Payload DefaultPayload = {"ok": false, "msg": "hi"}
+`
+	require.NoError(t, os.WriteFile(mainPath, []byte(thrift), 0o644))
+
+	m, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "out.thrift")
+	require.NoError(t, m.GenerateThriftFile(outPath))
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	generated := string(content)
+
+	assert.Contains(t, generated, "const bool Flag = false")
+	assert.Contains(t, generated, "const double Ratio = 1.5")
+	assert.Contains(t, generated, "const i32 Ref = 7")
+	assert.Contains(t, generated, "const set<i32> Values")
+	assert.Contains(t, generated, "const list<i32> EmptyList = []")
+	assert.Contains(t, generated, "const map<string, i32> EmptyMap = {}")
+	assert.Contains(t, generated, "const Payload DefaultPayload")
+	assert.Contains(t, generated, `"ok": false`)
+	assert.Contains(t, generated, `"msg": "hi"`)
+}
+
+func TestGenerateThriftFile_IncludedServiceParent(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "shared.thrift"), []byte(`
+namespace go shared
+
+service KeyValue {
+  void get()
+}
+`), 0o644))
+	mainPath := filepath.Join(dir, "main.thrift")
+	require.NoError(t, os.WriteFile(mainPath, []byte(`
+namespace go main
+
+include "shared.thrift"
+
+service BulkKeyValue extends shared.KeyValue {
+  void setValues(1: required map<string, binary> items)
+}
+`), 0o644))
+
+	m, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "out.thrift")
+	require.NoError(t, m.GenerateThriftFile(outPath))
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	generated := string(content)
+
+	assert.Contains(t, generated, "service BulkKeyValue extends shared.KeyValue")
+	assert.Contains(t, generated, "1: required map<string, binary> items")
+}
+
+func TestGenerateThriftFile_EnumDetails(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.thrift")
+	thrift := `
+namespace go main
+
+/**
+ * Status codes.
+ */
+enum Status {
+  /** ok */
+  OK = 0 (stable),
+  FAIL = 1,
+} (go.name = "StatusCode")
+`
+	require.NoError(t, os.WriteFile(mainPath, []byte(thrift), 0o644))
+
+	m, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "out.thrift")
+	require.NoError(t, m.GenerateThriftFile(outPath))
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	generated := string(content)
+
+	assert.Contains(t, generated, "Status codes")
+	assert.Contains(t, generated, "OK = 0 (stable)")
+	assert.Contains(t, generated, "} (go.name = \"StatusCode\")")
+}
+
+func TestGenerateThriftFile_NoNamespaces(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.thrift")
+	require.NoError(t, os.WriteFile(mainPath, []byte(`
+struct Empty {}
+`), 0o644))
+
+	m, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "out.thrift")
+	require.NoError(t, m.GenerateThriftFile(outPath))
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "struct Empty")
+	assert.NotContains(t, string(content), "namespace")
+}
+
+func TestGenerateThriftFile_CreatesNestedOutputDirectory(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.thrift")
+	require.NoError(t, os.WriteFile(mainPath, []byte("struct S { 1: required i32 x }"), 0o644))
+
+	m, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "nested", "deep", "out.thrift")
+	require.NoError(t, m.GenerateThriftFile(outPath))
+	assert.FileExists(t, outPath)
+}
+
+func TestGenerateThriftFile_WriteBlockedByFile(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o644))
+
+	m := &Module{ThriftPath: filepath.Join(dir, "main.thrift")}
+	err := m.GenerateThriftFile(filepath.Join(blocker, "out.thrift"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create directory")
+}
+
+func TestGenerateThriftFile_ThriftIDLError(t *testing.T) {
+	m := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Includes: map[string]*IncludedModule{
+			"bad": {Name: "bad", Module: nil},
+		},
+	}
+	err := m.GenerateThriftFile(filepath.Join(t.TempDir(), "out.thrift"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "generate thrift content")
+}
+
+func TestWriteIncludes_NilIncludedModule(t *testing.T) {
+	var b strings.Builder
+	m := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Includes: map[string]*IncludedModule{
+			"bad": {Name: "bad", Module: nil},
+		},
+	}
+	err := writeIncludes(&b, m, "/tmp/out.thrift")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "included module")
+}
+
+func TestWriteConstants_SkipsNilConstant(t *testing.T) {
+	var b strings.Builder
+	m := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Constants: map[string]*Constant{
+			"skip": nil,
+			"ok": {
+				Name:  "ok",
+				Type:  &I32Spec{},
+				Value: ConstantInt(1),
+			},
+		},
+	}
+	require.NoError(t, writeConstants(&b, m))
+	assert.Contains(t, b.String(), "const i32 ok = 1")
+}
+
+func TestConstantValueToString_AllBranches(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+
+	boolStr, err := constantValueToString(ConstantBool(false), module, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "false", boolStr)
+
+	doubleStr, err := constantValueToString(ConstantDouble(2.5), module, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "2.5", doubleStr)
+
+	setStr, err := constantValueToString(ConstantSet{ConstantInt(1)}, module, 0)
+	require.NoError(t, err)
+	assert.Contains(t, setStr, "1")
+
+	enum := &EnumSpec{
+		Name: "Color",
+		File: "/tmp/main.thrift",
+		Items: []EnumItem{
+			{Name: "RED", Value: 0},
+		},
+	}
+	enumRef, err := constantValueToString(EnumItemReference{
+		Enum: enum,
+		Item: &enum.Items[0],
+	}, module, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "Color.RED", enumRef)
+
+	_, err = constantValueToString(ConstReference{}, module, 0)
+	require.Error(t, err)
+
+	_, err = constantValueToString(EnumItemReference{}, module, 0)
+	require.Error(t, err)
+
+	_, err = constantValueToString(fakeConstantValue{}, module, 0)
+	require.Error(t, err)
+}
+
+func TestConstantStructToString(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+
+	empty, err := constantStructToString(&ConstantStruct{}, module, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", empty)
+
+	nilStruct, err := constantStructToString(nil, module, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", nilStruct)
+
+	populated, err := constantStructToString(&ConstantStruct{
+		Fields: map[string]ConstantValue{
+			"b": ConstantInt(2),
+			"a": ConstantInt(1),
+		},
+	}, module, 0)
+	require.NoError(t, err)
+	assert.Contains(t, populated, `"a": 1`)
+	assert.Contains(t, populated, `"b": 2`)
+}
+
+func TestGetAnnotatedType_Errors(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+
+	_, err := getAnnotatedType(nil, module)
+	require.Error(t, err)
+
+	_, err = getAnnotatedType(unknownGenerateType{}, module)
+	require.Error(t, err)
+
+	_, err = getAnnotatedType(typeSpecReference{Name: "Missing"}, module)
+	require.Error(t, err)
+}
+
+func TestGetQualifiedTypeName_Error(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+	_, err := getQualifiedTypeName("Foo", "/other/other.thrift", module)
+	require.Error(t, err)
+}
+
+func TestGetOriginalServiceParentName(t *testing.T) {
+	module := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Includes: map[string]*IncludedModule{
+			"shared": {
+				Name: "shared",
+				Module: &Module{
+					ThriftPath: "/tmp/shared.thrift",
+				},
+			},
+		},
+	}
+
+	localParent := &ServiceSpec{Name: "Base", File: "/tmp/main.thrift"}
+	name, err := getOriginalServiceParentName(module, "API", localParent)
+	require.NoError(t, err)
+	assert.Equal(t, "Base", name)
+
+	includedParent := &ServiceSpec{Name: "KeyValue", File: "/tmp/shared.thrift"}
+	name, err = getOriginalServiceParentName(module, "Bulk", includedParent)
+	require.NoError(t, err)
+	assert.Equal(t, "shared.KeyValue", name)
+
+	_, err = getOriginalServiceParentName(module, "API", nil)
+	require.Error(t, err)
+
+	missingParent := &ServiceSpec{Name: "Missing", File: "/tmp/missing.thrift"}
+	_, err = getOriginalServiceParentName(module, "API", missingParent)
+	require.Error(t, err)
+}
+
+func TestWriteTypedefWriteEnumWriteStruct_Errors(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+	var b strings.Builder
+
+	require.Error(t, writeTypedef(&b, nil, module))
+	require.Error(t, writeEnum(&b, nil))
+	require.Error(t, writeStruct(&b, nil, module))
+
+	b.Reset()
+	require.Error(t, writeTypedef(&b, &TypedefSpec{
+		Name:   "Bad",
+		Target: unknownGenerateType{},
+	}, module))
+
+	b.Reset()
+	require.Error(t, writeStruct(&b, &StructSpec{
+		Name: "Bad",
+		Type: ast.StructureType(99),
+	}, module))
+}
+
+func TestWriteFieldNameDefaultAndAnnotations_Error(t *testing.T) {
+	var b strings.Builder
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+	field := &FieldSpec{
+		Name:    "bad",
+		Default: ConstReference{},
+	}
+	err := writeFieldNameDefaultAndAnnotations(&b, field, module)
+	require.Error(t, err)
+}
+
+func TestWriteFunctionFields_MultilineAndErrors(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+	var b strings.Builder
+
+	require.NoError(t, writeFunctionFields(&b, nil, module, "fn", "argument"))
+
+	b.Reset()
+	fields := FieldGroup{
+		{ID: 1, Name: "a", Type: &I32Spec{}, Doc: "first", Required: true},
+		{ID: 2, Name: "b", Type: &StringSpec{}},
+	}
+	require.NoError(t, writeFunctionFields(&b, fields, module, "fn", "argument"))
+	assert.Contains(t, b.String(), "first")
+	assert.Contains(t, b.String(), "required")
+
+	b.Reset()
+	require.Error(t, writeFunctionFields(&b, FieldGroup{
+		{ID: 1, Name: "bad", Type: unknownGenerateType{}},
+	}, module, "fn", "argument"))
+
+	b.Reset()
+	require.Error(t, writeFunctionFields(&b, FieldGroup{
+		{ID: 1, Name: "bad", Default: ConstReference{}},
+	}, module, "fn", "exception"))
+}
+
+func TestWriteServices_ParentResolutionError(t *testing.T) {
+	var b strings.Builder
+	module := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Services: map[string]*ServiceSpec{
+			"Broken": {
+				Name: "Broken",
+				File: "/tmp/main.thrift",
+				Parent: &ServiceSpec{
+					Name: "Missing",
+					File: "/tmp/missing.thrift",
+				},
+			},
+		},
+	}
+	err := writeServices(&b, module)
+	require.Error(t, err)
+}
+
+func TestSortTypesByKind_UnknownTypePriority(t *testing.T) {
+	module := &Module{
+		Types: map[string]TypeSpec{
+			"orphan": &I32Spec{},
+		},
+	}
+	names := sortTypesByKind(module)
+	require.Equal(t, []string{"orphan"}, names)
+}
+
+func TestConstantMapToString_EmptyAndPopulated(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+
+	empty, err := constantMapToString(ConstantMap{}, module, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", empty)
+
+	populated, err := constantMapToString(ConstantMap{
+		{Key: ConstantString("k"), Value: ConstantInt(1)},
+	}, module, 0)
+	require.NoError(t, err)
+	assert.Contains(t, populated, `"k": 1`)
+}
+
+func TestConstantSliceToString_Empty(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+	out, err := constantSliceToString(nil, module, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", out)
+}
+
+func TestConstReference_QualifiedName(t *testing.T) {
+	module := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Includes: map[string]*IncludedModule{
+			"shared": {
+				Name: "shared",
+				Module: &Module{
+					ThriftPath: "/tmp/shared.thrift",
+					Constants: map[string]*Constant{
+						"Seed": {Name: "Seed", File: "/tmp/shared.thrift"},
+					},
+				},
+			},
+		},
+	}
+	target := module.Includes["shared"].Module.Constants["Seed"]
+	out, err := constantValueToString(ConstReference{Target: target}, module, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "shared.Seed", out)
+}
+
+func TestGenerateThriftFile_WriteFileError(t *testing.T) {
+	dir := t.TempDir()
+	m := &Module{ThriftPath: filepath.Join(dir, "main.thrift")}
+	err := m.GenerateThriftFile(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write thrift file")
+}
+
+func TestThriftIDL_ErrorPropagation(t *testing.T) {
+	badConstants := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Constants: map[string]*Constant{
+			"bad": {Name: "bad", Type: unknownGenerateType{}, Value: ConstantInt(1)},
+		},
+	}
+	_, err := badConstants.thriftIDL("/tmp/out.thrift")
+	require.Error(t, err)
+
+	badTypes := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Types: map[string]TypeSpec{
+			"bad": &TypedefSpec{Name: "bad", Target: unknownGenerateType{}},
+		},
+	}
+	_, err = badTypes.thriftIDL("/tmp/out.thrift")
+	require.Error(t, err)
+
+	badServices := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Services: map[string]*ServiceSpec{
+			"Broken": {
+				Name:   "Broken",
+				File:   "/tmp/main.thrift",
+				Parent: &ServiceSpec{Name: "Missing", File: "/tmp/missing.thrift"},
+			},
+		},
+	}
+	_, err = badServices.thriftIDL("/tmp/out.thrift")
+	require.Error(t, err)
+}
+
+func TestWriteConstants_Errors(t *testing.T) {
+	var b strings.Builder
+	require.Error(t, writeConstants(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Constants: map[string]*Constant{
+			"badType": {Name: "badType", Type: unknownGenerateType{}, Value: ConstantInt(1)},
+		},
+	}))
+
+	b.Reset()
+	require.Error(t, writeConstants(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Constants: map[string]*Constant{
+			"badValue": {Name: "badValue", Type: &I32Spec{}, Value: fakeConstantValue{}},
+		},
+	}))
+
+	b.Reset()
+	require.NoError(t, writeConstants(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Constants: map[string]*Constant{
+			"ok": {Name: "ok", Type: &BoolSpec{}, Value: ConstantBool(true), Doc: "doc"},
+		},
+	}))
+	assert.Contains(t, b.String(), "const bool ok = true")
+	assert.Contains(t, b.String(), "doc")
+}
+
+func TestWriteTypes_Errors(t *testing.T) {
+	var b strings.Builder
+	require.Error(t, writeTypes(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Types: map[string]TypeSpec{
+			"badTypedef": &TypedefSpec{Name: "badTypedef", Target: unknownGenerateType{}},
+		},
+	}))
+
+	b.Reset()
+	require.Error(t, writeTypes(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Types: map[string]TypeSpec{
+			"badStruct": &StructSpec{Name: "badStruct", Type: ast.StructureType(99)},
+		},
+	}))
+}
+
+func TestGetAnnotatedType_ContainerErrors(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+
+	_, err := getAnnotatedType(&ListSpec{ValueSpec: unknownGenerateType{}}, module)
+	require.Error(t, err)
+
+	_, err = getAnnotatedType(&SetSpec{ValueSpec: unknownGenerateType{}}, module)
+	require.Error(t, err)
+
+	_, err = getAnnotatedType(&MapSpec{KeySpec: unknownGenerateType{}, ValueSpec: &I32Spec{}}, module)
+	require.Error(t, err)
+
+	_, err = getAnnotatedType(&MapSpec{KeySpec: &StringSpec{}, ValueSpec: unknownGenerateType{}}, module)
+	require.Error(t, err)
+}
+
+func TestWriteStruct_SuccessAndFieldErrors(t *testing.T) {
+	var b strings.Builder
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+
+	require.NoError(t, writeStruct(&b, &StructSpec{
+		Name:        "Annotated",
+		Type:        ast.StructType,
+		Annotations: Annotations{"s": "v"},
+		Fields: FieldGroup{
+			{ID: 1, Name: "x", Type: &I32Spec{}, Required: true},
+			{ID: 2, Name: "y", Type: &StringSpec{}, Default: ConstantString("d")},
+		},
+	}, module))
+	assert.Contains(t, b.String(), "(s = \"v\")")
+	assert.Contains(t, b.String(), `= "d"`)
+
+	b.Reset()
+	require.Error(t, writeStruct(&b, &StructSpec{
+		Name:   "BadFieldType",
+		Type:   ast.StructType,
+		Fields: FieldGroup{{ID: 1, Name: "x", Type: unknownGenerateType{}}},
+	}, module))
+
+	b.Reset()
+	require.Error(t, writeStruct(&b, &StructSpec{
+		Name:   "BadDefault",
+		Type:   ast.StructType,
+		Fields: FieldGroup{{ID: 1, Name: "x", Type: &I32Spec{}, Default: ConstReference{}}},
+	}, module))
+}
+
+func TestWriteFunctionFields_InlineComma(t *testing.T) {
+	var b strings.Builder
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+	require.NoError(t, writeFunctionFields(&b, FieldGroup{
+		{ID: 1, Name: "a", Type: &I32Spec{}},
+		{ID: 2, Name: "b", Type: &StringSpec{}},
+	}, module, "fn", "argument"))
+	assert.Contains(t, b.String(), ", ")
+}
+
+func TestWriteServices_SuccessPaths(t *testing.T) {
+	var b strings.Builder
+	module := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Services: map[string]*ServiceSpec{
+			"S": {
+				Name:        "S",
+				File:        "/tmp/main.thrift",
+				Annotations: Annotations{"deprecated": ""},
+				Functions: map[string]*FunctionSpec{
+					"notify": {
+						Name:   "notify",
+						OneWay: true,
+						ArgsSpec: ArgsSpec{
+							{ID: 1, Name: "msg", Type: &StringSpec{}},
+						},
+					},
+					"fetch": {
+						Name: "fetch",
+						ArgsSpec: ArgsSpec{
+							{ID: 1, Name: "id", Type: &I32Spec{}, Required: true},
+						},
+						ResultSpec: &ResultSpec{
+							ReturnType: &StringSpec{},
+							Exceptions: FieldGroup{
+								{ID: 1, Name: "err", Type: &StructSpec{Name: "E", Type: ast.ExceptionType, File: "/tmp/main.thrift"}},
+							},
+						},
+						Annotations: Annotations{"http.method": "GET"},
+					},
+					"ping": {
+						Name:       "ping",
+						ResultSpec: &ResultSpec{},
+					},
+				},
+			},
+		},
+		Types: map[string]TypeSpec{
+			"E": &StructSpec{Name: "E", Type: ast.ExceptionType, File: "/tmp/main.thrift"},
+		},
+	}
+	require.NoError(t, writeServices(&b, module))
+	out := b.String()
+	assert.Contains(t, out, "oneway")
+	assert.Contains(t, out, "void ping()")
+	assert.Contains(t, out, "string fetch")
+	assert.Contains(t, out, "throws")
+	assert.Contains(t, out, "(http.method = \"GET\")")
+	assert.Contains(t, out, "(deprecated)")
+
+	b.Reset()
+	require.Error(t, writeServices(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Services: map[string]*ServiceSpec{
+			"BadReturn": {
+				Name: "BadReturn",
+				File: "/tmp/main.thrift",
+				Functions: map[string]*FunctionSpec{
+					"bad": {
+						Name: "bad",
+						ResultSpec: &ResultSpec{
+							ReturnType: unknownGenerateType{},
+						},
+					},
+				},
+			},
+		},
+	}))
+}
+
+func TestConstantValueToString_ErrorPaths(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+
+	_, err := constantValueToString(EnumItemReference{
+		Enum: &EnumSpec{Name: "E", File: "/tmp/other.thrift", Items: []EnumItem{{Name: "A", Value: 0}}},
+		Item: &EnumItem{Name: "A", Value: 0},
+	}, module, 0)
+	require.Error(t, err)
+
+	_, err = constantSliceToString([]ConstantValue{ConstReference{}}, module, 0)
+	require.Error(t, err)
+
+	_, err = constantMapToString(ConstantMap{
+		{Key: ConstantString("k"), Value: ConstReference{}},
+	}, module, 0)
+	require.Error(t, err)
+
+	_, err = constantStructToString(&ConstantStruct{
+		Fields: map[string]ConstantValue{"bad": ConstReference{}},
+	}, module, 0)
+	require.Error(t, err)
+}
+
+func TestGetTypePriority_UnknownStructKind(t *testing.T) {
+	priority := getTypePriority(&StructSpec{Name: "X", Type: ast.StructureType(99)})
+	assert.Equal(t, 5, priority)
+}
+
+func TestWriteServices_WriteFunctionFieldsError(t *testing.T) {
+	var b strings.Builder
+	err := writeServices(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Services: map[string]*ServiceSpec{
+			"S": {
+				Name: "S",
+				File: "/tmp/main.thrift",
+				Functions: map[string]*FunctionSpec{
+					"bad": {
+						Name: "bad",
+						ArgsSpec: ArgsSpec{
+							{ID: 1, Name: "x", Type: unknownGenerateType{}},
+						},
+						ResultSpec: &ResultSpec{},
+					},
+				},
+			},
+		},
+	})
+	require.Error(t, err)
+
+	b.Reset()
+	err = writeServices(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Services: map[string]*ServiceSpec{
+			"S": {
+				Name: "S",
+				File: "/tmp/main.thrift",
+				Functions: map[string]*FunctionSpec{
+					"badArgDefault": {
+						Name: "badArgDefault",
+						ArgsSpec: ArgsSpec{
+							{ID: 1, Name: "x", Type: &I32Spec{}, Default: ConstReference{}},
+						},
+						ResultSpec: &ResultSpec{},
+					},
+				},
+			},
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestWriteServices_ThrowsFieldError(t *testing.T) {
+	var b strings.Builder
+	err := writeServices(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Services: map[string]*ServiceSpec{
+			"S": {
+				Name: "S",
+				File: "/tmp/main.thrift",
+				Functions: map[string]*FunctionSpec{
+					"badThrows": {
+						Name: "badThrows",
+						ResultSpec: &ResultSpec{
+							Exceptions: FieldGroup{
+								{ID: 1, Name: "e", Type: &StructSpec{Name: "E", Type: ast.ExceptionType, File: "/tmp/main.thrift"}, Default: ConstReference{}},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestWriteTypes_NilEnumError(t *testing.T) {
+	var b strings.Builder
+	err := writeTypes(&b, &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Types: map[string]TypeSpec{
+			"bad": (*EnumSpec)(nil),
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "enum")
+}
+
+func TestGetAnnotatedType_TypedefReference(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+	out, err := getAnnotatedType(&TypedefSpec{
+		Name:   "Timestamp",
+		File:   "/tmp/main.thrift",
+		Target: &I64Spec{},
+	}, module)
+	require.NoError(t, err)
+	assert.Equal(t, "Timestamp", out)
+
+	_, err = getAnnotatedType(&TypedefSpec{
+		Name:   "Foreign",
+		File:   "/tmp/other/other.thrift",
+		Target: &I64Spec{},
+	}, module)
+	require.Error(t, err)
+}
+
+func TestConstantMapToString_KeyError(t *testing.T) {
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+	_, err := constantMapToString(ConstantMap{
+		{Key: ConstReference{}, Value: ConstantInt(1)},
+	}, module, 0)
+	require.Error(t, err)
+}
+
+func TestWriteFunctionFields_DefaultError(t *testing.T) {
+	var b strings.Builder
+	module := &Module{ThriftPath: "/tmp/main.thrift"}
+	err := writeFunctionFields(&b, FieldGroup{
+		{ID: 1, Name: "x", Type: &I32Spec{}, Default: ConstReference{}},
+	}, module, "fn", "argument")
+	require.Error(t, err)
+}
+
+func TestWriteIncludes_InvalidPaths(t *testing.T) {
+	var b strings.Builder
+	m := &Module{
+		ThriftPath: "/tmp/main.thrift",
+		Includes: map[string]*IncludedModule{
+			"shared": {
+				Name: "shared",
+				Module: &Module{
+					ThriftPath: "/tmp/shared.thrift",
+				},
+			},
+		},
+	}
+	require.NoError(t, writeIncludes(&b, m, "/tmp/out/out.thrift"))
+
+	oldAbs, oldRel := filepathAbs, filepathRel
+	t.Cleanup(func() {
+		filepathAbs = oldAbs
+		filepathRel = oldRel
+	})
+
+	b.Reset()
+	filepathAbs = func(string) (string, error) {
+		return "", fmt.Errorf("abs output dir failed")
+	}
+	err := writeIncludes(&b, m, "/tmp/out/out.thrift")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "output directory")
+
+	b.Reset()
+	filepathAbs = func(path string) (string, error) {
+		if path == "/tmp/shared.thrift" {
+			return "", fmt.Errorf("abs included failed")
+		}
+		return filepath.Abs(path)
+	}
+	err = writeIncludes(&b, m, "/tmp/out/out.thrift")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "included module")
+
+	b.Reset()
+	filepathAbs = filepath.Abs
+	filepathRel = func(string, string) (string, error) {
+		return "", fmt.Errorf("rel failed")
+	}
+	err = writeIncludes(&b, m, "/tmp/out/out.thrift")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "include path")
+}
+
+func TestGenerateThriftFile_TypedefFieldReference(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.thrift")
+	require.NoError(t, os.WriteFile(mainPath, []byte(`
+namespace go main
+
+typedef i64 Timestamp
+
+struct Event {
+  1: required Timestamp createdAt
+}
+`), 0o644))
+
+	m, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	outPath := filepath.Join(dir, "out.thrift")
+	require.NoError(t, m.GenerateThriftFile(outPath))
+
+	content, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "1: required Timestamp createdAt")
 }

--- a/compile/generate_test.go
+++ b/compile/generate_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package compile
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const generateTestIncludedThrift = `
+namespace go shared
+
+struct Shared {
+  1: required string id
+}
+`
+
+const generateTestMainThrift = `
+namespace go main
+namespace java com.example.main
+
+include "included.thrift"
+
+const i32 MaxRetries = 3
+const string Greeting = "hello\n\"world\""
+const list<i32> Primes = [2, 3, 5]
+const map<string, i32> Scores = {"a": 1, "b": 2}
+
+typedef i64 Timestamp
+typedef list<string> StringList
+
+enum Color {
+  RED = 0,
+  GREEN = 1,
+  BLUE = 2
+}
+
+struct Point {
+  1: required i32 x
+  2: optional i32 y = 10
+  3: optional Color color = Color.RED
+  4: optional included.Shared shared
+}
+
+union Value {
+  1: i32 intValue
+  2: string strValue
+}
+
+exception NotFound {
+  1: required string message
+}
+
+service Base {
+  void ping()
+}
+
+service API extends Base {
+  oneway void notify(1: string msg)
+  Point getPoint(1: required i32 id) throws (1: NotFound notFound)
+}
+`
+
+func writeGenerateTestFiles(t *testing.T) (dir, mainPath string) {
+	t.Helper()
+	dir = t.TempDir()
+
+	mainPath = filepath.Join(dir, "main.thrift")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "included.thrift"), []byte(generateTestIncludedThrift), 0o644))
+	require.NoError(t, os.WriteFile(mainPath, []byte(generateTestMainThrift), 0o644))
+	return dir, mainPath
+}
+
+func typeNames(m *Module) []string {
+	names := make([]string, 0, len(m.Types))
+	for name := range m.Types {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func constantNames(m *Module) []string {
+	names := make([]string, 0, len(m.Constants))
+	for name := range m.Constants {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func serviceNames(m *Module) []string {
+	names := make([]string, 0, len(m.Services))
+	for name := range m.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestGenerateThriftFile_RoundTrip(t *testing.T) {
+	dir, mainPath := writeGenerateTestFiles(t)
+
+	original, err := Compile(mainPath)
+	require.NoError(t, err, "compiling source thrift")
+
+	// Generate into the same directory so the relative include still resolves.
+	outPath := filepath.Join(dir, "out_main.thrift")
+	require.NoError(t, original.GenerateThriftFile(outPath), "generating thrift file")
+
+	generated, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	content := string(generated)
+
+	t.Run("content_contains_expected_constructs", func(t *testing.T) {
+		for _, want := range []string{
+			"namespace go main",
+			"namespace java com.example.main",
+			`include "included.thrift"`,
+			"const i32 MaxRetries = 3",
+			`\n\"world\"`, // escaped newline + escaped quote in the string constant
+			"typedef i64 Timestamp",
+			"typedef list<string> StringList",
+			"enum Color {",
+			"RED = 0",
+			"struct Point {",
+			"1: required i32 x",
+			"2: optional i32 y = 10",
+			"3: optional Color color = Color.RED",
+			"included.Shared shared",
+			"union Value {",
+			"exception NotFound {",
+			"service Base {",
+			"service API extends Base {",
+			"oneway void notify(",
+			"throws (",
+			"void ping()",
+		} {
+			assert.Contains(t, content, want)
+		}
+	})
+
+	t.Run("recompiles_to_equivalent_module", func(t *testing.T) {
+		recompiled, err := Compile(outPath)
+		require.NoError(t, err, "recompiling generated thrift")
+
+		assert.Equal(t, typeNames(original), typeNames(recompiled), "type names")
+		assert.Equal(t, constantNames(original), constantNames(recompiled), "constant names")
+		assert.Equal(t, serviceNames(original), serviceNames(recompiled), "service names")
+		assert.Equal(t, original.Namespaces, recompiled.Namespaces, "namespaces")
+		assert.Equal(t, len(original.Includes), len(recompiled.Includes), "include count")
+
+		// Spot-check a struct's field-level details survive the round trip.
+		pt, ok := recompiled.Types["Point"].(*StructSpec)
+		require.True(t, ok, "Point should be a struct")
+		require.Len(t, pt.Fields, 4)
+		assert.True(t, pt.Fields[0].Required, "field x should be required")
+		require.NotNil(t, pt.Fields[1].Default, "field y should have a default")
+
+		// The union's fields should not be required.
+		union, ok := recompiled.Types["Value"].(*StructSpec)
+		require.True(t, ok)
+		for _, f := range union.Fields {
+			assert.False(t, f.Required, "union field %s should not be required", f.Name)
+		}
+	})
+}
+
+func TestGenerateThriftFile_NilModule(t *testing.T) {
+	var m *Module
+	assert.Error(t, m.GenerateThriftFile(filepath.Join(t.TempDir(), "out.thrift")))
+}
+
+func TestModuleThriftIDL_Deterministic(t *testing.T) {
+	_, mainPath := writeGenerateTestFiles(t)
+
+	m, err := Compile(mainPath)
+	require.NoError(t, err)
+
+	first, err := m.thriftIDL()
+	require.NoError(t, err)
+	second, err := m.thriftIDL()
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second, "generated output should be deterministic across runs")
+}

--- a/compile/generate_test.go
+++ b/compile/generate_test.go
@@ -393,7 +393,7 @@ func TestGenerateThriftFile_IncludeRelativeToOutputDir(t *testing.T) {
 
 	expectedRel, err := filepath.Rel(outDir, filepath.Join(srcDir, "included.thrift"))
 	require.NoError(t, err)
-	assert.Contains(t, string(generated), `include "`+expectedRel+`"`,
+	assert.Contains(t, string(generated), `include "`+filepath.ToSlash(expectedRel)+`"`,
 		"include should be relative to the output file's directory")
 
 	// The generated file must recompile: this proves the include actually
@@ -420,10 +420,10 @@ func TestModuleThriftIDL_Deterministic(t *testing.T) {
 // unknownGenerateType is a TypeSpec outside the set handled by getAnnotatedType.
 type unknownGenerateType struct{ nativeThriftType }
 
-func (unknownGenerateType) ThriftName() string                            { return "unknown" }
-func (unknownGenerateType) ThriftAnnotations() Annotations                { return nil }
-func (unknownGenerateType) Link(Scope) (TypeSpec, error)                  { return nil, nil }
-func (unknownGenerateType) TypeCode() wire.Type                           { return wire.TI32 }
+func (unknownGenerateType) ThriftName() string                              { return "unknown" }
+func (unknownGenerateType) ThriftAnnotations() Annotations                  { return nil }
+func (unknownGenerateType) Link(Scope) (TypeSpec, error)                    { return nil, nil }
+func (unknownGenerateType) TypeCode() wire.Type                             { return wire.TI32 }
 func (unknownGenerateType) ForEachTypeReference(func(TypeSpec) error) error { return nil }
 
 type fakeConstantValue struct{}

--- a/compile/module.go
+++ b/compile/module.go
@@ -36,10 +36,11 @@ type Module struct {
 	// Mapping from the /Thrift name/ to the compiled representation of
 	// different definitions.
 
-	Includes  map[string]*IncludedModule
-	Constants map[string]*Constant
-	Types     map[string]TypeSpec
-	Services  map[string]*ServiceSpec
+	Includes   map[string]*IncludedModule
+	Constants  map[string]*Constant
+	Types      map[string]TypeSpec
+	Services   map[string]*ServiceSpec
+	Namespaces map[string]string
 
 	Raw []byte // The raw IDL input.
 }


### PR DESCRIPTION
**Background**
The `Module` struct currently contains a `Raw` field that stores the original Thrift file contents as a `[]byte`. However, if the `Raw` field becomes inconsistent with the rest of the fields in the `Module` object, there is currently no mechanism to regenerate the Thrift file from the in-memory representation.

A similar issue was encountered by **Bliss-Hydrator** (a platform service at Uber), where the `Module` object was modified programmatically and a reliable way to reconstruct the corresponding Thrift file was required.

**New Functionality**
This change introduces support for generating a Thrift file directly from a `Module` object. The implementation traverses the `Module` representation and writes the corresponding Thrift definition to a specified target path, enabling the Thrift file to be regenerated from the object model itself.

**Additional Changes**
To support Thrift file regeneration, namespace information must be preserved within the `Module` object. As a result, the `Module` struct has been extended to store namespace declarations in addition to the existing metadata.